### PR TITLE
chore(mcp): add glama.json to claim the MCP server listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "r13i"
+  ]
+}


### PR DESCRIPTION
Glama (https://glama.ai/mcp/servers) auto-discovers MCP servers from GitHub — no submission needed — but claiming the listing (via GitHub login) is required to configure Docker build instructions and get review notifications, per https://glama.ai/mcp/servers/hail-hq/hail.

Since this repo is org-owned, claiming requires a `glama.json` at repo root listing GitHub maintainers, per Glama's docs.

This is a standalone, isolated change branched from the last pushed `main` (`9813ace`) — no other in-flight work included.