### PR TITLE
fix(mcp): use r@hail.so as the Glama connector maintainer email

### DIFF
--- a/mcp/hailhq/mcp/server.py
+++ b/mcp/hailhq/mcp/server.py
@@ -79,7 +79,7 @@ def _build_app() -> tuple[FastMCP, HailClient | None, Starlette]:
         return JSONResponse(
             {
                 "$schema": "https://glama.ai/mcp/schemas/connector.json",
-                "maintainers": [{"email": "redouane.a.achouri@gmail.com"}],
+                "maintainers": [{"email": "r@hail.so"}],
             }
         )
 


### PR DESCRIPTION
Switches the /.well-known/glama.json maintainer from a personal email to r@hail.so, per request. Follow-up to #5.