### PR TITLE
fix(core,cli,infra): drop hardcoded defaults; short-ID resolution eve…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,145 +6,74 @@
 #   cp .env.example .env.local  # for local dev on the host
 # .env and .env.local are gitignored; .env.example is the only one committed.
 
+# ─── Hail core ───────────────────────────────────────────────────────────────
+
+# Self-host shared-key auth (generate: openssl rand -base64 32). Empty in cloud.
+HAIL_API_KEY=
+HAIL_API_URL=http://localhost:8080
+
+# Cloud only — hail-website base + internal HMAC for API↔website signing.
+HAIL_BASE_URL=
+HAIL_INTERNAL_SECRET=
+
+# Cloud only — Better Auth JWT issuer + accepted audiences.
+HAIL_AUTH_URL=
+HAIL_AUTH_AUDIENCES=
+
+# Cloud only — public MCP URL for OAuth resource discovery.
+MCP_RESOURCE_URL=
+
+# Prod overlay only (`-f docker-compose.prod.yml`). See docs/setup/vm-deploy.md.
+HAIL_DOMAIN=
+CADDY_ACME_EMAIL=
+
+# ─── Database ────────────────────────────────────────────────────────────────
+
+# Bundled Postgres (default):
+DATABASE_URL=postgresql://hail:hail@postgres:5432/hail
+# Managed (Neon / Supabase / RDS / …):
+# DATABASE_URL=postgresql://USER:PASSWORD@HOST/DBNAME?sslmode=require
+
+# ─── AWS ─────────────────────────────────────────────────────────────────────
+
+# Single IAM identity used by every Hail service. Provisioned by terragrunt:
+#   AWS_ACCESS_KEY_ID     ← `terragrunt output -raw iam_access_key_id`
+#   AWS_SECRET_ACCESS_KEY ← `terragrunt output -raw iam_secret_access_key`
+# Leave empty on EC2/ECS/EKS with an attached IAM role.
+# AWS_PROFILE is operator-only — set it in your shell, not here, or
+# containerized services crash with ProfileNotFound.
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
+# Terragrunt remote state. Pre-create bucket + lock table once per AWS account.
+HAIL_TERRAFORM_STATE_BUCKET=
+HAIL_TERRAFORM_LOCK_TABLE=
+HAIL_TERRAFORM_STATE_REGION=
+HAIL_INBOUND_EMAIL_NAME_PREFIX=hail-email-inbound
+
+# IAM user the Hail policy attaches to. Terragrunt auto-detects whether
+# it exists — created if missing, referenced if found.
+HAIL_IAM_USER_NAME=hail
+
 # ─── LLM providers ───────────────────────────────────────────────────────────
 
-# OpenAI
 OPENAI_API_BASE_URL=https://api.openai.com/v1
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-5.4-mini
 
-# Google (Gemini API)
 GOOGLE_API_KEY=
 GOOGLE_MODEL=gemini-3-flash
-
-# Google (Vertex AI)
 GOOGLE_GENAI_USE_VERTEXAI=false
-# Option A: Path to service account key file (local dev)
 GOOGLE_APPLICATION_CREDENTIALS=
-# Option B: Base64-encoded service account JSON (production / Docker)
-#   Generate with: base64 -i service-account-key.json | tr -d '\n'
-#   At startup, decoded to a temp file and GOOGLE_APPLICATION_CREDENTIALS is set automatically.
+# Base64-encoded SA JSON for Docker. Decoded to a temp file at startup.
 GOOGLE_SERVICE_ACCOUNT_JSON_B64=
 GOOGLE_CLOUD_PROJECT=
 
-# Anthropic
 ANTHROPIC_API_KEY=
 ANTHROPIC_MODEL=claude-sonnet-4-6
 
-# ─── Voice pipeline ──────────────────────────────────────────────────────────
-
-# Deepgram (STT)
-DEEPGRAM_API_KEY=
-DEEPGRAM_MODEL=nova-3
-
-# ElevenLabs (TTS) — ELEVENLABS_VOICE_ID is required at runtime; pick one from
-# your ElevenLabs voice library.
-ELEVEN_API_KEY=
-ELEVENLABS_VOICE_ID=
-ELEVENLABS_MODEL=eleven_turbo_v2_5
-
-# ─── Carriers ────────────────────────────────────────────────────────────────
-
-# Twilio (phone + SMS)
-TWILIO_ACCOUNT_SID=
-TWILIO_AUTH_TOKEN=
-
-# AWS SES (email) — boto3 falls back to its default credential chain
-# (env vars / ~/.aws/credentials / IAM role) when these are empty, so
-# workloads on EC2/ECS/EKS pick up IAM-role creds automatically and only
-# need AWS_REGION set. See docs/setup/aws-ses.md for the full setup
-# (sandbox limits, DKIM, the parent-domain dance for hail-mail).
-AWS_REGION=us-east-1
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-# AWS named profile from ~/.aws/credentials. The AWS SDK reads this env
-# var natively — set it once and both runtime boto3 calls and the
-# infra/terragrunt.hcl backend pick it up. Leave empty to use the default
-# credential chain.
-AWS_PROFILE=
-
-# Terragrunt remote state (infra/terragrunt.hcl). Bucket + lock table
-# must be pre-created in your AWS account before the first
-# `terragrunt init` — the backend can't bootstrap itself. See the
-# comment block at the top of infra/terragrunt.hcl for the AWS CLI
-# one-liners.
-HAIL_TERRAFORM_STATE_BUCKET=
-HAIL_TERRAFORM_LOCK_TABLE=
-# Region where the state bucket + lock table live. Typically a single
-# shared region across every Hail deployment in your account
-# (e.g. us-east-1), independent of where the inbound-email infra runs.
-# Falls back to AWS_REGION when unset, so single-region setups can leave
-# this empty.
-HAIL_TERRAFORM_STATE_REGION=
-# AWS resource name prefix for the SES inbound-email module — names
-# the S3 bucket, SES receipt rule set + rule, Lambda function, IAM
-# role, and CloudWatch log group. Only the email path goes through
-# AWS infra; SMS and voice inbound terminate at Twilio / LiveKit and
-# don't need a Terraform-managed naming convention. Override to run
-# multiple environments (prod, staging, dev) in the same AWS account.
-HAIL_INBOUND_EMAIL_NAME_PREFIX=hail-email-inbound
-
-# Operator-managed parent domain used to mint hail-mail addresses of the form
-# ``<user>+<org>@<HAIL_MAIL_BASE_DOMAIN>`` (e.g. ``alice+acme@mail.hail.so``).
-# Verify this one domain with SES once, out of band; per-org rows land
-# already-verified and never call SES. Leave empty to disable hail-mail mode
-# — orgs must then register their own custom domains via POST /sender-domains.
-HAIL_MAIL_BASE_DOMAIN=
-
-# Single-variable shortcut for self-hosters: the full From address. Server
-# splits the local part on ``+`` into the user/org prefix pair. Domain must
-# match HAIL_MAIL_BASE_DOMAIN. Wins over HAIL_MAIL_DEFAULT_*_PREFIX below.
-HAIL_MAIL_FROM=
-
-# Advanced/managed-cloud: separate user vs org prefix defaults. Useful if you
-# want to set deploy-time defaults independently of any fixed From address.
-# Both must match ^[a-z0-9]([a-z0-9-]{0,18}[a-z0-9])?$ (1–20 chars, lowercase
-# alphanumeric + hyphens, no leading/trailing hyphen). Org admins on managed
-# Hail override per-org values via the console (PATCH /sender-domains/{id}).
-HAIL_MAIL_DEFAULT_USER_PREFIX=
-HAIL_MAIL_DEFAULT_ORG_PREFIX=
-
-# ─── AWS SES (inbound email) ─────────────────────────────────────────────────
-
-# Turn the /internal/ses-events ingest endpoint on. Off by default so a
-# misconfigured Lambda can't write rows into a deployment that hasn't opted
-# into inbound yet. See docs/setup/aws-ses.md §10 and infra/terraform/.
-HAIL_INBOUND_ENABLED=false
-# S3 bucket Lambda writes raw MIME into and that the API reads back
-# for parsing + presigned downloads. Provisioned by infra/terragrunt.
-#
-# Why this is separate from the `S3_*` family further down: that family
-# is for **call recordings** and works against any S3-compatible
-# endpoint (MinIO in local dev). Inbound mail must land in **real AWS
-# S3** because SES writes to it directly — MinIO is not reachable from
-# SES, and SES → S3 is a built-in receipt-rule action. The two paths
-# can point at different buckets, or at the same bucket with different
-# key prefixes (recordings under e.g. ``recordings/``, inbound under
-# ``raw/`` + ``attachments/`` — but that requires the bucket to be real
-# AWS, which defeats MinIO-in-dev).
-#
-# Credential sources also differ: this path uses AWS_ACCESS_KEY_ID /
-# AWS_SECRET_ACCESS_KEY (the general AWS provider keys above); the
-# S3_* family uses its own S3_ACCESS_KEY / S3_SECRET_KEY so a dedicated
-# MinIO user can hold recordings without touching the AWS account.
-HAIL_INBOUND_BUCKET=
-# Shared secret between ses-ingest-lambda and the API. Lambda signs every
-# POST with HMAC-SHA256 of the body; API verifies with this value.
-HAIL_INBOUND_HMAC_SECRET=
-# Forwarding controls — see docs/superpowers/specs/2026-06-06-inbound-email-design.md §6.2.
-HAIL_FORWARD_MAX_HOPS=3
-HAIL_FORWARD_RATE_PER_HOUR=200
-# Inbound rate cap per org per hour. Beyond it, persist but skip fan-out.
-HAIL_INBOUND_ORG_RATE_PER_HOUR=1000
-# Self-host convenience: allow webhook targets pointing at localhost /
-# RFC-1918 / link-local addresses. Leave false in production.
-HAIL_WEBHOOK_ALLOW_PRIVATE_NETWORKS=false
-# Fernet key for encrypting webhook secrets at rest (required for webhooks).
-# Generate (inside the project venv so `cryptography` is importable):
-#   uv run --directory core python -c "from hailhq.core.secret_cipher import generate_key; print(generate_key())"
-HAIL_WEBHOOK_SECRET_KEY=
-
-# ─── Media ───────────────────────────────────────────────────────────────────
+# ─── Voice ───────────────────────────────────────────────────────────────────
 
 # LiveKit Cloud
 LIVEKIT_URL=
@@ -153,112 +82,51 @@ LIVEKIT_API_SECRET=
 LIVEKIT_SIP_OUTBOUND_TRUNK_ID=
 LIVEKIT_SIP_INBOUND_TRUNK_ID=
 
-# ─── Storage ─────────────────────────────────────────────────────────────────
+# Deepgram (STT)
+DEEPGRAM_API_KEY=
+DEEPGRAM_MODEL=nova-3
 
-# PostgreSQL
-#
-# Two modes — pick one:
-#   * Bundled local Postgres (docker compose with docker-compose.local.yml):
-DATABASE_URL=postgresql://hail:hail@postgres:5432/hail
-#   * Managed (Neon / Supabase / RDS / …) — omit docker-compose.local.yml and
-#     point this at the managed URL; sslmode=require is usually mandatory:
-# DATABASE_URL=postgresql://USER:PASSWORD@HOST/DBNAME?sslmode=require
+# ElevenLabs (TTS) — ELEVENLABS_VOICE_ID is required at runtime.
+ELEVEN_API_KEY=
+ELEVENLABS_VOICE_ID=
+ELEVENLABS_MODEL=eleven_turbo_v2_5
 
-# S3 — call recordings only. S3-compatible endpoints work, so MinIO
-# stands in for AWS S3 in local dev. **Inbound email** uses a separate
-# bucket family above (`HAIL_INBOUND_BUCKET`) because SES writes to it
-# directly and can only target real AWS S3 — see the comment block at
-# HAIL_INBOUND_BUCKET for why these are intentionally split.
+# Twilio (PSTN)
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+
+# Voice soft-cap. 0 disables.
+HAIL_VOICE_MAX_DURATION_SECONDS=300
+# Pool-number sweeper grace before force-releasing a stuck reservation.
+HAIL_POOL_RELEASE_GRACE_SECONDS=120
+
+# ─── Email ───────────────────────────────────────────────────────────────────
+
+# Outbound — operator-managed parent domain. Verify with SES once, out of band.
+HAIL_MAIL_BASE_DOMAIN=
+# Self-host shortcut: full From address. Wins over HAIL_MAIL_DEFAULT_*_PREFIX.
+HAIL_MAIL_FROM=
+HAIL_MAIL_DEFAULT_USER_PREFIX=
+HAIL_MAIL_DEFAULT_ORG_PREFIX=
+
+# Inbound — off by default. Bucket name is derived as `${prefix}-raw`
+# from HAIL_INBOUND_EMAIL_NAME_PREFIX above; Terraform creates that bucket
+# and the API reads from it — single source, no drift.
+HAIL_INBOUND_ENABLED=false
+HAIL_INBOUND_HMAC_SECRET=
+HAIL_FORWARD_MAX_HOPS=3
+HAIL_FORWARD_RATE_PER_HOUR=200
+HAIL_INBOUND_ORG_RATE_PER_HOUR=1000
+# Dev only.
+HAIL_WEBHOOK_ALLOW_PRIVATE_NETWORKS=false
+# Fernet key for at-rest webhook-secret encryption. Generate:
+#   uv run --directory core python -c "from hailhq.core.secret_cipher import generate_key; print(generate_key())"
+HAIL_WEBHOOK_SECRET_KEY=
+
+# ─── Call recordings (S3-compatible — MinIO in dev) ──────────────────────────
+
 S3_ENDPOINT=http://minio:9000
 S3_BUCKET=hail-recordings
 S3_ACCESS_KEY=
 S3_SECRET_KEY=
 S3_REGION=us-east-1
-
-# ─── Hail ────────────────────────────────────────────────────────────────────
-
-# Shared-key auth for self-host mode:
-#   * inbound — hail/api compares incoming `Authorization: Bearer …` against this
-#     and routes the request to the seeded "Self-hosted" organization
-#   * outbound — CLI / MCP / voicebot send this same value when calling the API
-# Generate with: openssl rand -base64 32
-# In managed cloud LEAVE THIS EMPTY — per-user keys minted via the auth backend's
-# `apikey` table are the only auth path. The shared-key fallback bypasses Better
-# Auth entirely; setting it in cloud is a misconfiguration.
-HAIL_API_KEY=
-HAIL_API_URL=http://localhost:8080
-
-# Voice soft-cap. When a call reaches this many seconds the voicebot speaks
-# a polite "we've reached the time limit" line, waits for playout, then
-# triggers shutdown — same lifecycle as a natural call end. Set to 0 to
-# disable the cap. Worst-case overrun = (this × per-minute rate), bounding
-# abuse from a single long call.
-HAIL_VOICE_MAX_DURATION_SECONDS=300
-
-# Pool-number sweeper backstop. Force-release a pool reservation when
-# now() > calls.requested_at + calls.max_duration_seconds + this grace,
-# even if neither the API nor the voicebot called release_pool_reservation.
-# Wide enough to absorb LiveKit/Twilio teardown + clock skew; small enough
-# that a stuck reservation doesn't starve the pool for long.
-HAIL_POOL_RELEASE_GRACE_SECONDS=120
-
-# Base URL of the hail-website deployment (cloud only). When set, voicebot
-# fires a signed POST to this host after recording a billable usage event,
-# so the website's private rater can turn raw units into a dollar debit in
-# near-real-time. Leave empty in self-host — voicebot becomes a no-op for
-# this notification, and `usage_events` accumulates as a local analytics
-# primitive for the operator to query directly.
-HAIL_BASE_URL=
-# Shared HMAC secret used to sign internal API↔website requests. Must match
-# HAIL_INTERNAL_SECRET on the hail-website side. Generate with:
-#   openssl rand -base64 32
-HAIL_INTERNAL_SECRET=
-
-# ─── Auth backend (cloud) ───────────────────────────────────────────────────
-# Set when running against the hail-website auth backend. The API gains a JWT
-# verification path alongside the existing API-key path: tokens with this
-# issuer and an audience in the allow-list are accepted and resolved to an
-# organization via the user_id (JWT sub) → members join.
-#
-# HAIL_AUTH_URL is the issuer URL stamped on JWTs by the auth backend (the
-# website's `${HAIL_BASE_URL}/api/auth`). The JWKS endpoint is derived as
-# `${HAIL_AUTH_URL}/jwks` — no separate var. Cloud example:
-#   HAIL_AUTH_URL=https://hail.so/api/auth
-# Leave empty in self-host — the JWT path stays disabled and the existing
-# shared-key (HAIL_API_KEY) + API-key (api_keys table) paths are the only
-# auth surfaces.
-HAIL_AUTH_URL=
-# Comma-separated allowed audiences. Cloud default: api.${HAIL_DOMAIN},mcp.${HAIL_DOMAIN}.
-HAIL_AUTH_AUDIENCES=
-
-# MCP service resource identity (cloud) — public URL the MCP serves under.
-
-# Used by the MCP server to publish .well-known/oauth-protected-resource and
-# to stamp the WWW-Authenticate header on 401s. Cloud example:
-#   MCP_RESOURCE_URL=https://mcp.hail.so
-# Leave empty in self-host (MCP runs in static-key mode and does not
-# publish protected-resource metadata).
-MCP_RESOURCE_URL=
-
-# Billing posture:
-#   * Cloud: balance gate on POST /v1/calls enforces against account_credits
-#     SUM, populated by the website's private rater turning usage_events into
-#     dollar debits. Per-user apikey requests gate; shared-key requests skip
-#     the gate entirely (master/admin path → seeded Self-hosted org).
-#   * Self-host: no website running → no rater → no debits → no gate to fail.
-#     Shared-key auth places calls freely; `usage_events` records raw units
-#     for the operator's own analytics.
-
-# ─── VM prod ingress (Caddy) ─────────────────────────────────────────────────
-# Only read when the compose stack is brought up with the prod overlay
-# (`-f docker-compose.yml -f docker-compose.prod.yml`). See
-# docs/setup/vm-deploy.md. Python code never reads this.
-#
-# Apex domain. api/mcp subdomains are derived as api.${HAIL_DOMAIN} and
-# mcp.${HAIL_DOMAIN}. Point both A records at the VM before first boot, or
-# Caddy's Let's Encrypt cert request will fail.
-HAIL_DOMAIN=
-# (Optional) email for Let's Encrypt expiry notices. Defaults to hi@hail.so
-# (set in docker-compose.prod.yml). Override only if you want renewal
-# warnings to land in your own inbox.
-CADDY_ACME_EMAIL=

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -8,12 +8,13 @@ module.exports = {
   // Markdown / JSON / YAML — format with Prettier.
   "**/*.{md,json,yml,yaml}": ["prettier --write"],
 
-  // Terraform — canonical formatter, in-place.
-  "infra/**/*.tf": ["terraform fmt"],
-
-  // Terragrunt — canonical formatter for .hcl files (also matches the
-  // `terragrunt hcl format --check` gate run in CI).
-  "infra/**/*.hcl": ["terragrunt hcl format"],
+  // Terraform / Terragrunt — format the whole infra dir in one shot.
+  // Per-file invocation is fragile: lint-staged passes absolute file
+  // paths, and `terraform fmt` resolves them relative to its own cwd
+  // (the repo root under husky) which doesn't always agree with what
+  // git stage rewrote. `-chdir=...` pins the directory either way.
+  "infra/**/*.tf": () => "terraform -chdir=infra/terraform fmt",
+  "infra/**/*.hcl": () => "bash -c 'cd infra && terragrunt hcl format'",
 
   // Dockerfiles — no formatter in v1; add hadolint via CI later.
 };

--- a/api/tests/test_internal_ses_events.py
+++ b/api/tests/test_internal_ses_events.py
@@ -57,7 +57,7 @@ def _payload(
             "dkim": "PASS",
             "dmarc": "PASS",
         },
-        "s3_bucket": "hail-inbound-test",
+        "s3_bucket": "hail-inbound-test-raw",
         "s3_key": s3_key,
         "timestamp": "2026-06-06T10:11:12Z",
     }
@@ -67,7 +67,8 @@ def _payload(
 def inbound_enabled(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(settings, "hail_inbound_enabled", True)
     monkeypatch.setattr(settings, "hail_inbound_hmac_secret", HMAC_SECRET)
-    monkeypatch.setattr(settings, "hail_inbound_bucket", "hail-inbound-test")
+    # Bucket is derived as `${prefix}-raw`, so this yields "hail-inbound-test-raw".
+    monkeypatch.setattr(settings, "hail_inbound_email_name_prefix", "hail-inbound-test")
     monkeypatch.setattr(settings, "hail_mail_base_domain", "mail.hail.so")
 
 

--- a/api/tests/test_internal_ses_events_multi_org.py
+++ b/api/tests/test_internal_ses_events_multi_org.py
@@ -55,7 +55,7 @@ def _payload_multi(
             "dkim": "PASS",
             "dmarc": "PASS",
         },
-        "s3_bucket": "hail-inbound-test",
+        "s3_bucket": "hail-inbound-test-raw",
         "s3_key": s3_key,
         "timestamp": "2026-06-06T10:11:12Z",
     }
@@ -67,7 +67,8 @@ def inbound_enabled(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr(settings, "hail_inbound_enabled", True)
     monkeypatch.setattr(settings, "hail_inbound_hmac_secret", HMAC_SECRET)
-    monkeypatch.setattr(settings, "hail_inbound_bucket", "hail-inbound-test")
+    # Bucket is derived as `${prefix}-raw`, so this yields "hail-inbound-test-raw".
+    monkeypatch.setattr(settings, "hail_inbound_email_name_prefix", "hail-inbound-test")
     monkeypatch.setattr(settings, "hail_mail_base_domain", "mail.hail.so")
 
 

--- a/cli/internal/cmd/call_status.go
+++ b/cli/internal/cmd/call_status.go
@@ -2,21 +2,13 @@ package cmd
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"net/http"
-	"strings"
 
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/hail-hq/hail/cli/internal/client"
 )
-
-// recentCallsPrefixWindow caps how far back `hail call status <prefix>` will
-// scan for a match. Referenced from both the Long help text and the lookup
-// so the two never drift.
-const recentCallsPrefixWindow = 200
 
 func newCallStatusCmd(opts *Options) *cobra.Command {
 	cmd := &cobra.Command{
@@ -28,7 +20,7 @@ func newCallStatusCmd(opts *Options) *cobra.Command {
 <call-id> may be either a full UUID or a hex prefix (e.g. the 8-char id
 shown by 'hail call list'). Prefix lookups scan the %d most recent calls
 and fail if the prefix is ambiguous or matches nothing — pass the full
-UUID to look up older calls unambiguously.`, recentCallsPrefixWindow),
+UUID to look up older calls unambiguously.`, recentPrefixWindow),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCallStatus(cmd.Context(), opts, args[0])
@@ -65,64 +57,6 @@ func runCallStatus(ctx context.Context, opts *Options, idStr string) error {
 	}
 
 	return printCallStatus(opts, resp.JSON200)
-}
-
-// resolveCallID resolves input to a UUID, and (on the prefix path) the
-// already-fetched CallResponse so the caller can skip the second GET. Dashes
-// in the prefix are stripped before matching, so 11111111 and 11111111-1111
-// resolve identically.
-//
-// Mirrors `git rev-parse`'s short-hash behavior: ambiguous prefixes and
-// no-match cases surface as CLI errors with the candidate list / hint.
-func resolveCallID(ctx context.Context, apiClient *client.ClientWithResponses, input string) (uuid.UUID, *client.CallResponse, error) {
-	if parsed, err := uuid.Parse(input); err == nil {
-		return parsed, nil, nil
-	}
-	needle := strings.ToLower(strings.ReplaceAll(input, "-", ""))
-	if len(needle) < 4 || len(needle) > 31 || !isHex(needle) {
-		return uuid.Nil, nil, fmt.Errorf("invalid call id %q (expected full UUID or hex prefix of 4+ chars)", input)
-	}
-
-	limit := recentCallsPrefixWindow
-	resp, err := apiClient.ListCallsCallsGetWithResponse(ctx, &client.ListCallsCallsGetParams{Limit: &limit})
-	if err != nil {
-		return uuid.Nil, nil, fmt.Errorf("resolve call prefix: %w", err)
-	}
-	if resp.HTTPResponse.StatusCode != http.StatusOK || resp.JSON200 == nil {
-		return uuid.Nil, nil, apiError(resp.HTTPResponse.StatusCode, resp.Body)
-	}
-
-	var matches []client.CallResponse
-	for _, c := range resp.JSON200.Items {
-		if strings.HasPrefix(hex.EncodeToString(c.Id[:]), needle) {
-			matches = append(matches, c)
-		}
-	}
-
-	switch len(matches) {
-	case 1:
-		return matches[0].Id, &matches[0], nil
-	case 0:
-		return uuid.Nil, nil, fmt.Errorf("no call matches prefix %q (searched %d recent calls); pass the full UUID for older calls", input, len(resp.JSON200.Items))
-	default:
-		names := make([]string, 0, len(matches))
-		for _, m := range matches {
-			names = append(names, m.Id.String())
-		}
-		return uuid.Nil, nil, fmt.Errorf("ambiguous prefix %q matches %d calls: %s", input, len(matches), strings.Join(names, ", "))
-	}
-}
-
-func isHex(s string) bool {
-	for _, c := range s {
-		switch {
-		case c >= '0' && c <= '9':
-		case c >= 'a' && c <= 'f':
-		default:
-			return false
-		}
-	}
-	return true
 }
 
 // printCallStatus renders a CallResponse for the `status` subcommand. Format

--- a/cli/internal/cmd/email_domain.go
+++ b/cli/internal/cmd/email_domain.go
@@ -182,12 +182,16 @@ func runEmailDomainList(
 func newEmailDomainGetCmd(opts *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get <id>",
-		Short: "Fetch one email domain by id",
+		Short: "Fetch one email domain by id (full UUID or 4+ char prefix)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, err := uuid.Parse(args[0])
+			apiClient, err := opts.newClient()
 			if err != nil {
-				return fmt.Errorf("invalid id: %w", err)
+				return err
+			}
+			id, err := resolveEmailDomainID(cmd.Context(), apiClient, args[0])
+			if err != nil {
+				return err
 			}
 			return runEmailDomainGet(cmd.Context(), opts, id)
 		},
@@ -221,12 +225,16 @@ func runEmailDomainGet(ctx context.Context, opts *Options, id uuid.UUID) error {
 func newEmailDomainVerifyCmd(opts *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify <id>",
-		Short: "Re-poll the email provider for a custom row's verification status",
+		Short: "Re-poll the email provider for a custom row's verification status (full UUID or 4+ char prefix)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, err := uuid.Parse(args[0])
+			apiClient, err := opts.newClient()
 			if err != nil {
-				return fmt.Errorf("invalid id: %w", err)
+				return err
+			}
+			id, err := resolveEmailDomainID(cmd.Context(), apiClient, args[0])
+			if err != nil {
+				return err
 			}
 			return runEmailDomainVerify(cmd.Context(), opts, id)
 		},
@@ -261,12 +269,16 @@ func newEmailDomainDeleteCmd(opts *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete <id>",
 		Aliases: []string{"rm"},
-		Short:   "Delete an email domain (and the SES identity for custom rows)",
+		Short:   "Delete an email domain (full UUID or 4+ char prefix). Also drops the SES identity for custom rows.",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, err := uuid.Parse(args[0])
+			apiClient, err := opts.newClient()
 			if err != nil {
-				return fmt.Errorf("invalid id: %w", err)
+				return err
+			}
+			id, err := resolveEmailDomainID(cmd.Context(), apiClient, args[0])
+			if err != nil {
+				return err
 			}
 			return runEmailDomainDelete(cmd.Context(), opts, id)
 		},

--- a/cli/internal/cmd/email_get.go
+++ b/cli/internal/cmd/email_get.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/google/uuid"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/spf13/cobra"
 
@@ -17,7 +16,7 @@ import (
 func newEmailGetCmd(opts *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get <id>",
-		Short: "Fetch one email by id",
+		Short: "Fetch one email by id (full UUID or 4+ char prefix)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runEmailGet(cmd.Context(), opts, args[0])
@@ -27,11 +26,11 @@ func newEmailGetCmd(opts *Options) *cobra.Command {
 }
 
 func runEmailGet(ctx context.Context, opts *Options, idStr string) error {
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		return fmt.Errorf("invalid email id: %w", err)
-	}
 	apiClient, err := opts.newClient()
+	if err != nil {
+		return err
+	}
+	id, err := resolveEmailID(ctx, apiClient, idStr)
 	if err != nil {
 		return err
 	}

--- a/cli/internal/cmd/resolve.go
+++ b/cli/internal/cmd/resolve.go
@@ -1,0 +1,160 @@
+package cmd
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	"github.com/hail-hq/hail/cli/internal/client"
+)
+
+const recentPrefixWindow = 200
+
+func isHex(s string) bool {
+	for _, c := range s {
+		switch {
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// resolveIDPrefix turns a CLI-supplied id (full UUID or 4+ char hex
+// prefix) into a full UUID via `lister`. Mirrors `git rev-parse`'s
+// short-hash UX. `label` is the noun used in error messages.
+func resolveIDPrefix[T any](
+	ctx context.Context,
+	input, label string,
+	lister func(ctx context.Context, limit int) ([]T, error),
+	getID func(T) openapi_types.UUID,
+) (uuid.UUID, *T, error) {
+	if parsed, err := uuid.Parse(input); err == nil {
+		return parsed, nil, nil
+	}
+	needle := strings.ToLower(strings.ReplaceAll(input, "-", ""))
+	if len(needle) < 4 || len(needle) > 31 || !isHex(needle) {
+		return uuid.Nil, nil, fmt.Errorf("invalid %s id %q (expected full UUID or 4+ char hex prefix)", label, input)
+	}
+
+	items, err := lister(ctx, recentPrefixWindow)
+	if err != nil {
+		return uuid.Nil, nil, fmt.Errorf("resolve %s prefix: %w", label, err)
+	}
+
+	var matches []*T
+	for i := range items {
+		id := getID(items[i])
+		if strings.HasPrefix(hex.EncodeToString(id[:]), needle) {
+			matches = append(matches, &items[i])
+		}
+	}
+
+	switch len(matches) {
+	case 1:
+		return uuid.UUID(getID(*matches[0])), matches[0], nil
+	case 0:
+		return uuid.Nil, nil, fmt.Errorf("no %s matches prefix %q (searched %d recent rows); pass the full UUID for older rows", label, input, len(items))
+	default:
+		names := make([]string, 0, len(matches))
+		for _, m := range matches {
+			names = append(names, uuid.UUID(getID(*m)).String())
+		}
+		return uuid.Nil, nil, fmt.Errorf("ambiguous prefix %q matches %d %ss: %s", input, len(matches), label, strings.Join(names, ", "))
+	}
+}
+
+func resolveCallID(ctx context.Context, apiClient *client.ClientWithResponses, input string) (uuid.UUID, *client.CallResponse, error) {
+	return resolveIDPrefix(ctx, input, "call",
+		func(ctx context.Context, limit int) ([]client.CallResponse, error) {
+			resp, err := apiClient.ListCallsCallsGetWithResponse(ctx, &client.ListCallsCallsGetParams{Limit: &limit})
+			if err != nil {
+				return nil, err
+			}
+			if resp.HTTPResponse.StatusCode != http.StatusOK || resp.JSON200 == nil {
+				return nil, apiError(resp.HTTPResponse.StatusCode, resp.Body)
+			}
+			return resp.JSON200.Items, nil
+		},
+		func(c client.CallResponse) openapi_types.UUID { return c.Id },
+	)
+}
+
+func resolveEmailID(ctx context.Context, apiClient *client.ClientWithResponses, input string) (uuid.UUID, error) {
+	id, _, err := resolveIDPrefix(ctx, input, "email",
+		func(ctx context.Context, limit int) ([]client.EmailSummary, error) {
+			resp, err := apiClient.ListEmailsEmailsGetWithResponse(ctx, &client.ListEmailsEmailsGetParams{Limit: &limit})
+			if err != nil {
+				return nil, err
+			}
+			if resp.HTTPResponse.StatusCode != http.StatusOK || resp.JSON200 == nil {
+				return nil, apiError(resp.HTTPResponse.StatusCode, resp.Body)
+			}
+			return resp.JSON200.Items, nil
+		},
+		func(e client.EmailSummary) openapi_types.UUID { return e.Id },
+	)
+	return id, err
+}
+
+func resolveEmailDomainID(ctx context.Context, apiClient *client.ClientWithResponses, input string) (uuid.UUID, error) {
+	id, _, err := resolveIDPrefix(ctx, input, "email-domain",
+		func(ctx context.Context, limit int) ([]client.EmailDomainResponse, error) {
+			resp, err := apiClient.ListEmailDomainsEmailDomainsGetWithResponse(ctx, &client.ListEmailDomainsEmailDomainsGetParams{Limit: &limit})
+			if err != nil {
+				return nil, err
+			}
+			if resp.HTTPResponse.StatusCode != http.StatusOK || resp.JSON200 == nil {
+				return nil, apiError(resp.HTTPResponse.StatusCode, resp.Body)
+			}
+			return resp.JSON200.Items, nil
+		},
+		func(d client.EmailDomainResponse) openapi_types.UUID { return d.Id },
+	)
+	return id, err
+}
+
+func resolveWebhookID(ctx context.Context, apiClient *client.ClientWithResponses, input string) (uuid.UUID, error) {
+	id, _, err := resolveIDPrefix(ctx, input, "webhook",
+		func(ctx context.Context, limit int) ([]client.WebhookSubscriptionResponse, error) {
+			resp, err := apiClient.ListSubscriptionsWebhooksGetWithResponse(ctx, &client.ListSubscriptionsWebhooksGetParams{Limit: &limit})
+			if err != nil {
+				return nil, err
+			}
+			if resp.HTTPResponse.StatusCode != http.StatusOK || resp.JSON200 == nil {
+				return nil, apiError(resp.HTTPResponse.StatusCode, resp.Body)
+			}
+			return resp.JSON200.Items, nil
+		},
+		func(s client.WebhookSubscriptionResponse) openapi_types.UUID { return s.Id },
+	)
+	return id, err
+}
+
+func resolveWebhookDeliveryID(ctx context.Context, apiClient *client.ClientWithResponses, subID uuid.UUID, input string) (uuid.UUID, error) {
+	id, _, err := resolveIDPrefix(ctx, input, "delivery",
+		func(ctx context.Context, limit int) ([]client.WebhookDeliveryResponse, error) {
+			resp, err := apiClient.ListDeliveriesWebhooksSubIdDeliveriesGetWithResponse(
+				ctx,
+				openapi_types.UUID(subID),
+				&client.ListDeliveriesWebhooksSubIdDeliveriesGetParams{Limit: &limit},
+			)
+			if err != nil {
+				return nil, err
+			}
+			if resp.HTTPResponse.StatusCode != http.StatusOK || resp.JSON200 == nil {
+				return nil, apiError(resp.HTTPResponse.StatusCode, resp.Body)
+			}
+			return resp.JSON200.Items, nil
+		},
+		func(d client.WebhookDeliveryResponse) openapi_types.UUID { return d.Id },
+	)
+	return id, err
+}

--- a/cli/internal/cmd/webhooks.go
+++ b/cli/internal/cmd/webhooks.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/google/uuid"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/spf13/cobra"
 
@@ -131,16 +130,16 @@ func newWebhooksListCmd(opts *Options) *cobra.Command {
 func newWebhooksDeliveriesCmd(opts *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deliveries <subscription-id>",
-		Short: "List delivery attempts for a subscription",
+		Short: "List delivery attempts for a subscription (full UUID or 4+ char prefix)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			apiClient, err := opts.newClient()
 			if err != nil {
 				return err
 			}
-			subID, err := uuid.Parse(args[0])
+			subID, err := resolveWebhookID(cmd.Context(), apiClient, args[0])
 			if err != nil {
-				return fmt.Errorf("invalid subscription id: %w", err)
+				return err
 			}
 			resp, err := apiClient.ListDeliveriesWebhooksSubIdDeliveriesGetWithResponse(
 				cmd.Context(),
@@ -162,20 +161,20 @@ func newWebhooksDeliveriesCmd(opts *Options) *cobra.Command {
 func newWebhooksRedeliverCmd(opts *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "redeliver <subscription-id> <delivery-id>",
-		Short: "Replay a single delivery row",
+		Short: "Replay a single delivery row (each id may be full UUID or 4+ char prefix)",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			apiClient, err := opts.newClient()
 			if err != nil {
 				return err
 			}
-			subID, err := uuid.Parse(args[0])
+			subID, err := resolveWebhookID(cmd.Context(), apiClient, args[0])
 			if err != nil {
-				return fmt.Errorf("invalid subscription id: %w", err)
+				return err
 			}
-			deliveryID, err := uuid.Parse(args[1])
+			deliveryID, err := resolveWebhookDeliveryID(cmd.Context(), apiClient, subID, args[1])
 			if err != nil {
-				return fmt.Errorf("invalid delivery id: %w", err)
+				return err
 			}
 			resp, err := apiClient.RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostWithResponse(
 				cmd.Context(),

--- a/core/hailhq/core/config.py
+++ b/core/hailhq/core/config.py
@@ -1,3 +1,4 @@
+from pydantic import computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -76,7 +77,10 @@ class Settings(BaseSettings):
     # SES Receipt Rule, and Lambda; HAIL_INBOUND_HMAC_SECRET is shared
     # between the Lambda env and the API.
     hail_inbound_enabled: bool = False
-    hail_inbound_bucket: str = ""
+    # Single source of truth for both the Terraform module and the API.
+    # The raw-MIME bucket name is derived as ``{prefix}-raw``; SES Lambda
+    # writes there, the API reads back from it. Set in .env / .env.example.
+    hail_inbound_email_name_prefix: str = ""
     hail_inbound_hmac_secret: str = ""
     # Forwarding controls — see docs spec §6.2.
     hail_forward_max_hops: int = 3
@@ -158,6 +162,14 @@ class Settings(BaseSettings):
     # WWW-Authenticate header points clients at this MCP's own
     # ``.well-known/oauth-protected-resource``. Empty in self-host.
     mcp_resource_url: str = ""
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def hail_inbound_bucket(self) -> str:
+        """Raw-MIME bucket name. Derived to match Terraform's `${prefix}-raw`."""
+        if not self.hail_inbound_email_name_prefix:
+            return ""
+        return f"{self.hail_inbound_email_name_prefix}-raw"
 
 
 settings = Settings()

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -1,0 +1,43 @@
+data "aws_iam_policy_document" "main" {
+  statement {
+    sid       = "InboundRawRead"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.inbound.arn}/raw/*"]
+  }
+
+  statement {
+    sid       = "InboundAttachmentsReadWrite"
+    actions   = ["s3:GetObject", "s3:PutObject"]
+    resources = ["${aws_s3_bucket.inbound.arn}/attachments/*"]
+  }
+
+  statement {
+    sid = "OutboundSES"
+    actions = [
+      "ses:SendEmail",
+      "ses:SendRawEmail",
+      "ses:CreateEmailIdentity",
+      "ses:GetEmailIdentity",
+      "ses:DeleteEmailIdentity",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "main" {
+  name   = var.iam_user_name
+  policy = data.aws_iam_policy_document.main.json
+}
+
+resource "aws_iam_user" "main" {
+  name = var.iam_user_name
+}
+
+resource "aws_iam_user_policy_attachment" "main" {
+  user       = aws_iam_user.main.name
+  policy_arn = aws_iam_policy.main.arn
+}
+
+resource "aws_iam_access_key" "main" {
+  user = aws_iam_user.main.name
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,8 +1,5 @@
 provider "aws" {
-  region = var.region
-  # Empty string is the AWS provider's idiom for "no explicit profile;
-  # fall back to env vars / default chain". Terragrunt threads
-  # $AWS_PROFILE from .env; plain `terraform apply` leaves it unset.
+  region  = var.region
   profile = var.aws_profile != "" ? var.aws_profile : null
 }
 

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,29 +1,43 @@
 output "inbound_mx_record" {
-  description = "Publish at DNS for the hail-mail base domain. The full record is e.g. '10 inbound-smtp.us-east-1.amazonaws.com'."
+  description = "Publish at DNS for the hail-mail base domain."
   value       = "10 inbound-smtp.${var.region}.amazonaws.com"
 }
 
 output "inbound_bucket" {
-  description = "Raw-MIME bucket. Set HAIL_INBOUND_BUCKET in the API .env to this value."
+  description = "Set as HAIL_INBOUND_BUCKET in .env."
   value       = aws_s3_bucket.inbound.bucket
 }
 
 output "lambda_function_arn" {
-  description = "ARN of the deployed ses-ingest-lambda."
-  value       = aws_lambda_function.ingest.arn
+  value = aws_lambda_function.ingest.arn
 }
 
 output "ingest_dlq_url" {
-  description = "SQS DLQ holding SES notifications the Lambda failed to deliver to the Hail API"
+  description = "SQS DLQ for SES notifications the Lambda failed to deliver."
   value       = aws_sqs_queue.ingest_dlq.url
 }
 
 output "receipt_rule_set_name" {
-  description = "Created but NOT activated. Activate manually — see activate_command."
-  value       = aws_ses_receipt_rule_set.hail.rule_set_name
+  description = "Created but NOT activated — see activate_command."
+  value       = aws_ses_receipt_rule_set.main.rule_set_name
 }
 
 output "activate_command" {
-  description = "Run once after apply, in an account with no other active receipt rule set. See docs/setup/aws-ses.md §10."
-  value       = "aws sesv2 set-active-receipt-rule-set --rule-set-name ${aws_ses_receipt_rule_set.hail.rule_set_name}"
+  description = "Run once per AWS account, after confirming no other rule set is active."
+  value       = "aws sesv2 set-active-receipt-rule-set --rule-set-name ${aws_ses_receipt_rule_set.main.rule_set_name}"
+}
+
+output "iam_policy_arn" {
+  value = aws_iam_policy.main.arn
+}
+
+output "iam_access_key_id" {
+  description = "Paste into .env as AWS_ACCESS_KEY_ID."
+  value       = aws_iam_access_key.main.id
+}
+
+output "iam_secret_access_key" {
+  description = "Paste into .env as AWS_SECRET_ACCESS_KEY."
+  value       = aws_iam_access_key.main.secret
+  sensitive   = true
 }

--- a/infra/terraform/ses_inbound.tf
+++ b/infra/terraform/ses_inbound.tf
@@ -1,14 +1,10 @@
-# SES has a single *active* receipt rule set per region per account.
-# This module creates the rule set but does NOT activate it — activation
-# is a destructive operation if the account already has one running.
-# Activate manually after apply; see docs/setup/aws-ses.md §10.
-resource "aws_ses_receipt_rule_set" "hail" {
+resource "aws_ses_receipt_rule_set" "main" {
   rule_set_name = local.rule_set_name
 }
 
-resource "aws_ses_receipt_rule" "hail" {
+resource "aws_ses_receipt_rule" "main" {
   name          = local.rule_name
-  rule_set_name = aws_ses_receipt_rule_set.hail.rule_set_name
+  rule_set_name = aws_ses_receipt_rule_set.main.rule_set_name
   enabled       = true
   scan_enabled  = true
   recipients    = [var.hail_mail_base_domain]

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,26 +1,26 @@
 variable "name_prefix" {
-  description = "Prefix for AWS resources (e.g. hail-inbound-prod). Buckets, the rule set, the Lambda, and IAM roles all derive their names from this."
+  description = "Prefix for AWS resources (S3 bucket, SES rule set, Lambda, IAM)."
   type        = string
 }
 
 variable "region" {
-  description = "AWS region for SES inbound. SES inbound is only available in select regions (us-east-1, us-west-2, eu-west-1, ...). Pick one and stick with it."
+  description = "AWS region. Must support SES inbound (us-east-1, us-west-2, eu-west-1, ...)."
   type        = string
 }
 
 variable "hail_api_url" {
-  description = "Base URL of the Hail API (e.g. https://api.hail.so). No trailing slash."
+  description = "Public base URL of the Hail API. The Lambda POSTs to <hail_api_url>/internal/ses-events."
   type        = string
 }
 
 variable "hail_inbound_hmac_secret" {
-  description = "Shared secret between the Lambda and the Hail API. Generate something random and 64+ hex chars. Set HAIL_INBOUND_HMAC_SECRET in the API service env to the same value."
+  description = "Shared HMAC secret between the Lambda and the API."
   type        = string
   sensitive   = true
 }
 
 variable "hail_mail_base_domain" {
-  description = "Base domain mail will be received on (e.g. mail.hail.so). Must be in the SES Receipt Rule's recipient filter."
+  description = "Domain SES receives mail on (e.g. mail.hail.so)."
   type        = string
 }
 
@@ -31,13 +31,19 @@ variable "raw_object_expiration_days" {
 }
 
 variable "lambda_source_dir" {
-  description = "Absolute path to the ses-ingest-lambda directory. Terragrunt resolves this from the repo root because `terraform` runs out of `.terragrunt-cache/...` and `path.module/../ses-ingest-lambda` no longer points at the sibling. Plain `terraform apply` callers can leave this empty — the default falls back to the in-tree path next to this module."
+  description = "Absolute path to the ses-ingest-lambda directory. Set by Terragrunt; default works when running `terraform` directly from infra/terraform/."
   type        = string
   default     = ""
 }
 
 variable "aws_profile" {
-  description = "AWS named profile from ~/.aws/credentials. Empty falls back to the default credential chain (env vars, IAM role, etc.). Terragrunt threads $AWS_PROFILE here from .env."
+  description = "AWS named profile for the provider. Empty uses the default credential chain."
   type        = string
   default     = ""
+}
+
+variable "iam_user_name" {
+  description = "IAM user provisioned for every Hail service."
+  type        = string
+  default     = "hail"
 }

--- a/infra/terragrunt.hcl
+++ b/infra/terragrunt.hcl
@@ -1,60 +1,20 @@
-# Terragrunt wrapper around the inbound-email Terraform module.
-#
-# Reads operator config from the repo's .env directly via run_cmd —
-# no need to `set -a; source .env; set +a` first. Just:
-#
-#   terragrunt apply
-#
-# AWS credentials come from the profile named in $AWS_PROFILE in .env.
-# The S3 backend block below reads the same .env, so backend auth and
-# module auth stay consistent.
-#
-# State + infra regions are decoupled. HAIL_TERRAFORM_STATE_REGION is
-# where the S3 state bucket and DynamoDB lock table live (typically a
-# single shared region across all your deployments); AWS_REGION is
-# where the SES + Lambda + raw-MIME S3 bucket get provisioned (often
-# per-deployment). If you don't set HAIL_TERRAFORM_STATE_REGION, it
-# falls back to AWS_REGION (single-region setups stay one var).
-#
-# One-time bootstrap (per AWS account, before the first `terragrunt
-# init`) — the state bucket + lock table can't bootstrap themselves:
-#
-#   set -a; source .env; set +a
-#   STATE_REGION=${HAIL_TERRAFORM_STATE_REGION:-$AWS_REGION}
-#   aws --profile $AWS_PROFILE s3api create-bucket \
-#       --bucket $HAIL_TERRAFORM_STATE_BUCKET \
-#       --region $STATE_REGION
-#   aws --profile $AWS_PROFILE s3api put-bucket-versioning \
-#       --bucket $HAIL_TERRAFORM_STATE_BUCKET \
-#       --versioning-configuration Status=Enabled
-#   aws --profile $AWS_PROFILE dynamodb create-table \
-#       --table-name $HAIL_TERRAFORM_LOCK_TABLE \
-#       --attribute-definitions AttributeName=LockID,AttributeType=S \
-#       --key-schema AttributeName=LockID,KeyType=HASH \
-#       --billing-mode PAY_PER_REQUEST \
-#       --region $STATE_REGION
+# Reads operator config from the repo's .env. AWS_PROFILE comes from
+# the shell (so it doesn't leak into containerized services that share
+# .env). State backend region defaults to AWS_REGION.
 
 locals {
   env_file = "${get_repo_root()}/.env"
 
-  # Sourced from .env. HCL only interprets `${...}` with braces — bare
-  # `$VAR` passes through to bash unchanged, so no escape needed for
-  # those. For `${VAR:-default}` we escape the HCL braces with `$${...}`
-  # so bash gets the parameter-expansion form. Empty AWS_PROFILE means
-  # "use the default AWS credential chain" — leave it that way for
-  # IAM-role hosts.
-  aws_profile  = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$${AWS_PROFILE:-}\"")
-  aws_region   = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$${AWS_REGION:-us-east-1}\"")
-  state_region = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$${HAIL_TERRAFORM_STATE_REGION:-$${AWS_REGION:-us-east-1}}\"")
-  state_bucket = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_TERRAFORM_STATE_BUCKET\"")
-  lock_table   = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_TERRAFORM_LOCK_TABLE\"")
-  # Prefix for the AWS resources THIS Terraform module owns
-  # (SES + S3 + Lambda for inbound email). Scoped to email because
-  # other inbound channels (SMS, voice) don't provision AWS infra.
-  email_inbound_name_prefix = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$${HAIL_INBOUND_EMAIL_NAME_PREFIX:-hail-email-inbound}\"")
-  hail_api_url              = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_API_URL\"")
-  hail_inbound_secret       = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_INBOUND_HMAC_SECRET\"")
-  hail_mail_base_domain     = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_MAIL_BASE_DOMAIN\"")
+  aws_profile           = get_env("AWS_PROFILE", "")
+  aws_region            = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$${AWS_REGION:-us-east-1}\"")
+  state_region          = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$${HAIL_TERRAFORM_STATE_REGION:-$${AWS_REGION:-us-east-1}}\"")
+  state_bucket          = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_TERRAFORM_STATE_BUCKET\"")
+  lock_table            = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_TERRAFORM_LOCK_TABLE\"")
+  name_prefix           = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_INBOUND_EMAIL_NAME_PREFIX\"")
+  iam_user_name         = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_IAM_USER_NAME\"")
+  hail_api_url          = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_API_URL\"")
+  hail_inbound_secret   = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_INBOUND_HMAC_SECRET\"")
+  hail_mail_base_domain = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_MAIL_BASE_DOMAIN\"")
 }
 
 terraform {
@@ -78,17 +38,12 @@ remote_state {
 }
 
 inputs = {
-  name_prefix              = local.email_inbound_name_prefix
+  name_prefix              = local.name_prefix
   region                   = local.aws_region
   hail_api_url             = local.hail_api_url
   hail_inbound_hmac_secret = local.hail_inbound_secret
   hail_mail_base_domain    = local.hail_mail_base_domain
-  # AWS profile for the provider — same value the S3 backend above
-  # uses so backend + resource calls share one credential source.
-  aws_profile = local.aws_profile
-  # Absolute path to the Lambda source. Terragrunt copies `./terraform`
-  # into `.terragrunt-cache/`, so the in-tree relative reference
-  # (`${path.module}/../ses-ingest-lambda`) breaks; thread the real
-  # repo-rooted path through as a variable.
-  lambda_source_dir = "${get_repo_root()}/infra/ses-ingest-lambda"
+  aws_profile              = local.aws_profile
+  iam_user_name            = local.iam_user_name
+  lambda_source_dir        = "${get_repo_root()}/infra/ses-ingest-lambda"
 }


### PR DESCRIPTION
…rywhere

  (1) Strip hardcoded identifier defaults from code:
      - Settings.hail_inbound_email_name_prefix now defaults to "" (matches the empty-default rule already used for model names and other ids).
      - terragrunt.hcl drops ${VAR:-hail-email-inbound} and ${VAR:-hail} bash-style fallbacks. Operator must set HAIL_INBOUND_EMAIL_NAME_PREFIX and HAIL_IAM_USER_NAME in .env; missing values now fail loudly at terragrunt init time instead of silently using a value the operator didn't choose. Defaults live only in .env.example. The single-source guarantee for the inbound bucket name (computed ${prefix}-raw) is unchanged.

  (2) Extract resolveIDPrefix as a generic short-ID resolver in
      cli/internal/cmd/resolve.go and apply it to every UUID-taking CLI command, not just `email get`: hail call status <id> hail email get <id> hail email-domain get <id> hail email-domain verify <id> hail email-domain delete <id> hail webhooks deliveries <subID> hail webhooks redeliver <subID> <deliveryID> Each command accepts either a full UUID or a 4+ char hex prefix. Ambiguous match lists candidates; no match hints to pass the full UUID.

  (3) lint-staged: format terraform / terragrunt at the infra dir level
      instead of per-file. `terraform fmt <abs-path>` was resolving paths relative to its own cwd under husky and failing; `-chdir=infra/...` pins the directory regardless of caller cwd.