### PR TITLE
feat(costs): weekly refresh 2026-07-13

### DIFF
--- a/costs/llm.json
+++ b/costs/llm.json
@@ -30,7 +30,7 @@
       "supports_pdf": true,
       "reasoning_tokens_billed": true,
       "deployment_options": ["native", "bedrock", "vertex"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-05",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -65,7 +65,7 @@
       "supports_pdf": true,
       "reasoning_tokens_billed": true,
       "deployment_options": ["native", "bedrock", "vertex"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-05",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -100,7 +100,7 @@
       "supports_pdf": true,
       "reasoning_tokens_billed": true,
       "deployment_options": ["native", "bedrock", "vertex"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-06-09",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -135,7 +135,7 @@
       "supports_pdf": true,
       "reasoning_tokens_billed": true,
       "deployment_options": ["native", "bedrock", "vertex"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-28",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -170,7 +170,7 @@
       "supports_pdf": true,
       "reasoning_tokens_billed": true,
       "deployment_options": ["native", "bedrock", "vertex"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-06-30",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -205,12 +205,12 @@
       "deployment_options": ["native", "azure"],
       "deprecated_at": "2026-06-11",
       "replaced_by_model_id": "gpt-5.5",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-05",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://developers.openai.com/api/docs/models/gpt-5",
-      "notes": "Reasoning model with adjustable reasoning_effort; reasoning tokens are billed at the output rate. Context window 400k, max output 128k confirmed against developers.openai.com/api/docs/models/gpt-5. Cached input at 10% of base ($0.125/MTok). Batch API at flat 50% off input and output. PDF input via the Files API; image input native; audio is NOT supported on this model_id. Knowledge cutoff Sept 2024. Deprecation announced 2026-06-11: dated snapshot gpt-5-2025-08-07 scheduled for API removal 2026-12-11, recommended replacement gpt-5.5 (per developers.openai.com/api/docs/deprecations); bare 'gpt-5' still serving as of 2026-07-02, prices unchanged."
+      "notes": "Reasoning model with adjustable reasoning_effort; reasoning tokens are billed at the output rate. Context window 400k, max output 128k confirmed against developers.openai.com/api/docs/models/gpt-5. Cached input at 10% of base ($0.125/MTok). Batch API at flat 50% off input and output. PDF input via the Files API; image input native; audio is NOT supported on this model_id. Knowledge cutoff Sept 2024. Deprecation announced 2026-06-11: dated snapshot gpt-5-2025-08-07 scheduled for API removal 2026-12-11, recommended replacement gpt-5.5 (per developers.openai.com/api/docs/deprecations); bare 'gpt-5' still serving as of 2026-07-13, prices unchanged. 2026-07-13 re-verify: model card prose now points to the newer GPT-5.6 family ('We recommend using the latest GPT-5.6') as of GPT-5.6's release, but the structured deprecations table still redirects the dated gpt-5-2025-08-07 snapshot to gpt-5.5; kept replaced_by_model_id at gpt-5.5 pending an update to the formal deprecation entry."
     },
     {
       "provider": "Google",
@@ -248,12 +248,12 @@
       "reasoning_tokens_billed": true,
       "deployment_options": ["native", "vertex"],
       "confidence": "high",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-05",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://ai.google.dev/pricing",
-      "notes": "Input pricing shown is for prompts <=200k tokens; prompts >200k tokens are billed per pricing_tiers; cached input also tiers at 200k (the >200k rate is captured in pricing_tiers[0].cache_read_per_mtok_usd). Context window and max_output_tokens confirmed via ai.google.dev/gemini-api/docs/models/gemini-2.5-pro. Thinking is always on and cannot be disabled; thinking tokens are billed at the output rate. Knowledge cutoff January 2025. Batch Mode discount is a flat 50% off input/output. Audio input is billed at the standard input rate of $1.25/MTok (no separate audio premium, unlike 2.5 Flash/Flash-Lite/2.0 Flash); audio_input_per_mtok_usd omitted. Explicit context caching storage is captured in cache_storage_per_mtok_per_hour_usd. Free tier (AI Studio) is published as per-minute RPM/TPM only, not per-day; free_tier omitted. PDF input via the Files API; image, audio, and video native. Re-verified 2026-07-02: prices, context window, and modalities unchanged; no new pricing tiers."
+      "notes": "Input pricing shown is for prompts <=200k tokens; prompts >200k tokens are billed per pricing_tiers; cached input also tiers at 200k (the >200k rate is captured in pricing_tiers[0].cache_read_per_mtok_usd). Context window and max_output_tokens confirmed via ai.google.dev/gemini-api/docs/models/gemini-2.5-pro. Thinking is always on and cannot be disabled; thinking tokens are billed at the output rate. Knowledge cutoff January 2025. Batch Mode discount is a flat 50% off input/output. Audio input is billed at the standard input rate of $1.25/MTok (no separate audio premium, unlike 2.5 Flash/Flash-Lite/2.0 Flash); audio_input_per_mtok_usd omitted. Explicit context caching storage is captured in cache_storage_per_mtok_per_hour_usd. Free tier (AI Studio) is published as per-minute RPM/TPM only, not per-day; free_tier omitted. PDF input via the Files API; image, audio, and video native. Re-verified 2026-07-02: prices, context window, and modalities unchanged; no new pricing tiers. Re-verified 2026-07-13: prices, tiers, and modalities unchanged against ai.google.dev/pricing; cross-checked ai.google.dev/gemini-api/docs/models."
     },
     {
       "provider": "DeepSeek",
@@ -278,12 +278,12 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": true,
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-05",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://api-docs.deepseek.com/quick_start/pricing",
-      "notes": "MoE architecture: 284B total parameters, 13B activated. Replaces deepseek-chat (V3-era alias). Cached input price ($0.0028/MTok) is 1/50th of base input, effective after DeepSeek reduced cache hit rates on 2026-04-26. Supports both non-thinking and thinking (default) modes; thinking output is billed at the same output rate, so reasoning_tokens_billed: true. deepseek-chat and deepseek-reasoner legacy aliases are scheduled for discontinuation on 2026-07-24; until then they route to V4 Flash non-thinking and thinking modes respectively. Re-verified 2026-07-02: prices, context window, and concurrency limit unchanged."
+      "notes": "MoE architecture: 284B total parameters, 13B activated. Replaces deepseek-chat (V3-era alias). Cached input price ($0.0028/MTok) is 1/50th of base input, effective after DeepSeek reduced cache hit rates on 2026-04-26. Supports both non-thinking and thinking (default) modes; thinking output is billed at the same output rate, so reasoning_tokens_billed: true. deepseek-chat and deepseek-reasoner legacy aliases are scheduled for discontinuation on 2026-07-24; until then they route to V4 Flash non-thinking and thinking modes respectively. Re-verified 2026-07-02: prices, context window, and concurrency limit unchanged. Re-verified 2026-07-13: prices, context window, and concurrency limit unchanged against api-docs.deepseek.com/quick_start/pricing; cross-checked api-docs.deepseek.com/news/news, which shows no new deprecation activity."
     },
     {
       "provider": "DeepSeek",
@@ -308,12 +308,12 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": true,
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://api-docs.deepseek.com/quick_start/pricing",
-      "notes": "Pro-tier sibling to deepseek-v4-flash, positioned for higher-quality responses at lower concurrency (500 vs Flash's 2500). The original list rates ($1.74 / $3.48 per MTok; cache hit $0.0145) carried a 75% launch promotion through 2026-05-31 15:59 UTC; DeepSeek made the discounted rate permanent (announced 2026-05-22) rather than reverting, so the promo price is now the standing list price: $0.435 input / $0.87 output / $0.003625 cache hit — exactly 1/4 of the original rates, confirmed live on the pricing page 2026-07-02. Secondary confirmation: https://apidog.com/blog/deepseek-v4-pro-permanent-price-cut/ (reporting DeepSeek's permanent 75% cut, citing Reuters/Engadget coverage). Cache miss is billed at the base input rate. Supports both non-thinking and thinking modes with tool calls and JSON output; thinking output is billed at the output rate, so reasoning_tokens_billed: true."
+      "notes": "Pro-tier sibling to deepseek-v4-flash, positioned for higher-quality responses at lower concurrency (500 vs Flash's 2500). The original list rates ($1.74 / $3.48 per MTok; cache hit $0.0145) carried a 75% launch promotion through 2026-05-31 15:59 UTC; DeepSeek made the discounted rate permanent (announced 2026-05-22) rather than reverting, so the promo price is now the standing list price: $0.435 input / $0.87 output / $0.003625 cache hit — exactly 1/4 of the original rates, confirmed live on the pricing page 2026-07-02. Secondary confirmation: https://apidog.com/blog/deepseek-v4-pro-permanent-price-cut/ (reporting DeepSeek's permanent 75% cut, citing Reuters/Engadget coverage). Cache miss is billed at the base input rate. Supports both non-thinking and thinking modes with tool calls and JSON output; thinking output is billed at the output rate, so reasoning_tokens_billed: true. Re-verified 2026-07-13: prices, context window, and concurrency limit unchanged against api-docs.deepseek.com/quick_start/pricing."
     },
     {
       "provider": "DeepSeek",
@@ -340,12 +340,12 @@
       "deployment_options": ["native"],
       "deprecated_at": "2026-04-24",
       "replaced_by_model_id": "deepseek-v4-flash",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-04-24",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://api-docs.deepseek.com/quick_start/pricing",
-      "notes": "Canonical API model_id for the DeepSeek V3 lineage (V3 launched 2024-12-26 as deepseek-chat; upgraded through V3-0324, V3.1, V3.1-Terminus, V3.2 by 2025-12-01). Deprecated 2026-04-24 when V4 launched; still callable until scheduled discontinuation 2026-07-24, currently routing to deepseek-v4-flash non-thinking mode (prices captured here reflect that routing). DeepSeek's pricing page no longer publishes V3-era historical rates; standalone deepseek-v3 model_id was never exposed by the API. Re-verified 2026-07-02: discontinuation date (2026-07-24 15:59 UTC) and routing/pricing unchanged."
+      "notes": "Canonical API model_id for the DeepSeek V3 lineage (V3 launched 2024-12-26 as deepseek-chat; upgraded through V3-0324, V3.1, V3.1-Terminus, V3.2 by 2025-12-01). Deprecated 2026-04-24 when V4 launched; still callable until scheduled discontinuation 2026-07-24, currently routing to deepseek-v4-flash non-thinking mode (prices captured here reflect that routing). DeepSeek's pricing page no longer publishes V3-era historical rates; standalone deepseek-v3 model_id was never exposed by the API. Re-verified 2026-07-02: discontinuation date (2026-07-24 15:59 UTC) and routing/pricing unchanged. Re-verified 2026-07-13: discontinuation date (2026-07-24 15:59 UTC) and routing/pricing unchanged; now 11 days out, expect this row to flip from deprecated to fully retired at the next refresh."
     },
     {
       "provider": "DeepSeek",
@@ -372,12 +372,12 @@
       "deployment_options": ["native"],
       "deprecated_at": "2026-04-24",
       "replaced_by_model_id": "deepseek-v4-flash",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-04-24",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://api-docs.deepseek.com/quick_start/pricing",
-      "notes": "Canonical API model_id for the DeepSeek R1 reasoning lineage (R1 launched 2025-01-20 as deepseek-reasoner; R1-0528 update 2025-05-28). Deprecated 2026-04-24 when V4 launched; still callable until scheduled discontinuation 2026-07-24, currently routing to deepseek-v4-flash thinking mode (prices captured here reflect that routing). Reasoning output is billed at the standard output rate (reasoning_tokens_billed: true). DeepSeek's pricing page no longer publishes R1-era historical rates; standalone deepseek-r1 model_id was never exposed by the API. Re-verified 2026-07-02: discontinuation date (2026-07-24 15:59 UTC) and routing/pricing unchanged."
+      "notes": "Canonical API model_id for the DeepSeek R1 reasoning lineage (R1 launched 2025-01-20 as deepseek-reasoner; R1-0528 update 2025-05-28). Deprecated 2026-04-24 when V4 launched; still callable until scheduled discontinuation 2026-07-24, currently routing to deepseek-v4-flash thinking mode (prices captured here reflect that routing). Reasoning output is billed at the standard output rate (reasoning_tokens_billed: true). DeepSeek's pricing page no longer publishes R1-era historical rates; standalone deepseek-r1 model_id was never exposed by the API. Re-verified 2026-07-02: discontinuation date (2026-07-24 15:59 UTC) and routing/pricing unchanged. Re-verified 2026-07-13: discontinuation date (2026-07-24 15:59 UTC) and routing/pricing unchanged; now 11 days out, expect this row to flip from deprecated to fully retired at the next refresh."
     },
     {
       "provider": "Anthropic",
@@ -411,7 +411,7 @@
       "supports_pdf": true,
       "reasoning_tokens_billed": true,
       "deployment_options": ["native", "bedrock", "vertex"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2025-10-01",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -450,7 +450,7 @@
       "supports_pdf": true,
       "reasoning_tokens_billed": true,
       "deployment_options": ["native", "bedrock", "vertex"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2025-09-29",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -489,7 +489,7 @@
       "supports_pdf": true,
       "reasoning_tokens_billed": true,
       "deployment_options": ["native", "bedrock", "vertex"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2025-11-01",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -531,7 +531,7 @@
       "deprecated_at": "2025-10-28",
       "replaced_by_model_id": "claude-sonnet-4-6",
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2025-10-28",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -573,7 +573,7 @@
       "deprecated_at": "2025-12-19",
       "replaced_by_model_id": "claude-haiku-4-5-20251001",
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2025-12-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -608,12 +608,12 @@
       "deployment_options": ["native", "azure"],
       "deprecated_at": "2026-06-11",
       "replaced_by_model_id": "gpt-5.4-mini",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-17",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://developers.openai.com/api/docs/models/gpt-5-mini",
-      "notes": "Faster, more cost-efficient GPT-5 variant for low-latency, high-volume workloads. Cached input at 10% of base ($0.025/MTok). Batch API at flat 50% off input and output. Reasoning model with adjustable reasoning_effort; reasoning tokens are billed at the output rate. PDF input via the Files API; image input native. Knowledge cutoff May 2024. Deprecation announced 2026-06-11: dated snapshot gpt-5-mini-2025-08-07 scheduled for API removal 2026-12-11, recommended replacement gpt-5.4-mini (per developers.openai.com/api/docs/deprecations); bare 'gpt-5-mini' still serving as of 2026-07-02, prices unchanged."
+      "notes": "Faster, more cost-efficient GPT-5 variant for low-latency, high-volume workloads. Cached input at 10% of base ($0.025/MTok). Batch API at flat 50% off input and output. Reasoning model with adjustable reasoning_effort; reasoning tokens are billed at the output rate. PDF input via the Files API; image input native. Knowledge cutoff May 2024. Deprecation announced 2026-06-11: dated snapshot gpt-5-mini-2025-08-07 scheduled for API removal 2026-12-11, recommended replacement gpt-5.4-mini (per developers.openai.com/api/docs/deprecations); bare 'gpt-5-mini' still serving as of 2026-07-13, prices unchanged. 2026-07-13 re-verify: model card now also points new low-latency workloads to GPT-5.6 Terra, but bare gpt-5-mini remains active."
     },
     {
       "provider": "OpenAI",
@@ -644,12 +644,12 @@
       "deprecated_at": "2026-06-11",
       "replaced_by_model_id": "gpt-5.4-nano",
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-17",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://developers.openai.com/api/docs/models/gpt-5-nano",
-      "notes": "Smallest GPT-5 variant; OpenAI model card lists 'Reasoning model: No' with 'Average' reasoning capability — reasoning_tokens_billed set to false on that basis (confidence: medium because other GPT-5 family members are reasoning models). Cached input at 10% of base ($0.005/MTok). Batch API at flat 50% off input and output. Knowledge cutoff May 2024. Deprecation announced 2026-06-11: dated snapshot gpt-5-nano-2025-08-07 scheduled for API removal 2026-12-11, recommended replacement gpt-5.4-nano (per developers.openai.com/api/docs/deprecations); bare 'gpt-5-nano' still serving as of 2026-07-02, prices unchanged."
+      "notes": "Smallest GPT-5 variant; OpenAI model card lists 'Reasoning model: No' with 'Average' reasoning capability — reasoning_tokens_billed set to false on that basis (confidence: medium because other GPT-5 family members are reasoning models). Cached input at 10% of base ($0.005/MTok). Batch API at flat 50% off input and output. Knowledge cutoff May 2024. Deprecation announced 2026-06-11: dated snapshot gpt-5-nano-2025-08-07 scheduled for API removal 2026-12-11, recommended replacement gpt-5.4-nano (per developers.openai.com/api/docs/deprecations); bare 'gpt-5-nano' still serving as of 2026-07-13, prices unchanged. 2026-07-13 re-verify: model card now also points new speed/cost-sensitive workloads to GPT-5.6 Luna, but bare gpt-5-nano remains active."
     },
     {
       "provider": "OpenAI",
@@ -677,12 +677,12 @@
       "supports_pdf": true,
       "reasoning_tokens_billed": false,
       "deployment_options": ["native", "azure"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-17",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://developers.openai.com/api/docs/models/gpt-4.1",
-      "notes": "Non-reasoning flagship with a ~1M-token context window (1,047,576). Cached input at 25% of base ($0.50/MTok). Batch API at flat 50% off input and output. PDF input via the Files API; image input native. Knowledge cutoff June 2024. Not on the June 2026 deprecation announcement; remains active alongside the new GPT-5.4/5.5 family."
+      "notes": "Non-reasoning flagship with a ~1M-token context window (1,047,576). Cached input at 25% of base ($0.50/MTok). Batch API at flat 50% off input and output. PDF input via the Files API; image input native. Knowledge cutoff June 2024. Not on the June 2026 deprecation announcement; remains active alongside the new GPT-5.4/5.5 family. Re-verified 2026-07-13: prices unchanged, still not on the deprecations table; remains active alongside the new GPT-5.6 family."
     },
     {
       "provider": "OpenAI",
@@ -711,13 +711,13 @@
       "reasoning_tokens_billed": false,
       "deployment_options": ["native", "azure"],
       "deprecated_at": "2026-04-22",
-      "replaced_by_model_id": "gpt-4.1",
-      "last_verified": "2026-07-02",
+      "replaced_by_model_id": "gpt-5.5",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-04-22",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://developers.openai.com/api/docs/models/gpt-4o",
-      "notes": "Deprecated 2026-04-22 (dated alias gpt-4o-2024-05-13 scheduled for shutdown 2026-10-23 per OpenAI deprecations page); still serving on the API as of 2026-05-17. Audio input/output are NOT supported on this model_id — they live on a sibling gpt-4o-audio-preview model card with separate pricing (audio input $40/MTok, audio output $80/MTok); text-mode prices captured here. Cached input at 50% of base ($1.25/MTok). Batch API at flat 50% off input and output. Knowledge cutoff Oct 2023."
+      "notes": "Deprecated 2026-04-22 (dated alias gpt-4o-2024-05-13 scheduled for shutdown 2026-10-23 per OpenAI deprecations page); still serving on the API as of 2026-07-13. Audio input/output are NOT supported on this model_id — they live on a sibling gpt-4o-audio-preview model card with separate pricing (audio input $40/MTok, audio output $80/MTok); text-mode prices captured here. Cached input at 50% of base ($1.25/MTok). Batch API at flat 50% off input and output. Knowledge cutoff Oct 2023. 2026-07-13 re-verify: the deprecations table now redirects the dated gpt-4o-2024-05-13 snapshot to gpt-5.5 (previously gpt-4.1); replaced_by_model_id updated to match the current table verbatim ('gpt-4o-2024-05-13 | gpt-5.5')."
     },
     {
       "provider": "OpenAI",
@@ -745,12 +745,12 @@
       "supports_pdf": true,
       "reasoning_tokens_billed": false,
       "deployment_options": ["native", "azure"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-17",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://developers.openai.com/api/docs/models/gpt-4o-mini",
-      "notes": "Not on the April 2026 deprecation list; remains active. Audio input/output are NOT supported on this model_id — they live on a sibling gpt-4o-mini-audio-preview model card; text-mode prices captured here. Cached input at 50% of base ($0.075/MTok). Batch API at flat 50% off input and output. Knowledge cutoff Oct 2023. Not on the June 2026 deprecation announcement either; remains active alongside the new GPT-5.4/5.5 family."
+      "notes": "Not on the April 2026 deprecation list; remains active. Audio input/output are NOT supported on this model_id — they live on a sibling gpt-4o-mini-audio-preview model card; text-mode prices captured here. Cached input at 50% of base ($0.075/MTok). Batch API at flat 50% off input and output. Knowledge cutoff Oct 2023. Not on the June 2026 deprecation announcement either; remains active alongside the new GPT-5.4/5.5 family. Re-verified 2026-07-13: prices unchanged, listed as 'Default' tier, still not on the deprecations table."
     },
     {
       "provider": "OpenAI",
@@ -780,12 +780,12 @@
       "deployment_options": ["native", "azure"],
       "deprecated_at": "2026-06-11",
       "replaced_by_model_id": "gpt-5.5",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-17",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://developers.openai.com/api/docs/models/o3",
-      "notes": "Reasoning model for complex tasks; reasoning tokens are billed at the output rate. Cached input at 25% of base ($0.50/MTok). Batch API at flat 50% off input and output. Knowledge cutoff June 2024. Deprecation announced 2026-06-11: dated snapshot o3-2025-04-16 scheduled for API removal 2026-12-11, recommended replacement gpt-5.5 (per developers.openai.com/api/docs/deprecations); bare 'o3' still serving as of 2026-07-02, prices unchanged."
+      "notes": "Reasoning model for complex tasks; reasoning tokens are billed at the output rate. Cached input at 25% of base ($0.50/MTok). Batch API at flat 50% off input and output. Knowledge cutoff June 2024. Deprecation announced 2026-06-11: dated snapshot o3-2025-04-16 scheduled for API removal 2026-12-11, recommended replacement gpt-5.5 (per developers.openai.com/api/docs/deprecations); bare 'o3' still serving as of 2026-07-13, prices unchanged."
     },
     {
       "provider": "OpenAI",
@@ -814,13 +814,13 @@
       "reasoning_tokens_billed": true,
       "deployment_options": ["native", "azure"],
       "deprecated_at": "2026-04-22",
-      "replaced_by_model_id": "gpt-5-mini",
-      "last_verified": "2026-07-02",
+      "replaced_by_model_id": "gpt-5.4-mini",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-04-22",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://developers.openai.com/api/docs/models/o4-mini",
-      "notes": "Fast, cost-efficient reasoning model; reasoning tokens are billed at the output rate. Deprecated 2026-04-22 (dated alias o4-mini-2025-04-16 scheduled for shutdown 2026-10-23 per OpenAI deprecations page); still serving as of 2026-05-17. OpenAI's model card notes 'succeeded by GPT-5 mini'. Cached input at 25% of base ($0.275/MTok). Batch API at flat 50% off input and output. Knowledge cutoff June 2024."
+      "notes": "Fast, cost-efficient reasoning model; reasoning tokens are billed at the output rate. Deprecated 2026-04-22 (dated alias o4-mini-2025-04-16 scheduled for shutdown 2026-10-23 per OpenAI deprecations page); still serving as of 2026-07-13. OpenAI's model card prose notes 'succeeded by GPT-5 mini'. Cached input at 25% of base ($0.275/MTok). Batch API at flat 50% off input and output. Knowledge cutoff June 2024. 2026-07-13 re-verify: the structured deprecations table lists the dated o4-mini-2025-04-16 snapshot's recommended replacement as gpt-5.4-mini (not gpt-5-mini); replaced_by_model_id updated to match that table verbatim."
     },
     {
       "provider": "OpenAI",
@@ -850,12 +850,12 @@
       "deployment_options": ["native", "azure"],
       "deprecated_at": "2026-04-22",
       "replaced_by_model_id": "gpt-5.5",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-04-22",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://developers.openai.com/api/docs/models/o1",
-      "notes": "First-generation reasoning model; reasoning tokens are billed at the output rate. Deprecated 2026-04-22 (dated alias o1-2024-12-17 scheduled for shutdown 2026-10-23 per OpenAI deprecations page); still serving as of 2026-07-02. OpenAI's recommended replacement is gpt-5.5, which is now in-file; replaced_by_model_id updated from the interim 'o3' successor (o3 itself was deprecated 2026-06-11). Cached input at 50% of base ($7.50/MTok). Batch API at flat 50% off input and output. Knowledge cutoff Oct 2023."
+      "notes": "First-generation reasoning model; reasoning tokens are billed at the output rate. Deprecated 2026-04-22 (dated alias o1-2024-12-17 scheduled for shutdown 2026-10-23 per OpenAI deprecations page); still serving as of 2026-07-13. OpenAI's recommended replacement is gpt-5.5, which is now in-file; replaced_by_model_id updated from the interim 'o3' successor (o3 itself was deprecated 2026-06-11). Cached input at 50% of base ($7.50/MTok). Batch API at flat 50% off input and output. Knowledge cutoff Oct 2023. Re-verified 2026-07-13: deprecations table confirms shutdown date 2026-10-23 and replacement gpt-5.5 unchanged."
     },
     {
       "provider": "OpenAI",
@@ -883,7 +883,7 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": true,
       "deployment_options": ["native", "azure"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -916,7 +916,7 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": true,
       "deployment_options": ["native", "azure"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -949,7 +949,7 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": true,
       "deployment_options": ["native", "azure"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -982,12 +982,174 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": true,
       "deployment_options": ["native", "azure"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://developers.openai.com/api/docs/models/gpt-5.4-nano",
       "notes": "New row this refresh — cheapest GPT-5.4-class model for simple, high-volume tasks (classification, extraction, ranking, sub-agents); replaces gpt-5-nano per the 2026-06-11 deprecations announcement. Reasoning model with adjustable reasoning_effort (none/low/medium/high/xhigh); reasoning tokens billed at the output rate. Cached input at 10% of base ($0.02/MTok). Batch API at flat 50% off input and output. Azure availability confirmed via learn.microsoft.com/azure/ai-foundry model list (context/output match exactly). supports_pdf set to false: modality table lists no PDF/file row — treating conservatively pending explicit confirmation."
+    },
+    {
+      "provider": "OpenAI",
+      "provider_url": "https://openai.com",
+      "model_id": "gpt-5.6-sol",
+      "display_name": "GPT-5.6 Sol",
+      "model_family": "GPT-5.6",
+      "knowledge_cutoff": "2026-02-16",
+      "context_window": 1050000,
+      "max_output_tokens": 128000,
+      "input_per_mtok_usd": "5.0",
+      "output_per_mtok_usd": "30.0",
+      "cache_read_per_mtok_usd": "0.5",
+      "modalities": {
+        "input": ["text", "image"],
+        "output": ["text"]
+      },
+      "supports_tool_use": true,
+      "structured_output": true,
+      "supports_vision": true,
+      "supports_audio_in": false,
+      "supports_audio_out": false,
+      "supports_pdf": false,
+      "reasoning_tokens_billed": true,
+      "deployment_options": ["native"],
+      "confidence": "medium",
+      "last_verified": "2026-07-13",
+      "last_changed_at": "2026-07-13",
+      "verification_method": "manual-confirmed",
+      "verified_by": "r13i",
+      "source_url": "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
+      "notes": "New row this refresh — frontier-tier model of the newly released GPT-5.6 family; model_id and price cross-checked across the OpenAI pricing page, the API models overview page, and this model's own docs page. Reasoning model with adjustable reasoning_effort; reasoning_tokens_billed set to true by parity with sibling GPT-5.4/5.5 reasoning models (not independently re-confirmed on this specific page, hence confidence: medium). Context window 1,050,000, max output 128k, knowledge cutoff 2026-02-16. Cached input at 10% of base ($0.50/MTok). Batch pricing was not explicitly published on the page as of this verification — omitted rather than assumed/invented. supports_pdf set to false and deployment_options limited to native (no Azure availability confirmed) — both treated conservatively pending explicit confirmation, matching how the GPT-5.4/5.5 rows were first added. Alias 'gpt-5.6' mentioned on the models overview page but not added here pending independent confirmation."
+    },
+    {
+      "provider": "OpenAI",
+      "provider_url": "https://openai.com",
+      "model_id": "gpt-5.6-terra",
+      "display_name": "GPT-5.6 Terra",
+      "model_family": "GPT-5.6",
+      "knowledge_cutoff": "2026-02-16",
+      "context_window": 1050000,
+      "max_output_tokens": 128000,
+      "input_per_mtok_usd": "2.5",
+      "output_per_mtok_usd": "15.0",
+      "cache_read_per_mtok_usd": "0.25",
+      "modalities": {
+        "input": ["text", "image"],
+        "output": ["text"]
+      },
+      "supports_tool_use": true,
+      "structured_output": true,
+      "supports_vision": true,
+      "supports_audio_in": false,
+      "supports_audio_out": false,
+      "supports_pdf": false,
+      "reasoning_tokens_billed": true,
+      "deployment_options": ["native"],
+      "confidence": "medium",
+      "last_verified": "2026-07-13",
+      "last_changed_at": "2026-07-13",
+      "verification_method": "manual-confirmed",
+      "verified_by": "r13i",
+      "source_url": "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
+      "notes": "New row this refresh — mid-tier model of the newly released GPT-5.6 family, described as balancing intelligence and cost; model_id and price cross-checked across the OpenAI pricing page, the API models overview page, and this model's own docs page. Reasoning model with adjustable reasoning_effort; reasoning_tokens_billed set to true by parity with sibling GPT-5.4/5.5 reasoning models. Context window 1,050,000, max output 128k, knowledge cutoff 2026-02-16. Cached input at 10% of base ($0.25/MTok). Batch pricing not explicitly published as of this verification — omitted rather than assumed. supports_pdf set to false and deployment_options limited to native — treated conservatively pending explicit confirmation. confidence: medium for the same reason as gpt-5.6-sol."
+    },
+    {
+      "provider": "OpenAI",
+      "provider_url": "https://openai.com",
+      "model_id": "gpt-5.6-luna",
+      "display_name": "GPT-5.6 Luna",
+      "model_family": "GPT-5.6",
+      "knowledge_cutoff": "2026-02-16",
+      "context_window": 1050000,
+      "max_output_tokens": 128000,
+      "input_per_mtok_usd": "1.0",
+      "output_per_mtok_usd": "6.0",
+      "cache_read_per_mtok_usd": "0.1",
+      "modalities": {
+        "input": ["text", "image"],
+        "output": ["text"]
+      },
+      "supports_tool_use": true,
+      "structured_output": true,
+      "supports_vision": true,
+      "supports_audio_in": false,
+      "supports_audio_out": false,
+      "supports_pdf": false,
+      "reasoning_tokens_billed": true,
+      "deployment_options": ["native"],
+      "confidence": "medium",
+      "last_verified": "2026-07-13",
+      "last_changed_at": "2026-07-13",
+      "verification_method": "manual-confirmed",
+      "verified_by": "r13i",
+      "source_url": "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
+      "notes": "New row this refresh — cheapest tier of the newly released GPT-5.6 family, designed for cost-sensitive, high-volume workloads; model_id and price cross-checked across the OpenAI pricing page, the API models overview page, and this model's own docs page. Reasoning model with adjustable reasoning_effort; reasoning_tokens_billed set to true by parity with sibling GPT-5.4/5.5 reasoning models. Context window 1,050,000, max output 128k, knowledge cutoff 2026-02-16. Cached input at 10% of base ($0.10/MTok). Batch pricing not explicitly published as of this verification — omitted rather than assumed. supports_pdf set to false and deployment_options limited to native — treated conservatively pending explicit confirmation. confidence: medium for the same reason as gpt-5.6-sol."
+    },
+    {
+      "provider": "OpenAI",
+      "provider_url": "https://openai.com",
+      "model_id": "gpt-5.5-pro",
+      "display_name": "GPT-5.5 Pro",
+      "model_family": "GPT-5.5",
+      "knowledge_cutoff": "2025-12-01",
+      "context_window": 1050000,
+      "max_output_tokens": 128000,
+      "input_per_mtok_usd": "30.0",
+      "output_per_mtok_usd": "180.0",
+      "batch_input_per_mtok_usd": "30.0",
+      "batch_output_per_mtok_usd": "180.0",
+      "modalities": {
+        "input": ["text", "image"],
+        "output": ["text"]
+      },
+      "supports_tool_use": true,
+      "structured_output": true,
+      "supports_vision": true,
+      "supports_audio_in": false,
+      "supports_audio_out": false,
+      "supports_pdf": false,
+      "reasoning_tokens_billed": true,
+      "deployment_options": ["native"],
+      "confidence": "medium",
+      "last_verified": "2026-07-13",
+      "last_changed_at": "2026-07-13",
+      "verification_method": "manual-confirmed",
+      "verified_by": "r13i",
+      "source_url": "https://developers.openai.com/api/docs/models/gpt-5.5-pro",
+      "notes": "New row this refresh — highest-effort reasoning tier of GPT-5.5, 'uses more compute to think harder'; model_id and price ($30/$180 per MTok) cross-checked across the OpenAI pricing page and this model's own docs page. No cache_read_per_mtok_usd field: the docs page states this model 'does not offer a cached input discount'. Batch API documented as the same rate as standard (no batch discount for this tier) — unusual versus sibling rows, recorded as given rather than assumed. Prompts over 272k input tokens incur a surcharge per the shared GPT-5.5 pricing note (not modeled as a separate pricing tier here, consistent with the gpt-5.5 row). supports_pdf false and deployment_options limited to native — treated conservatively pending explicit confirmation. confidence: medium because tool/structured-output flags were read from an AI-summarized fetch rather than raw page content."
+    },
+    {
+      "provider": "OpenAI",
+      "provider_url": "https://openai.com",
+      "model_id": "gpt-5.4-pro",
+      "display_name": "GPT-5.4 Pro",
+      "model_family": "GPT-5.4",
+      "knowledge_cutoff": "2025-08-31",
+      "context_window": 1050000,
+      "max_output_tokens": 128000,
+      "input_per_mtok_usd": "30.0",
+      "output_per_mtok_usd": "180.0",
+      "batch_input_per_mtok_usd": "30.0",
+      "batch_output_per_mtok_usd": "180.0",
+      "modalities": {
+        "input": ["text", "image"],
+        "output": ["text"]
+      },
+      "supports_tool_use": true,
+      "structured_output": false,
+      "supports_vision": true,
+      "supports_audio_in": false,
+      "supports_audio_out": false,
+      "supports_pdf": false,
+      "reasoning_tokens_billed": true,
+      "deployment_options": ["native"],
+      "confidence": "medium",
+      "last_verified": "2026-07-13",
+      "last_changed_at": "2026-07-13",
+      "verification_method": "manual-confirmed",
+      "verified_by": "r13i",
+      "source_url": "https://developers.openai.com/api/docs/models/gpt-5.4-pro",
+      "notes": "New row this refresh — highest-effort reasoning tier of GPT-5.4, 'uses more compute to think harder'; model_id and price ($30/$180 per MTok) cross-checked across the OpenAI pricing page and this model's own docs page. structured_output recorded as false: unlike every other row in this file, this model's docs page explicitly states structured outputs are NOT supported — flagged here rather than assumed true by parity with siblings; re-verify next refresh since this is a surprising outlier. No cache_read_per_mtok_usd field: no cache discount documented for this tier. Batch API documented as the same rate as standard (no batch discount). Prompts over 272k input tokens incur a surcharge per the shared GPT-5.4 pricing note (not modeled as a separate pricing tier here, consistent with the gpt-5.4 row). supports_pdf false and deployment_options limited to native — treated conservatively pending explicit confirmation. confidence: medium."
     },
     {
       "provider": "Google",
@@ -1018,12 +1180,12 @@
       "reasoning_tokens_billed": true,
       "deployment_options": ["native", "vertex"],
       "confidence": "high",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-18",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://ai.google.dev/gemini-api/docs/pricing",
-      "notes": "Hybrid reasoning model with dynamic thinking on by default; thinking can be disabled via thinkingBudget=0. When thinking is on, response pricing is the sum of output and thinking tokens (both billed at the output rate). Audio input is priced separately (captured in audio_input_per_mtok_usd); cached audio input is $0.10/MTok vs $0.03/MTok for text/image/video. Batch Mode at flat 50% off; audio batch input is $0.50/MTok. No long-context tier. Context window and max_output_tokens confirmed via ai.google.dev/gemini-api/docs/models/gemini-2.5-flash. Knowledge cutoff January 2025. Explicit context caching storage is captured in cache_storage_per_mtok_per_hour_usd. Free tier (AI Studio) is published as per-minute RPM/TPM only, not per-day; free_tier omitted. Cross-verified prompt/completion price against openrouter.ai/google/gemini-2.5-flash. Re-verified 2026-07-02: prices unchanged."
+      "notes": "Hybrid reasoning model with dynamic thinking on by default; thinking can be disabled via thinkingBudget=0. When thinking is on, response pricing is the sum of output and thinking tokens (both billed at the output rate). Audio input is priced separately (captured in audio_input_per_mtok_usd); cached audio input is $0.10/MTok vs $0.03/MTok for text/image/video. Batch Mode at flat 50% off; audio batch input is $0.50/MTok. No long-context tier. Context window and max_output_tokens confirmed via ai.google.dev/gemini-api/docs/models/gemini-2.5-flash. Knowledge cutoff January 2025. Explicit context caching storage is captured in cache_storage_per_mtok_per_hour_usd. Free tier (AI Studio) is published as per-minute RPM/TPM only, not per-day; free_tier omitted. Cross-verified prompt/completion price against openrouter.ai/google/gemini-2.5-flash. Re-verified 2026-07-02: prices unchanged. Re-verified 2026-07-13: prices unchanged against ai.google.dev/pricing; cross-checked ai.google.dev/gemini-api/docs/models."
     },
     {
       "provider": "Google",
@@ -1054,12 +1216,12 @@
       "reasoning_tokens_billed": true,
       "deployment_options": ["native", "vertex"],
       "confidence": "high",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-18",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://ai.google.dev/gemini-api/docs/pricing",
-      "notes": "Hybrid reasoning model; thinking is OFF by default (unlike 2.5 Flash/Pro) but can be enabled by setting thinkingBudget. When thinking is enabled, response pricing is the sum of output and thinking tokens at the output rate, so reasoning_tokens_billed is true. Audio input is priced separately (captured in audio_input_per_mtok_usd); cached audio input is $0.03/MTok vs $0.01/MTok for text/image/video. Batch Mode at flat 50% off; audio batch input is $0.15/MTok. No long-context tier. Context window and max_output_tokens confirmed via ai.google.dev/gemini-api/docs/models/gemini-2.5-flash-lite. Knowledge cutoff January 2025. Explicit context caching storage is captured in cache_storage_per_mtok_per_hour_usd. Free tier (AI Studio) is published as per-minute RPM/TPM only, not per-day; free_tier omitted. Cross-verified prompt/completion price against openrouter.ai/google/gemini-2.5-flash-lite. Re-verified 2026-07-02: prices unchanged."
+      "notes": "Hybrid reasoning model; thinking is OFF by default (unlike 2.5 Flash/Pro) but can be enabled by setting thinkingBudget. When thinking is enabled, response pricing is the sum of output and thinking tokens at the output rate, so reasoning_tokens_billed is true. Audio input is priced separately (captured in audio_input_per_mtok_usd); cached audio input is $0.03/MTok vs $0.01/MTok for text/image/video. Batch Mode at flat 50% off; audio batch input is $0.15/MTok. No long-context tier. Context window and max_output_tokens confirmed via ai.google.dev/gemini-api/docs/models/gemini-2.5-flash-lite. Knowledge cutoff January 2025. Explicit context caching storage is captured in cache_storage_per_mtok_per_hour_usd. Free tier (AI Studio) is published as per-minute RPM/TPM only, not per-day; free_tier omitted. Cross-verified prompt/completion price against openrouter.ai/google/gemini-2.5-flash-lite. Re-verified 2026-07-02: prices unchanged. Re-verified 2026-07-13: prices unchanged against ai.google.dev/pricing; cross-checked ai.google.dev/gemini-api/docs/models."
     },
     {
       "provider": "Google",
@@ -1092,12 +1254,12 @@
       "deprecated_at": "2026-06-01",
       "replaced_by_model_id": "gemini-3.5-flash",
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-18",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://ai.google.dev/gemini-api/docs/pricing",
-      "notes": "Deprecated; shut down 2026-06-01 per the model card's verbatim notice: \"Gemini 2.0 Flash is deprecated and has been shut down June 1, 2026. Migrate to Gemini 3.5 Flash to avoid service disruption.\" replaced_by_model_id updated 2026-07-02 to gemini-3.5-flash (Google's documented migration target), now that it is in-dataset; previously pointed at gemini-2.5-flash as a placeholder in-file successor. Standard production 2.0 Flash does not support thinking (thinking exists only on Gemini 2.5+ and 3 series per ai.google.dev/gemini-api/docs/thinking); reasoning_tokens_billed=false. Audio input is priced separately (captured in audio_input_per_mtok_usd); cached audio input is $0.175/MTok vs $0.025/MTok for text/image/video. Batch Mode at flat 50% off. No long-context tier. supports_pdf=false since the 2.0 Flash model card lists supported inputs as audio/images/video/text (PDF not enumerated). Confidence medium because Vertex AI's published pricing for the same model name differs ($0.15 input / $0.60 output) from AI Studio's $0.10/$0.40; AI Studio primary value retained per spec, and OpenRouter (openrouter.ai/google/gemini-2.0-flash-001) cross-confirms $0.10/$0.40. Explicit context caching storage is captured in cache_storage_per_mtok_per_hour_usd. Free tier (AI Studio) is published as per-minute RPM/TPM only, not per-day; free_tier omitted. Prices unchanged as of 2026-07-02 re-verification."
+      "notes": "Deprecated; shut down 2026-06-01 per the model card's verbatim notice: \"Gemini 2.0 Flash is deprecated and has been shut down June 1, 2026. Migrate to Gemini 3.5 Flash to avoid service disruption.\" replaced_by_model_id updated 2026-07-02 to gemini-3.5-flash (Google's documented migration target), now that it is in-dataset; previously pointed at gemini-2.5-flash as a placeholder in-file successor. Standard production 2.0 Flash does not support thinking (thinking exists only on Gemini 2.5+ and 3 series per ai.google.dev/gemini-api/docs/thinking); reasoning_tokens_billed=false. Audio input is priced separately (captured in audio_input_per_mtok_usd); cached audio input is $0.175/MTok vs $0.025/MTok for text/image/video. Batch Mode at flat 50% off. No long-context tier. supports_pdf=false since the 2.0 Flash model card lists supported inputs as audio/images/video/text (PDF not enumerated). Confidence medium because Vertex AI's published pricing for the same model name differs ($0.15 input / $0.60 output) from AI Studio's $0.10/$0.40; AI Studio primary value retained per spec, and OpenRouter (openrouter.ai/google/gemini-2.0-flash-001) cross-confirms $0.10/$0.40. Explicit context caching storage is captured in cache_storage_per_mtok_per_hour_usd. Free tier (AI Studio) is published as per-minute RPM/TPM only, not per-day; free_tier omitted. Prices unchanged as of 2026-07-02 re-verification. Re-verified 2026-07-13: deprecation notice and shutdown date still confirmed on ai.google.dev/pricing; no new information."
     },
     {
       "provider": "Google",
@@ -1127,12 +1289,12 @@
       "reasoning_tokens_billed": true,
       "deployment_options": ["native"],
       "confidence": "high",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://ai.google.dev/pricing",
-      "notes": "New GA/stable row added 2026-07-02; this is Google's documented migration target for the retired Gemini 2.0 Flash (see that row's notes). Thinking is on by default (medium level) and configurable (minimal/low/medium/high); when on, response pricing is the sum of output and thinking tokens billed at the output rate, so reasoning_tokens_billed=true. No >200k-token pricing tier is published for this model (unlike Gemini 3.1 Pro Preview). Context window and max_output_tokens confirmed via ai.google.dev/gemini-api/docs/models/gemini-3.5-flash. Knowledge cutoff January 2025, unchanged from the Gemini 2.5 family. Explicit context caching storage is captured in cache_storage_per_mtok_per_hour_usd. Google Search grounding is billed separately (5,000 prompts/month free, shared across Gemini 3 models, then $14/1,000 queries); not captured as a structured field since sibling 2.5-series rows in this file omit the same grounding fee for consistency. Vertex AI availability not confirmed as of this pass; deployment_options limited to native pending verification. Free tier (AI Studio) is published as per-minute RPM/TPM only, not per-day; free_tier omitted."
+      "notes": "New GA/stable row added 2026-07-02; this is Google's documented migration target for the retired Gemini 2.0 Flash (see that row's notes). Thinking is on by default (medium level) and configurable (minimal/low/medium/high); when on, response pricing is the sum of output and thinking tokens billed at the output rate, so reasoning_tokens_billed=true. No >200k-token pricing tier is published for this model (unlike Gemini 3.1 Pro Preview). Context window and max_output_tokens confirmed via ai.google.dev/gemini-api/docs/models/gemini-3.5-flash. Knowledge cutoff January 2025, unchanged from the Gemini 2.5 family. Explicit context caching storage is captured in cache_storage_per_mtok_per_hour_usd. Google Search grounding is billed separately (5,000 prompts/month free, shared across Gemini 3 models, then $14/1,000 queries); not captured as a structured field since sibling 2.5-series rows in this file omit the same grounding fee for consistency. Vertex AI availability not confirmed as of this pass; deployment_options limited to native pending verification. Free tier (AI Studio) is published as per-minute RPM/TPM only, not per-day; free_tier omitted. Re-verified 2026-07-13: prices unchanged against ai.google.dev/pricing; cross-checked ai.google.dev/gemini-api/docs/models."
     },
     {
       "provider": "Google",
@@ -1170,12 +1332,12 @@
       "reasoning_tokens_billed": true,
       "deployment_options": ["native"],
       "confidence": "high",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://ai.google.dev/pricing",
-      "notes": "New preview row added 2026-07-02; not GA. Optimized for software engineering and agentic workflows; a specialized gemini-3.1-pro-preview-customtools variant exists but is not tracked as a separate row. Input/output/cache-read pricing tiers at >200k tokens (>200k rate captured in pricing_tiers[0]); batch pricing also tiers ($2.00/$9.00 input/output above 200k) but batch has no tiered field in this schema, so only the <=200k batch rate is captured. Thinking is on by default at high level (configurable low/medium/high); thinking tokens billed at the output rate, so reasoning_tokens_billed=true. Context window and max_output_tokens confirmed via ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview. Knowledge cutoff January 2025, unchanged from the Gemini 2.5 family. Google Search grounding billed separately (5,000 prompts/month free, shared across Gemini 3 models, then $14/1,000 queries); omitted as a structured field for consistency with sibling rows. Vertex AI availability not confirmed as of this pass; deployment_options limited to native pending verification. Free tier (AI Studio) is published as per-minute RPM/TPM only, not per-day; free_tier omitted."
+      "notes": "New preview row added 2026-07-02; not GA. Optimized for software engineering and agentic workflows; a specialized gemini-3.1-pro-preview-customtools variant exists but is not tracked as a separate row. Input/output/cache-read pricing tiers at >200k tokens (>200k rate captured in pricing_tiers[0]); batch pricing also tiers ($2.00/$9.00 input/output above 200k) but batch has no tiered field in this schema, so only the <=200k batch rate is captured. Thinking is on by default at high level (configurable low/medium/high); thinking tokens billed at the output rate, so reasoning_tokens_billed=true. Context window and max_output_tokens confirmed via ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview. Knowledge cutoff January 2025, unchanged from the Gemini 2.5 family. Google Search grounding billed separately (5,000 prompts/month free, shared across Gemini 3 models, then $14/1,000 queries); omitted as a structured field for consistency with sibling rows. Vertex AI availability not confirmed as of this pass; deployment_options limited to native pending verification. Free tier (AI Studio) is published as per-minute RPM/TPM only, not per-day; free_tier omitted. Re-verified 2026-07-13: prices, tiers, and status (still preview, not GA) unchanged against ai.google.dev/pricing; cross-checked ai.google.dev/gemini-api/docs/models."
     },
     {
       "provider": "Google",
@@ -1206,12 +1368,12 @@
       "reasoning_tokens_billed": true,
       "deployment_options": ["native"],
       "confidence": "high",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://ai.google.dev/pricing",
-      "notes": "New preview row added 2026-07-02; not GA. Audio input is priced separately (captured in audio_input_per_mtok_usd); cached audio input is $0.10/MTok vs $0.05/MTok for text/image/video. No >200k-token pricing tier published. Thinking is on by default at high level (configurable minimal/low/medium/high); thinking tokens billed at the output rate, so reasoning_tokens_billed=true. Context window and max_output_tokens confirmed via ai.google.dev/gemini-api/docs/models/gemini-3-flash-preview. Knowledge cutoff January 2025, unchanged from the Gemini 2.5 family. Google Search grounding billed separately (5,000 prompts/month free, shared across Gemini 3 models, then $14/1,000 queries); omitted as a structured field for consistency with sibling rows. Vertex AI availability not confirmed as of this pass; deployment_options limited to native pending verification. Free tier (AI Studio) is published as per-minute RPM/TPM only, not per-day; free_tier omitted."
+      "notes": "New preview row added 2026-07-02; not GA. Audio input is priced separately (captured in audio_input_per_mtok_usd); cached audio input is $0.10/MTok vs $0.05/MTok for text/image/video. No >200k-token pricing tier published. Thinking is on by default at high level (configurable minimal/low/medium/high); thinking tokens billed at the output rate, so reasoning_tokens_billed=true. Context window and max_output_tokens confirmed via ai.google.dev/gemini-api/docs/models/gemini-3-flash-preview. Knowledge cutoff January 2025, unchanged from the Gemini 2.5 family. Google Search grounding billed separately (5,000 prompts/month free, shared across Gemini 3 models, then $14/1,000 queries); omitted as a structured field for consistency with sibling rows. Vertex AI availability not confirmed as of this pass; deployment_options limited to native pending verification. Free tier (AI Studio) is published as per-minute RPM/TPM only, not per-day; free_tier omitted. Re-verified 2026-07-13: prices and status (still preview, not GA) unchanged against ai.google.dev/pricing; cross-checked ai.google.dev/gemini-api/docs/models."
     },
     {
       "provider": "Google",
@@ -1242,12 +1404,12 @@
       "reasoning_tokens_billed": true,
       "deployment_options": ["native"],
       "confidence": "high",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://ai.google.dev/pricing",
-      "notes": "New GA/stable row added 2026-07-02. Audio input is priced separately (captured in audio_input_per_mtok_usd); cached audio input is $0.05/MTok vs $0.025/MTok for text/image/video. No >200k-token pricing tier published. Thinking is minimal by default (options: minimal or high); thinking tokens billed at the output rate, so reasoning_tokens_billed=true. Context window and max_output_tokens confirmed via ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite. Knowledge cutoff January 2025, unchanged from the Gemini 2.5 family. Google Search grounding billed separately (5,000 prompts/month free, shared across Gemini 3 models, then $14/1,000 queries); omitted as a structured field for consistency with sibling rows. Vertex AI availability not confirmed as of this pass; deployment_options limited to native pending verification. Free tier (AI Studio) is published as per-minute RPM/TPM only, not per-day; free_tier omitted."
+      "notes": "New GA/stable row added 2026-07-02. Audio input is priced separately (captured in audio_input_per_mtok_usd); cached audio input is $0.05/MTok vs $0.025/MTok for text/image/video. No >200k-token pricing tier published. Thinking is minimal by default (options: minimal or high); thinking tokens billed at the output rate, so reasoning_tokens_billed=true. Context window and max_output_tokens confirmed via ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite. Knowledge cutoff January 2025, unchanged from the Gemini 2.5 family. Google Search grounding billed separately (5,000 prompts/month free, shared across Gemini 3 models, then $14/1,000 queries); omitted as a structured field for consistency with sibling rows. Vertex AI availability not confirmed as of this pass; deployment_options limited to native pending verification. Free tier (AI Studio) is published as per-minute RPM/TPM only, not per-day; free_tier omitted. Re-verified 2026-07-13: prices unchanged against ai.google.dev/pricing; cross-checked ai.google.dev/gemini-api/docs/models."
     },
     {
       "provider": "Meta",
@@ -1278,12 +1440,12 @@
       "deployment_options": ["together"],
       "aggregators": ["openrouter"],
       "confidence": "high",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-18",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E-Instruct",
-      "notes": "Multi-host pricing snapshot 2026-05-18: Together $0.27/$0.85 per MTok (meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8) is the row's structured price as the lowest direct-host rate. OpenRouter aggregator routes at $0.15/$0.60 (informational only; structured input/output stay at the lowest direct-host price per the PR4 convention) and is structured as aggregators[\"openrouter\"]. Groq does not list Maverick on its public pricing page; Fireworks does not offer Maverick on serverless (on-demand deployments only). Context window is Meta's published 1M (1048576 tokens); OpenRouter advertises 1.05M but the HuggingFace model card spec is 1M. max_output_tokens not published on the model card; defaulted to 8192. 17B activated / 400B total MoE with 128 experts. deployment_options[] omits hosts whose canonical slug or full pricing could not be confirmed in a single primary source on this date (Fireworks no-serverless, Groq absent)."
+      "notes": "Multi-host pricing re-verified 2026-07-13: Together still $0.27/$0.85 per MTok (meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8), the row's structured price as the lowest direct-host rate; unchanged since 2026-05-18. OpenRouter aggregator now routes at $0.20/$0.80 (was $0.15/$0.60 on 2026-05-18; informational only, structured input/output stay at the lowest direct-host price per the PR4 convention) and is structured as aggregators[\"openrouter\"]. Groq still does not list Maverick on its public pricing page; Fireworks still does not offer Maverick on serverless (on-demand deployments only, no listed per-token price). Context window is Meta's published 1M (1048576 tokens); OpenRouter advertises 1.05M but the HuggingFace model card spec is 1M. max_output_tokens not published on the model card; defaulted to 8192. 17B activated / 400B total MoE with 128 experts. deployment_options[] omits hosts whose canonical slug or full pricing could not be confirmed in a single primary source on this date (Fireworks no-serverless, Groq absent)."
     },
     {
       "provider": "Meta",
@@ -1316,12 +1478,12 @@
       "deployment_options": ["together", "fireworks", "groq"],
       "aggregators": ["openrouter"],
       "confidence": "high",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-18",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct",
-      "notes": "Multi-host pricing snapshot 2026-05-18: Together $0.18/$0.59 per MTok (meta-llama/Llama-4-Scout-17B-16E-Instruct); Fireworks $0.15/$0.60 (accounts/fireworks/models/llama4-scout-instruct-basic); Groq $0.11/$0.34 (meta-llama/llama-4-scout-17b-16e-instruct) is the lowest direct-host rate and is the row's structured price. OpenRouter aggregator routes at $0.08/$0.30 (informational only; structured input/output stay at the lowest direct-host price per the PR4 convention) and is structured as aggregators[\"openrouter\"]. Context window is Meta's published 10M (10485760 tokens); most hosts cap below Meta's spec (e.g. Groq, Fireworks typically expose ~128K-1M at the API). max_output_tokens not published on the model card; defaulted to 8192. 17B activated / 109B total MoE with 16 experts."
+      "notes": "Multi-host pricing re-verified 2026-07-13: Together still $0.18/$0.59 per MTok (meta-llama/Llama-4-Scout-17B-16E-Instruct); Fireworks still $0.15/$0.60 (accounts/fireworks/models/llama4-scout-instruct-basic); Groq still $0.11/$0.34 (meta-llama/llama-4-scout-17b-16e-instruct) remains the lowest direct-host rate and the row's structured price; all unchanged since 2026-05-18. OpenRouter aggregator now routes at $0.10/$0.30 (was $0.08/$0.30 on 2026-05-18; informational only, structured input/output stay at the lowest direct-host price per the PR4 convention) and is structured as aggregators[\"openrouter\"]. Context window is Meta's published 10M (10485760 tokens); most hosts cap below Meta's spec (e.g. Groq, Fireworks typically expose ~128K-1M at the API). max_output_tokens not published on the model card; defaulted to 8192. 17B activated / 109B total MoE with 16 experts."
     },
     {
       "provider": "Meta",
@@ -1354,12 +1516,12 @@
       "deployment_options": ["together", "groq"],
       "aggregators": ["openrouter"],
       "confidence": "high",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-18",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
-      "notes": "Multi-host pricing re-verified 2026-07-02: Together now lists $1.04/$1.04 per MTok for Llama 3.3 70B (up from $0.88/$0.88 on 2026-05-18); Groq $0.59/$0.79 (llama-3.3-70b-versatile) remains the lowest direct-host rate and stays the row's structured price, so last_changed_at is unaffected by Together's move. Fireworks publishes $0.90 input on accounts/fireworks/models/llama-v3p3-70b-instruct but output price was not captured from a single primary source on this date so Fireworks is omitted from deployment_options. OpenRouter aggregator routes at $0.10/$0.32 (informational only; structured input/output stay at the lowest direct-host price per the PR4 convention) and is structured as aggregators[\"openrouter\"]. Context window 128K per Meta's spec (131072 tokens). Text-only; no vision. max_output_tokens not published on the model card; defaulted to 8192. Knowledge cutoff December 2023 per model card."
+      "notes": "Multi-host pricing re-verified 2026-07-13: Together still $1.04/$1.04 per MTok for Llama 3.3 70B (unchanged since the 2026-07-02 jump from $0.88/$0.88); Groq still $0.59/$0.79 (llama-3.3-70b-versatile) remains the lowest direct-host rate and stays the row's structured price. Fireworks still publishes $0.90 input on accounts/fireworks/models/llama-v3p3-70b-instruct and its own model page states serverless is not supported for this model, so Fireworks remains omitted from deployment_options. OpenRouter aggregator still routes at $0.10/$0.32 (informational only; structured input/output stay at the lowest direct-host price per the PR4 convention) and is structured as aggregators[\"openrouter\"]. Context window 128K per Meta's spec (131072 tokens). Text-only; no vision. max_output_tokens not published on the model card; defaulted to 8192. Knowledge cutoff December 2023 per model card."
     },
     {
       "provider": "Mistral",
@@ -1386,12 +1548,12 @@
       "deployment_options": ["native", "bedrock", "vertex", "azure"],
       "deprecated_at": "2026-02-27",
       "replaced_by_model_id": "mistral-medium-3-5",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2024-11-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://mistral.ai/news/mistral-large-2407",
-      "notes": "La Plateforme rates ($2.00 / $6.00 per MTok) are the row's structured price. Multi-host availability: Bedrock (mistral.mistral-large-2407-v1:0 in us-west-2), Vertex AI, Azure AI Foundry, IBM watsonx. Bedrock published the 24.07 build only, not 24.11. Deprecated on La Plateforme 2026-02-27; retirement 2026-05-31 per Mistral's legacy table has now passed (re-verified 2026-07-02 via docs.mistral.ai/getting-started/models/models_overview) so the model_id should be treated as fully retired/non-callable, not merely deprecated. `mistral-large-latest` moved to Mistral Large 3 (mistral-large-2512, added to this dataset) so the alias was removed from this row to avoid a duplicate. Mistral's own deprecation table lists Mistral Medium 3.5 (mistral-medium-3-5) as the recommended alternative, not Large 3; replaced_by_model_id follows the vendor's stated alternative. Text-only; no vision (Pixtral Large was the multimodal sibling, also retired). max_output_tokens not published on the model card; defaulted to 8192. Batch API is a 50% discount where available but per-model availability is not confirmed from a single primary source on this date, so batch fields are unset. Knowledge cutoff not published by Mistral."
+      "notes": "La Plateforme rates ($2.00 / $6.00 per MTok) are the row's structured price. Multi-host availability: Bedrock (mistral.mistral-large-2407-v1:0 in us-west-2), Vertex AI, Azure AI Foundry, IBM watsonx. Bedrock published the 24.07 build only, not 24.11. Deprecated on La Plateforme 2026-02-27; retirement 2026-05-31 per Mistral's legacy table has now passed (re-verified 2026-07-13 via docs.mistral.ai/getting-started/models/models_overview) so the model_id should be treated as fully retired/non-callable, not merely deprecated. `mistral-large-latest` moved to Mistral Large 3 (mistral-large-2512, added to this dataset) so the alias was removed from this row to avoid a duplicate. Mistral's own deprecation table lists Mistral Medium 3.5 (mistral-medium-3-5) as the recommended alternative, not Large 3; replaced_by_model_id follows the vendor's stated alternative. Text-only; no vision (Pixtral Large was the multimodal sibling, also retired). max_output_tokens not published on the model card; defaulted to 8192. Batch API is a 50% discount where available but per-model availability is not confirmed from a single primary source on this date, so batch fields are unset. Knowledge cutoff not published by Mistral."
     },
     {
       "provider": "Mistral",
@@ -1417,7 +1579,7 @@
       "deployment_options": ["native"],
       "deprecated_at": "2026-05-22",
       "replaced_by_model_id": "mistral-medium-3-5",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2025-05-07",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -1449,7 +1611,7 @@
       "deployment_options": ["native"],
       "deprecated_at": "2025-11-06",
       "replaced_by_model_id": "mistral-small-2603",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2025-01-30",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -1479,7 +1641,7 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": false,
       "deployment_options": ["native", "vertex"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2025-07-31",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -1511,12 +1673,12 @@
       "deployment_options": ["native", "bedrock"],
       "deprecated_at": "2026-02-27",
       "replaced_by_model_id": "mistral-medium-3-5",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2024-11-18",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://mistral.ai/news/pixtral-large",
-      "notes": "La Plateforme rates ($2.00 / $6.00 per MTok) are the row's structured price; pricing parity with Mistral Large 2 since Pixtral Large is the multimodal 124B-parameter open-weight model built on top of Mistral Large 2. Vision-capable: handles documents, charts, and natural images alongside text. Context window 128K (131072 tokens). Bedrock publishes the 25.02 refresh (`mistral.pixtral-large-2502-v1:0`, also routed via `us.mistral.pixtral-large-2502-v1:0`), not the 24.11 build. Deprecated on La Plateforme 2026-02-27; retirement 2026-05-31 per Mistral's legacy table has now passed (re-verified 2026-07-02) so the model_id should be treated as fully retired/non-callable. Mistral's stated alternative is Mistral Medium 3.5 (mistral-medium-3-5, added to this dataset this pass); Pixtral as a standalone product line has been discontinued, its vision capability absorbed into Large 3 / Medium 3.5. `pixtral-large-latest` alias is likely non-functional post-retirement but is left on this row since nothing else claims it. max_output_tokens not published on the model card; defaulted to 8192. Vertex/Azure availability not confirmed for Pixtral Large on this date. Batch API discount per-model availability not confirmed on this date, so batch fields are unset. Knowledge cutoff not published by Mistral."
+      "notes": "La Plateforme rates ($2.00 / $6.00 per MTok) are the row's structured price; pricing parity with Mistral Large 2 since Pixtral Large is the multimodal 124B-parameter open-weight model built on top of Mistral Large 2. Vision-capable: handles documents, charts, and natural images alongside text. Context window 128K (131072 tokens). Bedrock publishes the 25.02 refresh (`mistral.pixtral-large-2502-v1:0`, also routed via `us.mistral.pixtral-large-2502-v1:0`), not the 24.11 build. Deprecated on La Plateforme 2026-02-27; retirement 2026-05-31 per Mistral's legacy table has now passed (re-verified 2026-07-13) so the model_id should be treated as fully retired/non-callable. Mistral's stated alternative is Mistral Medium 3.5 (mistral-medium-3-5, added to this dataset this pass); Pixtral as a standalone product line has been discontinued, its vision capability absorbed into Large 3 / Medium 3.5. `pixtral-large-latest` alias is likely non-functional post-retirement but is left on this row since nothing else claims it. max_output_tokens not published on the model card; defaulted to 8192. Vertex/Azure availability not confirmed for Pixtral Large on this date. Batch API discount per-model availability not confirmed on this date, so batch fields are unset. Knowledge cutoff not published by Mistral."
     },
     {
       "provider": "Mistral",
@@ -1541,7 +1703,7 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": false,
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2025-12-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -1571,7 +1733,7 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": false,
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-04-28",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -1601,7 +1763,7 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": false,
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-03-16",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -1631,7 +1793,7 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": false,
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2025-12-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -1661,7 +1823,7 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": false,
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2025-12-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -1691,7 +1853,7 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": false,
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2025-12-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -1722,12 +1884,12 @@
       "reasoning_tokens_billed": false,
       "deployment_options": ["native", "azure"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2025-03-01",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://docs.cohere.com/docs/command-a",
-      "notes": "Cohere's flagship 111B-parameter model: 256K context, text-only, optimized for tool use, RAG, agents, and 23-language multilingual workloads. Price ($2.50 / $10.00 per MTok) per artificialanalysis.ai citing Cohere's API; Command A is still not listed on cohere.com/pricing as of 2026-07-02 (page only publishes a \"Legacy Model Pricing\" FAQ table for Command/Command-light/Command R/Command R+ 04-2024/Command R+ 08-2024, plus Model Vault dedicated-instance rates; newer generative models including Command A route to \"Get in touch for custom enterprise pricing\"), so confidence remains medium. docs.cohere.com/docs/models confirms `command-a-03-2025` is still Live (256K context, 8K max output, text-only) and Cohere's deprecations page (docs.cohere.com/docs/deprecations) does not list it, so status is unchanged. Cohere docs still don't surface AWS Bedrock availability for this model (so `bedrock` remains omitted from deployment_options); Azure AI Foundry availability is published but uses per-deployment IDs, so no Azure alias is encoded. Oracle OCI exposes it as `cohere.command-a-03-2025` (kept as alias). Cache and batch pricing not published by Cohere. Knowledge cutoff not published on the Cohere model card."
+      "notes": "Cohere's flagship 111B-parameter model: 256K context, text-only, optimized for tool use, RAG, agents, and 23-language multilingual workloads. Price ($2.50 / $10.00 per MTok) per artificialanalysis.ai citing Cohere's API; Command A is still not listed on cohere.com/pricing as of 2026-07-13 (page only publishes a \"Legacy Model Pricing\" FAQ table for Command/Command-light/Command R/Command R+ 04-2024/Command R+ 08-2024, plus Model Vault dedicated-instance rates; newer generative models including Command A route to \"Get in touch for custom enterprise pricing\"), so confidence remains medium. docs.cohere.com/docs/models confirms `command-a-03-2025` is still Live (256K context, 8K max output, text-only) and Cohere's deprecations page (docs.cohere.com/docs/deprecations, re-checked 2026-07-13) does not list it, so status and price are unchanged. Cohere's model catalog has grown since last pass (command-a-reasoning-08-2025, command-a-vision-07-2025, command-a-translate-08-2025, command-r-08-2024, and a command-a-plus-05-2026 sighted on docs.cohere.com/docs/models) but none of these publish per-token input/output pricing on cohere.com/pricing or a corroborating secondary source (artificialanalysis.ai only has a blended/zero rate for Command A / Command A+, not a clean input/output split), so they are deferred rather than added this pass. Cohere docs still don't surface AWS Bedrock availability for this model (so `bedrock` remains omitted from deployment_options); Azure AI Foundry availability is published but uses per-deployment IDs, so no Azure alias is encoded. Oracle OCI exposes it as `cohere.command-a-03-2025` (kept as alias). Cache and batch pricing not published by Cohere. Knowledge cutoff not published on the Cohere model card."
     },
     {
       "provider": "Cohere",
@@ -1753,12 +1915,12 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": false,
       "deployment_options": ["native", "bedrock", "azure"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2024-08-30",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://cohere.com/pricing",
-      "notes": "Cohere Platform rates ($2.50 / $10.00 per MTok) are the row's structured price, listed on cohere.com/pricing as \"Command R+ 08-2024\" (page now files it under a \"Legacy Model Pricing\" FAQ table alongside Command/Command-light/Command R/Command R+ 04-2024, meaning it's held for existing customers rather than a headline SKU, but the price is unchanged and it remains orderable). 128K context, text-only, optimized for complex RAG and multi-step tool use. Cohere's deprecations page (docs.cohere.com/docs/deprecations, re-checked 2026-07-02) still sunsets only the predecessor `command-r-plus-04-2024` on 2025-09-15 and names this 08-2024 build as the recommended replacement, so it is active on Cohere Platform; docs.cohere.com/docs/models also lists `command-r-plus-08-2024` as Live. Bedrock SKU `cohere.command-r-plus-v1:0` launched Aug 2024 with a Mar 2024 knowledge cutoff (per Bedrock model card), matching this row; Bedrock marks the model \"Legacy\" with an EOL of 2026-08-19, which is a Bedrock-side lifecycle marker, not a Cohere deprecation. Azure AI Foundry availability published by Cohere; per-deployment IDs there, so no Azure alias is encoded. Cache and batch pricing not published by Cohere."
+      "notes": "Cohere Platform rates ($2.50 / $10.00 per MTok) are the row's structured price, listed on cohere.com/pricing as \"Command R+ 08-2024\" (page now files it under a \"Legacy Model Pricing\" FAQ table alongside Command/Command-light/Command R/Command R+ 04-2024, meaning it's held for existing customers rather than a headline SKU, but the price is unchanged and it remains orderable). 128K context, text-only, optimized for complex RAG and multi-step tool use. Cohere's deprecations page (docs.cohere.com/docs/deprecations, re-checked 2026-07-13) still sunsets only the predecessor `command-r-plus-04-2024` on 2025-09-15 and names this 08-2024 build as the recommended replacement, so it is active on Cohere Platform; docs.cohere.com/docs/models also lists `command-r-plus-08-2024` as Live. Bedrock SKU `cohere.command-r-plus-v1:0` launched Aug 2024 with a Mar 2024 knowledge cutoff (per Bedrock model card), matching this row; Bedrock marks the model \"Legacy\" with an EOL of 2026-08-19, which is a Bedrock-side lifecycle marker, not a Cohere deprecation. Azure AI Foundry availability published by Cohere; per-deployment IDs there, so no Azure alias is encoded. Cache and batch pricing not published by Cohere. Cohere's docs/models catalog also now lists a plain `command-r-08-2024` (non-plus) SKU, but it has no published per-token pricing on cohere.com/pricing or a corroborating secondary source, so it is deferred rather than added this pass."
     },
     {
       "provider": "Cohere",
@@ -1783,12 +1945,12 @@
       "reasoning_tokens_billed": false,
       "deployment_options": ["native"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2024-10-24",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://cohere.com/pricing",
-      "notes": "New row this pass. 32B-parameter multilingual research/generative model (23 languages), 128K context, text-only. Cohere's \"Legacy Model Pricing\" FAQ table on cohere.com/pricing lists a single bundled rate for \"Aya Expanse (8B and 32B): $0.50 / $1.50 per MTok\" (not broken out per size), so confidence is medium. docs.cohere.com/docs/aya-expanse confirms `c4ai-aya-expanse-32b`, 128K context, 4K max output, text-only, available via the Chat API and as open weights on Hugging Face (Hugging Face not encoded as a deployment_option since it isn't a hosted API SKU). docs.cohere.com/docs/models lists it as Live. The 8B sibling `c4ai-aya-expanse-8b` is scheduled for retirement 2026-04-04 per docs.cohere.com/docs/deprecations (replacement: `command-r7b-12-2024`, `command-a-03-2025`, or `command-a-reasoning-08-2025`) and is therefore intentionally not added as a row. Tool use, structured output, and knowledge cutoff not published by Cohere for this model; booleans defaulted to false pending confirmation. Cache and batch pricing not published."
+      "notes": "32B-parameter multilingual research/generative model (23 languages), 128K context, text-only. Cohere's \"Legacy Model Pricing\" FAQ table on cohere.com/pricing still lists the same single bundled rate for \"Aya Expanse (8B and 32B): $0.50 / $1.50 per MTok\" (not broken out per size) as of 2026-07-13, so confidence remains medium. docs.cohere.com/docs/aya-expanse confirms `c4ai-aya-expanse-32b`, 128K context, 4K max output, text-only, available via the Chat API and as open weights on Hugging Face (Hugging Face not encoded as a deployment_option since it isn't a hosted API SKU). docs.cohere.com/docs/models lists it as Live and unchanged. The 8B sibling `c4ai-aya-expanse-8b` reached its scheduled retirement/shutdown date of 2026-04-04 per docs.cohere.com/docs/deprecations (replacement: `command-r7b-12-2024`, `command-a-03-2025`, or `command-a-reasoning-08-2025`) and remains intentionally excluded as a row (never tracked, so no deprecated_at entry needed here). Tool use, structured output, and knowledge cutoff not published by Cohere for this model; booleans defaulted to false pending confirmation. Cache and batch pricing not published."
     },
     {
       "provider": "xAI",
@@ -1824,12 +1986,12 @@
       "deployment_options": ["native"],
       "deprecated_at": "2026-05-15",
       "replaced_by_model_id": "grok-4.3",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-15",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://docs.x.ai/developers/migration/may-15-retirement",
-      "notes": "xAI native rates ($3.00 / $15.00 per MTok, $0.75 cached input) are the row's structured price; prompts above 128K total tokens are billed at the higher pricing_tiers rate ($6.00 / $30.00) per xAI's documented long-context tiering. Grok 4 (snapshot `grok-4-0709`, released 2025-07-09) was xAI's flagship reasoning model: reasoning is always on (thinking tokens billed at the output rate, hence reasoning_tokens_billed: true), parallel tool calling and structured outputs supported, accepts text and image inputs. max_output_tokens of 256000 reflects xAI's documented \"up to 256K tokens of output\" within the shared 256K prompt+response context. Retired from the xAI API on 2026-05-15 12:00 PM PT alongside seven other legacy slugs; requests to `grok-4-0709` and `grok-4` continue to resolve but are now redirected to `grok-4.3` with `low` reasoning effort and billed at grok-4.3 rates. Successor is `grok-4.3`, captured in this dataset and referenced via `replaced_by_model_id`. xAI's API is native-only (not on Bedrock/Vertex/Azure). Batch API not published for this model. Re-verified 2026-07-02: `grok-4-0709` absent from both docs.x.ai/docs/models and docs.x.ai/docs/pricing, confirming retirement status is unchanged; redirect target `grok-4.3` still present in this dataset."
+      "notes": "xAI native rates ($3.00 / $15.00 per MTok, $0.75 cached input) are the row's structured price; prompts above 128K total tokens are billed at the higher pricing_tiers rate ($6.00 / $30.00) per xAI's documented long-context tiering. Grok 4 (snapshot `grok-4-0709`, released 2025-07-09) was xAI's flagship reasoning model: reasoning is always on (thinking tokens billed at the output rate, hence reasoning_tokens_billed: true), parallel tool calling and structured outputs supported, accepts text and image inputs. max_output_tokens of 256000 reflects xAI's documented \"up to 256K tokens of output\" within the shared 256K prompt+response context. Retired from the xAI API on 2026-05-15 12:00 PM PT alongside seven other legacy slugs; requests to `grok-4-0709` and `grok-4` continue to resolve but are now redirected to `grok-4.3` with `low` reasoning effort and billed at grok-4.3 rates. Successor is `grok-4.3`, captured in this dataset and referenced via `replaced_by_model_id`. xAI's API is native-only (not on Bedrock/Vertex/Azure). Batch API not published for this model. Re-verified 2026-07-02 and 2026-07-13: `grok-4-0709` absent from both docs.x.ai/docs/models and docs.x.ai/docs/pricing, and still listed on docs.x.ai/developers/migration/may-15-retirement with redirect target `grok-4.3`, confirming retirement status is unchanged."
     },
     {
       "provider": "xAI",
@@ -1857,12 +2019,12 @@
       "deployment_options": ["native"],
       "deprecated_at": "2026-05-15",
       "replaced_by_model_id": "grok-4.3",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-15",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://docs.x.ai/developers/migration/may-15-retirement",
-      "notes": "xAI native rates ($3.00 / $15.00 per MTok, $0.75 cached input) are the row's structured price (xAI's pricing page and mem0/pricepertoken aggregator both report $3/$15; artificialanalysis.ai reports a higher $4/$20 — choosing xAI-aligned figures). Grok 3 (released 2025-02-19) was xAI's flagship non-reasoning chat model; text-only inputs, function calling and structured outputs supported, 131,072-token combined prompt+response context window. Not a reasoning model (direct responses, no extended chain-of-thought; the reasoning sibling was `grok-3-mini`, not in this dataset). max_output_tokens defaulted to the documented context cap; xAI does not publish a separate max-output limit beyond the shared 131,072-token window. Retired from the xAI API on 2026-05-15 12:00 PM PT; requests to `grok-3` continue to resolve but are now redirected to `grok-4.3` with `none` reasoning effort and billed at grok-4.3 rates. Successor is `grok-4.3`, captured in this dataset and referenced via `replaced_by_model_id`. xAI's API is native-only. Batch API not published for this model. Re-verified 2026-07-02: `grok-3` absent from both docs.x.ai/docs/models and docs.x.ai/docs/pricing, confirming retirement status is unchanged."
+      "notes": "xAI native rates ($3.00 / $15.00 per MTok, $0.75 cached input) are the row's structured price (xAI's pricing page and mem0/pricepertoken aggregator both report $3/$15; artificialanalysis.ai reports a higher $4/$20 — choosing xAI-aligned figures). Grok 3 (released 2025-02-19) was xAI's flagship non-reasoning chat model; text-only inputs, function calling and structured outputs supported, 131,072-token combined prompt+response context window. Not a reasoning model (direct responses, no extended chain-of-thought; the reasoning sibling was `grok-3-mini`, not in this dataset). max_output_tokens defaulted to the documented context cap; xAI does not publish a separate max-output limit beyond the shared 131,072-token window. Retired from the xAI API on 2026-05-15 12:00 PM PT; requests to `grok-3` continue to resolve but are now redirected to `grok-4.3` with `none` reasoning effort and billed at grok-4.3 rates. Successor is `grok-4.3`, captured in this dataset and referenced via `replaced_by_model_id`. xAI's API is native-only. Batch API not published for this model. Re-verified 2026-07-02 and 2026-07-13: `grok-3` absent from both docs.x.ai/docs/models and docs.x.ai/docs/pricing, and still listed on docs.x.ai/developers/migration/may-15-retirement with redirect target `grok-4.3`, confirming retirement status is unchanged."
     },
     {
       "provider": "xAI",
@@ -1888,13 +2050,13 @@
       "reasoning_tokens_billed": true,
       "deployment_options": ["native"],
       "deprecated_at": "2026-05-15",
-      "replaced_by_model_id": "grok-4.3",
-      "last_verified": "2026-07-02",
+      "replaced_by_model_id": "grok-build-0.1",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-15",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://docs.x.ai/developers/migration/may-15-retirement",
-      "notes": "xAI native rates ($0.20 / $1.50 per MTok, $0.02 cached input) are the row's structured price. Grok Code Fast 1 (released 2025-08-26) was xAI's speedy, economical coding-specialized reasoning model: 314B-parameter MoE architecture, 256K combined prompt+response context, agentic coding focus, visible reasoning traces (`reasoning_content` field in streaming responses), function calling and structured outputs supported, text-only. Reasoning is enabled by default so reasoning tokens are billed at the output rate. max_output_tokens defaulted to the documented 256K context cap; xAI does not publish a separate max-output limit beyond the shared window. Retired from the xAI API on 2026-05-15 12:00 PM PT; requests to `grok-code-fast-1` continue to resolve but are now redirected to `grok-4.3` with `low` reasoning effort and billed at grok-4.3 rates. Successor is `grok-4.3`, captured in this dataset and referenced via `replaced_by_model_id`. xAI's API is native-only. Batch API not published for this model. Knowledge cutoff not published by xAI. Re-verified 2026-07-02: `grok-code-fast-1` absent from both docs.x.ai/docs/models and docs.x.ai/docs/pricing, confirming retirement status is unchanged."
+      "notes": "xAI native rates ($0.20 / $1.50 per MTok, $0.02 cached input) are the row's structured price. Grok Code Fast 1 (released 2025-08-26) was xAI's speedy, economical coding-specialized reasoning model: 314B-parameter MoE architecture, 256K combined prompt+response context, agentic coding focus, visible reasoning traces (`reasoning_content` field in streaming responses), function calling and structured outputs supported, text-only. Reasoning is enabled by default so reasoning tokens are billed at the output rate. max_output_tokens defaulted to the documented 256K context cap; xAI does not publish a separate max-output limit beyond the shared window. Retired from the xAI API on 2026-05-15 12:00 PM PT; requests to `grok-code-fast-1` continue to resolve. CORRECTION on 2026-07-13 re-verification: docs.x.ai/developers/migration/may-15-retirement now states the redirect target is `grok-build-0.1` (\"After May 15, requests to `grok-code-fast-1` are routed to `grok-build-0.1`\"), not `grok-4.3` as previously recorded on 2026-07-02 — `replaced_by_model_id` updated accordingly; this is a referential correction, not a price change to this row, so `last_changed_at` is not bumped. `grok-build-0.1` is now captured in this dataset. xAI's API is native-only. Batch API not published for this model. Knowledge cutoff not published by xAI. `grok-code-fast-1` remains absent from both docs.x.ai/docs/models and docs.x.ai/docs/pricing, confirming retirement status is unchanged."
     },
     {
       "provider": "xAI",
@@ -1918,12 +2080,73 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": true,
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-15",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://docs.x.ai/docs/models",
-      "notes": "xAI native rates ($1.25 / $2.50 per MTok) are the row's structured price, listed on docs.x.ai/docs/models and docs.x.ai/docs/pricing. Grok 4.3 is xAI's current flagship: positioned as \"the most intelligent and fastest model\" recommended for chat, coding, and general use across the Grok API. 1M-token combined prompt+response context window (a 4x expansion over the 256K window on Grok 4 / Grok Code Fast 1). Successor to `grok-4-0709`, `grok-3`, and `grok-code-fast-1`, all of which xAI retired on 2026-05-15 12:00 PM PT and now redirect to this SKU at varying default `reasoning_effort` levels (`low` for grok-4-0709 / grok-code-fast-1, `none` for grok-3). Thinking mode is exposed via the `reasoning_effort` parameter (`none` / `low` / `medium` / `high`); when reasoning is on, thinking tokens are billed at the output rate, hence reasoning_tokens_billed: true. Accepts text and image inputs, text output; parallel tool calling and structured outputs supported. max_output_tokens reflects the documented 1M-token shared window — xAI does not publish a separate max-output limit. Cached input price, knowledge cutoff, and release date are not published by xAI on the models or pricing pages as of last_verified; omitted rather than guessed. xAI's API is native-only (not on Bedrock / Vertex / Azure). Batch API not published for this model. Re-verified 2026-07-02: still listed as flagship, price and 1M context window unchanged. Both docs.x.ai/docs/models and docs.x.ai/docs/pricing now also list four additional model_ids (`grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning`, `grok-4.20-multi-agent-0309` at $1.25/$2.50 per MTok 1M context; `grok-build-0.1` at $1.00/$2.00 per MTok 256K context) not yet added as rows — see provider-level notes on this refresh pass for why they were deferred rather than added."
+      "notes": "xAI native rates ($1.25 / $2.50 per MTok) are the row's structured price, listed on docs.x.ai/docs/models and docs.x.ai/docs/pricing, unchanged as of 2026-07-13. 1M-token combined prompt+response context window (a 4x expansion over the 256K window on Grok 4 / Grok Code Fast 1). Successor to `grok-4-0709`, `grok-3`, and `grok-code-fast-1` (the latter's redirect target was corrected to `grok-build-0.1` on 2026-07-13; see that row), which xAI retired on 2026-05-15 12:00 PM PT. Thinking mode is exposed via the `reasoning_effort` parameter (`none` / `low` / `medium` / `high`); when reasoning is on, thinking tokens are billed at the output rate, hence reasoning_tokens_billed: true. Accepts text and image inputs, text output; parallel tool calling and structured outputs supported. max_output_tokens reflects the documented 1M-token shared window — xAI does not publish a separate max-output limit. Cached input price, knowledge cutoff, and release date are not published by xAI on the models or pricing pages as of last_verified; omitted rather than guessed. xAI's API is native-only (not on Bedrock / Vertex / Azure). Batch API not published for this model. STATUS UPDATE 2026-07-13: xAI launched `grok-4.5` on 2026-07-08 as its new top-line recommended model (\"Your choice depends on your use case... For everything else, including code, use Grok 4.5\" per docs.x.ai/docs/models) — captured as a new row in this dataset. `grok-4.3` remains listed on both docs.x.ai/docs/models and docs.x.ai/docs/pricing with no deprecation banner, so it is kept active here with unchanged price and 1M context window, but is no longer singled out in xAI's own guidance as the flagship pick. docs.x.ai/docs/pricing also lists `grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning`, and `grok-4.20-multi-agent-0309` (beta variants, $1.25/$2.50 per MTok, xAI-stated 1M context) — deferred again this pass: a third-party technical writeup (buildfastwithai.com, published 2026-03-14) reports conflicting specs for the same three model_ids ($2.00/$6.00 per MTok, 2M context matching Grok 4.1, multi-agent variant API still 'coming soon'), and the two-source rule requires corroboration, not contradiction. Re-verify next pass once sources converge."
+    },
+    {
+      "provider": "xAI",
+      "provider_url": "https://x.ai",
+      "model_id": "grok-4.5",
+      "display_name": "Grok 4.5",
+      "model_family": "Grok 4",
+      "knowledge_cutoff": "2026-02-01",
+      "context_window": 500000,
+      "max_output_tokens": 500000,
+      "input_per_mtok_usd": "2.00",
+      "output_per_mtok_usd": "6.00",
+      "cache_read_per_mtok_usd": "0.50",
+      "modalities": {
+        "input": ["text", "image"],
+        "output": ["text"]
+      },
+      "supports_tool_use": true,
+      "structured_output": true,
+      "supports_vision": true,
+      "supports_audio_in": false,
+      "supports_audio_out": false,
+      "supports_pdf": true,
+      "reasoning_tokens_billed": true,
+      "deployment_options": ["native"],
+      "last_verified": "2026-07-13",
+      "last_changed_at": "2026-07-13",
+      "verification_method": "manual-confirmed",
+      "verified_by": "r13i",
+      "source_url": "https://docs.x.ai/docs/models",
+      "notes": "New row, added on the 2026-07-13 refresh. Grok 4.5 launched 2026-07-08 as xAI's new top-line recommended model (\"the most intelligent and fastest model we've built\"; docs.x.ai/docs/models: \"For everything else, including code, use Grok 4.5\"), positioned for coding, agentic, and knowledge-work use. xAI native rates ($2.00 / $6.00 per MTok) confirmed on both docs.x.ai/docs/models and docs.x.ai/docs/pricing, cross-checked against OpenRouter's public models API (openrouter.ai/api/v1/models, x-ai/grok-4.5: prompt $0.000002/token = $2.00/MTok, completion $0.000006/token = $6.00/MTok, input_cache_read $0.0000005/token = $0.50/MTok cache read) — satisfies the two-source rule. Context window 500,000 tokens (smaller than grok-4.3's 1M) per docs.x.ai and OpenRouter agreement; knowledge cutoff \"February 1, 2026\" per docs.x.ai/docs/models verbatim. max_output_tokens defaulted to the 500K context cap; xAI does not publish a separate max-output limit (OpenRouter reports max_completion_tokens: null, consistent with no separate cap). Input modalities text + image (OpenRouter architecture also lists a `file` input modality, taken here as supports_pdf: true; images up to 20MiB, jpg/jpeg/png); output text-only. OpenRouter's supported_parameters list for this model includes `tools`/`tool_choice` (supports_tool_use: true), `response_format`/`structured_outputs` (structured_output: true), and `reasoning`/`reasoning_effort`/`include_reasoning` (reasoning_tokens_billed: true, consistent with the `reasoning_effort` parameter pattern on grok-4.3). Audio input/output not supported. Batch pricing and deployment options beyond native not published by xAI as of last_verified; xAI's API remains native-only (not on Bedrock/Vertex/Azure). Does not affect the existing `grok-4.3` row, which remains active at its own unchanged price — see that row's notes."
+    },
+    {
+      "provider": "xAI",
+      "provider_url": "https://x.ai",
+      "model_id": "grok-build-0.1",
+      "display_name": "Grok Build 0.1",
+      "model_family": "Grok Code",
+      "context_window": 256000,
+      "max_output_tokens": 256000,
+      "input_per_mtok_usd": "1.00",
+      "output_per_mtok_usd": "2.00",
+      "cache_read_per_mtok_usd": "0.20",
+      "modalities": {
+        "input": ["text", "image"],
+        "output": ["text"]
+      },
+      "supports_tool_use": true,
+      "structured_output": true,
+      "supports_vision": true,
+      "supports_audio_in": false,
+      "supports_audio_out": false,
+      "supports_pdf": true,
+      "reasoning_tokens_billed": true,
+      "deployment_options": ["native"],
+      "last_verified": "2026-07-13",
+      "last_changed_at": "2026-07-13",
+      "verification_method": "manual-confirmed",
+      "verified_by": "r13i",
+      "source_url": "https://docs.x.ai/docs/models",
+      "notes": "New row, added on the 2026-07-13 refresh. Grok Build 0.1 (public beta, first opened via API 2026-05-20) is xAI's fast, economical agentic-coding model that powers the Grok Build CLI; it is the documented redirect target for the retired `grok-code-fast-1` slug (docs.x.ai/developers/migration/may-15-retirement: \"After May 15, requests to `grok-code-fast-1` are routed to `grok-build-0.1`\") — see that row's `replaced_by_model_id`. xAI native rates ($1.00 / $2.00 per MTok) confirmed on docs.x.ai/docs/models and docs.x.ai/docs/pricing, cross-checked against OpenRouter's public models API (openrouter.ai/api/v1/models, x-ai/grok-build-0.1: prompt $0.000001/token = $1.00/MTok, completion $0.000002/token = $2.00/MTok, input_cache_read $0.0000002/token = $0.20/MTok cache read) — satisfies the two-source rule. Context window 256,000 tokens per both sources; max_output_tokens defaulted to the 256K context cap (OpenRouter reports max_completion_tokens: null, no separate limit published). Input modalities text + image (OpenRouter architecture lists a `file` input modality too, taken here as supports_pdf: true); output text-only. OpenRouter's supported_parameters for this model include `tools`/`tool_choice` (supports_tool_use: true), `response_format`/`structured_outputs` (structured_output: true), and `reasoning`/`include_reasoning` (reasoning_tokens_billed: true — consistent with predecessor `grok-code-fast-1`'s visible reasoning traces). Audio input/output not supported. Knowledge cutoff and release date beyond the 2026-05-20 API-opening not published by xAI; omitted rather than guessed. Batch pricing not published. xAI's API is native-only (not on Bedrock/Vertex/Azure); limited regional availability noted by third-party docs (us-east-1, us-west-2) but not encoded as a separate deployment_option since it isn't a distinct hosted-API SKU distinction xAI itself publishes."
     },
     {
       "provider": "Alibaba",
@@ -1960,12 +2183,12 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": true,
       "deployment_options": ["dashscope"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
-      "notes": "Alibaba DashScope (International) tiered pricing by input-token bucket: 0-32K = $1.20 input / $6.00 output per MTok (base row rate); 32K-128K = $2.40 / $12.00; 128K-252K = $3.00 / $15.00 (captured in pricing_tiers) — unchanged at last_verified. Context window 262,144 tokens (DashScope publishes 252K as the top-tier pricing ceiling; Qwen team and OpenRouter publish the full 262,144 model context). Max output 32,768 tokens. `qwen3-max` is a rolling alias: as of 2026-07-02 it resolves to `qwen3-max-2026-01-23` (previously `qwen3-max-2025-09-23`, still separately listed); pricing identical across both dated snapshots, so this is a metadata-only pointer change. Knowledge cutoff 2025-06-30 (unverified against the new snapshot; vendor page does not publish per-snapshot cutoffs, carried over from prior verification). Hybrid thinking model: thinking mode disabled by default but available via `/think` (and disabled via `/no_think`); when enabled, thinking tokens are billed at the output rate, hence reasoning_tokens_billed: true. Text-only inputs and outputs (the Qwen3-VL family is a separate set of model_ids). Tool calling and structured outputs supported via the DashScope and OpenAI-compatible endpoints. Explicit context cache discounts cached input tokens to 10% of the standard rate, but DashScope does not publish a single cache_read figure across the tiered input rates, so cache_read_per_mtok_usd is omitted rather than guessed. Deployment via DashScope (Model Studio) only at last_verified; not on Bedrock, Vertex, Together, Fireworks, or Groq as a first-party offering. CHANGE 2026-07-02: batch_input_per_mtok_usd/batch_output_per_mtok_usd removed — the vendor pricing page's International/Singapore \"Qwen-Max\" table for qwen3-max no longer carries a batch-inference-discount badge (verified against raw page HTML: only the \"context caching discount\" annotation remains). The 50% batch discount badge is now only shown on the Chinese-mainland deployment row for this model family, which this dataset does not price (DashScope International is canonical). Prior batch figures ($0.60/$3.00) were the International 50%-off rate and are no longer offered there as of this verification."
+      "notes": "Alibaba DashScope (International) tiered pricing by input-token bucket: 0-32K = $1.20 input / $6.00 output per MTok (base row rate); 32K-128K = $2.40 / $12.00; 128K-252K = $3.00 / $15.00 (captured in pricing_tiers) — unchanged at last_verified. Context window 262,144 tokens (DashScope publishes 252K as the top-tier pricing ceiling; Qwen team and OpenRouter publish the full 262,144 model context). Max output 32,768 tokens. `qwen3-max` is a rolling alias: as of 2026-07-02 it resolves to `qwen3-max-2026-01-23` (previously `qwen3-max-2025-09-23`, still separately listed); pricing identical across both dated snapshots, so this is a metadata-only pointer change. Knowledge cutoff 2025-06-30 (unverified against the new snapshot; vendor page does not publish per-snapshot cutoffs, carried over from prior verification). Hybrid thinking model: thinking mode disabled by default but available via `/think` (and disabled via `/no_think`); when enabled, thinking tokens are billed at the output rate, hence reasoning_tokens_billed: true. Text-only inputs and outputs (the Qwen3-VL family is a separate set of model_ids). Tool calling and structured outputs supported via the DashScope and OpenAI-compatible endpoints. Explicit context cache discounts cached input tokens to 10% of the standard rate, but DashScope does not publish a single cache_read figure across the tiered input rates, so cache_read_per_mtok_usd is omitted rather than guessed. Deployment via DashScope (Model Studio) only at last_verified; not on Bedrock, Vertex, Together, Fireworks, or Groq as a first-party offering. CHANGE 2026-07-02: batch_input_per_mtok_usd/batch_output_per_mtok_usd removed — the vendor pricing page's International/Singapore \"Qwen-Max\" table for qwen3-max no longer carries a batch-inference-discount badge (verified against raw page HTML: only the \"context caching discount\" annotation remains). The 50% batch discount badge is now only shown on the Chinese-mainland deployment row for this model family, which this dataset does not price (DashScope International is canonical). Prior batch figures ($0.60/$3.00) were the International 50%-off rate and are no longer offered there as of this verification. Re-verified 2026-07-13: prices, tiers, and batch/cache posture unchanged against alibabacloud.com/help/en/model-studio/billing; still no batch badge on the International row (China-mainland row still carries it), model_id still active (not deprecated), no newer dated snapshot beyond qwen3-max-2026-01-23."
     },
     {
       "provider": "Alibaba",
@@ -2006,12 +2229,12 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": false,
       "deployment_options": ["dashscope"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
-      "notes": "Alibaba DashScope (International) tiered pricing by input-token bucket: 0-32K = $1.00 / $5.00 per MTok (base row rate); 32K-128K = $1.80 / $9.00; 128K-256K = $3.00 / $15.00; 256K-1M = $6.00 / $60.00 (captured in pricing_tiers) — unchanged at last_verified. 1,000,000-token context window with 65,536 max output tokens. `qwen3-coder-plus` still resolves to `qwen3-coder-plus-2025-09-23` (no newer dated snapshot published; an older `qwen3-coder-plus-2025-07-22` snapshot remains listed separately at identical pricing). Built on the Qwen3-Coder 480B-A35B MoE base; positioned for agentic coding (robust tool calling and environment interaction). Not a thinking/reasoning SKU (no chain-of-thought billing semantics), so reasoning_tokens_billed is false. Text-only modalities. Explicit context cache discounts cached input to 10% of the standard rate; implicit cache to 20%; DashScope does not publish a single cache_read figure across tiered input rates, so cache_read_per_mtok_usd is omitted rather than guessed. Knowledge cutoff not published. Deployment via DashScope (Model Studio) only at last_verified. CHANGE 2026-07-02: batch_input_per_mtok_usd/batch_output_per_mtok_usd removed — the vendor's \"Qwen-Coder\" pricing section intro no longer mentions batch-call pricing at all (unlike the \"Qwen-Max\" section, which still documents a batch discount), and neither the International nor Chinese-mainland qwen3-coder-plus table rows carry a batch badge (verified against raw page HTML across all 4 occurrences of this model_id on the page). Batch inference discount is no longer offered for this model as of this verification; prior figures ($0.50/$2.50) are stale."
+      "notes": "Alibaba DashScope (International) tiered pricing by input-token bucket: 0-32K = $1.00 / $5.00 per MTok (base row rate); 32K-128K = $1.80 / $9.00; 128K-256K = $3.00 / $15.00; 256K-1M = $6.00 / $60.00 (captured in pricing_tiers) — unchanged at last_verified. 1,000,000-token context window with 65,536 max output tokens. `qwen3-coder-plus` still resolves to `qwen3-coder-plus-2025-09-23` (no newer dated snapshot published; an older `qwen3-coder-plus-2025-07-22` snapshot remains listed separately at identical pricing). Built on the Qwen3-Coder 480B-A35B MoE base; positioned for agentic coding (robust tool calling and environment interaction). Not a thinking/reasoning SKU (no chain-of-thought billing semantics), so reasoning_tokens_billed is false. Text-only modalities. Explicit context cache discounts cached input to 10% of the standard rate; implicit cache to 20%; DashScope does not publish a single cache_read figure across tiered input rates, so cache_read_per_mtok_usd is omitted rather than guessed. Knowledge cutoff not published. Deployment via DashScope (Model Studio) only at last_verified. CHANGE 2026-07-02: batch_input_per_mtok_usd/batch_output_per_mtok_usd removed — the vendor's \"Qwen-Coder\" pricing section intro no longer mentions batch-call pricing at all (unlike the \"Qwen-Max\" section, which still documents a batch discount), and neither the International nor Chinese-mainland qwen3-coder-plus table rows carry a batch badge (verified against raw page HTML across all 4 occurrences of this model_id on the page). Batch inference discount is no longer offered for this model as of this verification; prior figures ($0.50/$2.50) are stale. Re-verified 2026-07-13: prices, tiers, and no-batch posture unchanged against alibabacloud.com/help/en/model-studio/billing; still resolves to qwen3-coder-plus-2025-09-23 with no newer dated snapshot; model_id still active."
     },
     {
       "provider": "Alibaba",
@@ -2037,12 +2260,88 @@
       "deployment_options": ["dashscope"],
       "aggregators": ["openrouter"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
-      "notes": "New flagship generation added this pass. `qwen3.7-max` is a rolling alias, currently equivalent to `qwen3.7-max-2026-05-20` per the vendor pricing page (updated Jun 26, 2026); a newer `qwen3.7-max-2026-06-08` dated snapshot is also listed at identical pricing but is not yet the default alias. Flat (non-tiered) DashScope International rate of $2.50 input / $7.50 output per MTok across the full 0-1M token range (no pricing_tiers needed, unlike qwen3-max/qwen3-coder-plus). Cross-verified against OpenRouter (openrouter.ai/qwen/qwen3.7-max), which lists the same $2.50/$7.50 standard rate (its displayed $1.25/$3.75 is an explicitly-labeled 50%-off launch promotion, not the standard price). No batch-inference-discount badge on the International row (Chinese-mainland deployment shows one; not priced here, DashScope International is canonical). Context caching discount available but DashScope does not publish a flat cache_read rate, so cache_read_per_mtok_usd is omitted. 1M-token context window confirmed on the vendor pricing page; max_output_tokens (65,536) is not published on the vendor pricing/model pages directly and is sourced from third-party trackers (OpenRouter, llm-stats.com) that agree on the figure — confidence: medium reflects this one field, not the price. Text-only modalities (MarkTechPost coverage of the 2026-05-20 launch explicitly notes no image input); native tool/function calling supported (reported over 1,000 sequential tool calls in agentic testing). Hybrid thinking model (Non-Thinking and Thinking modes both billed at the same rate), hence reasoning_tokens_billed: true. Knowledge cutoff not published by the vendor; omitted rather than guessed. Deployment via DashScope (Model Studio) only; not yet confirmed on Bedrock, Vertex, Together, Fireworks, or Groq as a first-party offering."
+      "notes": "New flagship generation added this pass. `qwen3.7-max` is a rolling alias, currently equivalent to `qwen3.7-max-2026-05-20` per the vendor pricing page (updated Jun 26, 2026); a newer `qwen3.7-max-2026-06-08` dated snapshot is also listed at identical pricing but is not yet the default alias. Flat (non-tiered) DashScope International rate of $2.50 input / $7.50 output per MTok across the full 0-1M token range (no pricing_tiers needed, unlike qwen3-max/qwen3-coder-plus). Cross-verified against OpenRouter (openrouter.ai/qwen/qwen3.7-max), which lists the same $2.50/$7.50 standard rate (its displayed $1.25/$3.75 is an explicitly-labeled 50%-off launch promotion, not the standard price). No batch-inference-discount badge on the International row (Chinese-mainland deployment shows one; not priced here, DashScope International is canonical). Context caching discount available but DashScope does not publish a flat cache_read rate, so cache_read_per_mtok_usd is omitted. 1M-token context window confirmed on the vendor pricing page; max_output_tokens (65,536) is not published on the vendor pricing/model pages directly and is sourced from third-party trackers (OpenRouter, llm-stats.com) that agree on the figure — confidence: medium reflects this one field, not the price. Text-only modalities (MarkTechPost coverage of the 2026-05-20 launch explicitly notes no image input); native tool/function calling supported (reported over 1,000 sequential tool calls in agentic testing). Hybrid thinking model (Non-Thinking and Thinking modes both billed at the same rate), hence reasoning_tokens_billed: true. Knowledge cutoff not published by the vendor; omitted rather than guessed. Deployment via DashScope (Model Studio) only; not yet confirmed on Bedrock, Vertex, Together, Fireworks, or Groq as a first-party offering. Re-verified 2026-07-13: flat $2.50/$7.50 rate, 1M context, and no-batch-on-International posture unchanged against alibabacloud.com/help/en/model-studio/billing; cross-checked openrouter.ai/api/v1/models (qwen/qwen3.7-max: context_length 1,000,000, top_provider.max_completion_tokens 65,536) — corroborates max_output_tokens beyond the prior third-party-tracker citation. Still no qwen4-generation flagship listed by the vendor as of this pass; qwen3.7-max remains current."
+    },
+    {
+      "provider": "Alibaba",
+      "provider_url": "https://www.alibabacloud.com/product/modelstudio",
+      "model_id": "qwen3.7-plus",
+      "display_name": "Qwen3.7-Plus",
+      "model_family": "Qwen 3.7 Plus",
+      "context_window": 1048576,
+      "max_output_tokens": 65536,
+      "input_per_mtok_usd": "0.40",
+      "output_per_mtok_usd": "1.60",
+      "pricing_tiers": [
+        {
+          "threshold_tokens": 262144,
+          "input_per_mtok_usd": "1.20",
+          "output_per_mtok_usd": "1.60"
+        }
+      ],
+      "modalities": {
+        "input": ["text", "image"],
+        "output": ["text"]
+      },
+      "supports_tool_use": true,
+      "structured_output": true,
+      "supports_vision": true,
+      "supports_audio_in": false,
+      "supports_audio_out": false,
+      "supports_pdf": false,
+      "reasoning_tokens_billed": true,
+      "deployment_options": ["dashscope"],
+      "aggregators": ["openrouter"],
+      "confidence": "medium",
+      "last_verified": "2026-07-13",
+      "last_changed_at": "2026-07-13",
+      "verification_method": "manual-confirmed",
+      "verified_by": "r13i",
+      "source_url": "https://www.alibabacloud.com/help/en/model-studio/billing",
+      "notes": "New row, added on the 2026-07-13 refresh. Qwen3.7-Plus is Alibaba's cost-effective multimodal agent model in the Qwen3.7 series (released 2026-05-31/06-02), a step down from qwen3.7-max. `qwen3.7-plus` is a rolling alias, currently equivalent to `qwen3.7-plus-2026-05-26`. DashScope International tiered pricing by input-token bucket: 0-256K = $0.40 input / $1.60 output per MTok (base row rate); 256K-1M = $1.20 input / $1.60 output (output rate does not change with tier, per vendor billing page — both Non-Thinking and Thinking modes billed at the same $1.60/MTok output rate). China-mainland row carries an additional 20%-off limited-time promotion, not priced here (DashScope International is canonical). Context window 1,048,576 tokens (1M) per vendor billing page. max_output_tokens (65,536) not published on the vendor billing page directly; sourced from OpenRouter's public models API (openrouter.ai/api/v1/models, qwen/qwen3.7-plus: top_provider.max_completion_tokens 65536, context_length 1,000,000) and cross-checked against llm-stats.com/api/models/qwen3.7-plus (\"up to 65,536 output tokens\", 1M context, multimodal: true) — satisfies the two-source rule; confidence: medium reflects this field, not the price. Input modalities text + image (\"multimodal interactive hybrid agent\": perceives scenes, reads screens/GUIs, writes code from visual references) per OpenRouter architecture (text+image->text) and llm-stats.com; output text-only. Vendor billing page itself does not call out modality explicitly (no separate image-token pricing tier), so supports_vision is sourced from the two secondary trackers, not the primary. Tool calling and structured outputs supported per OpenRouter's supported_parameters (tools/tool_choice, response_format/structured_outputs). Always-on/hybrid thinking (llm-stats.com tags thinking: true); thinking tokens billed at the standard output rate, hence reasoning_tokens_billed: true. Context caching discount available but DashScope does not publish a flat cache_read rate, so cache_read_per_mtok_usd is omitted rather than guessed. No batch-inference-discount badge found for the International row. Knowledge cutoff not published by the vendor; omitted rather than guessed. Deployment via DashScope (Model Studio) only; not yet confirmed on Bedrock, Vertex, Together, Fireworks, or Groq as a first-party offering."
+    },
+    {
+      "provider": "Alibaba",
+      "provider_url": "https://www.alibabacloud.com/product/modelstudio",
+      "model_id": "qwen3.6-flash",
+      "display_name": "Qwen3.6-Flash",
+      "model_family": "Qwen 3.6 Flash",
+      "context_window": 1048576,
+      "max_output_tokens": 65536,
+      "input_per_mtok_usd": "0.25",
+      "output_per_mtok_usd": "1.50",
+      "pricing_tiers": [
+        {
+          "threshold_tokens": 262144,
+          "input_per_mtok_usd": "1.00",
+          "output_per_mtok_usd": "4.00"
+        }
+      ],
+      "modalities": {
+        "input": ["text", "image", "video"],
+        "output": ["text"]
+      },
+      "supports_tool_use": true,
+      "structured_output": true,
+      "supports_vision": true,
+      "supports_audio_in": false,
+      "supports_audio_out": false,
+      "supports_pdf": false,
+      "reasoning_tokens_billed": true,
+      "deployment_options": ["dashscope"],
+      "aggregators": ["openrouter"],
+      "confidence": "medium",
+      "last_verified": "2026-07-13",
+      "last_changed_at": "2026-07-13",
+      "verification_method": "manual-confirmed",
+      "verified_by": "r13i",
+      "source_url": "https://www.alibabacloud.com/help/en/model-studio/billing",
+      "notes": "New row, added on the 2026-07-13 refresh. Qwen3.6-Flash is Alibaba's fast/efficient tier in the Qwen3.6 series (released 2026-04-16), positioned below the Qwen3.7 generation on price but supporting multimodal input. `qwen3.6-flash` is a rolling alias, currently equivalent to `qwen3.6-flash-2026-04-16`. DashScope International tiered pricing by input-token bucket: 0-256K = $0.25 input / $1.50 output per MTok (base row rate); 256K-1M = $1.00 / $4.00 (captured in pricing_tiers). Context window 1,048,576 tokens (1M) per vendor billing page. max_output_tokens (65,536) not published on the vendor billing page directly; sourced from OpenRouter's public models API (openrouter.ai/api/v1/models, qwen/qwen3.6-flash: top_provider.max_completion_tokens 65536, context_length 1,000,000, architecture text+image+video->text) — satisfies the two-source rule alongside the vendor's own pricing table; confidence: medium reflects this field and modality, not the price. Input modalities text + image + video per OpenRouter; output text-only. Unlike qwen3-max/qwen3.7-max, this SKU carries a 50% batch-inference-discount badge on the International/Singapore row itself (confirmed on the vendor billing page) rather than only the China-mainland row — batch_input_per_mtok_usd/batch_output_per_mtok_usd are nonetheless omitted here because the discount applies per input-token tier and the schema's batch fields are flat (non-tiered), so a single number would misrepresent the 256K/1M split; noted here instead of guessed. Context caching discount available but DashScope does not publish a flat cache_read rate, so cache_read_per_mtok_usd is omitted. Tool calling and structured outputs supported per OpenRouter's supported_parameters. Hybrid thinking (OpenRouter reasoning.mandatory: false); thinking tokens billed at the standard output rate, hence reasoning_tokens_billed: true. Knowledge cutoff not published by the vendor; omitted rather than guessed. Deployment via DashScope (Model Studio) only; not yet confirmed on Bedrock, Vertex, Together, Fireworks, or Groq as a first-party offering."
     },
     {
       "provider": "Perplexity",
@@ -2067,7 +2366,7 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": false,
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -2097,7 +2396,7 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": false,
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -2127,7 +2426,7 @@
       "supports_pdf": false,
       "reasoning_tokens_billed": true,
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",

--- a/costs/stt.json
+++ b/costs/stt.json
@@ -14,7 +14,7 @@
       "streaming": true,
       "realtime": true,
       "diarization": "extra-cost",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -33,7 +33,7 @@
       "streaming": true,
       "realtime": true,
       "diarization": "extra-cost",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -63,7 +63,7 @@
       "diarization": "extra-cost",
       "deployment_options": ["native"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -80,7 +80,7 @@
       "streaming": true,
       "realtime": true,
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -97,7 +97,7 @@
       "streaming": true,
       "realtime": true,
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -114,12 +114,12 @@
       "streaming": false,
       "realtime": false,
       "diarization": "extra-cost",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-05",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://www.assemblyai.com/pricing",
-      "notes": "Pre-recorded (file-based) only — broadest AssemblyAI language coverage. Published as $0.15/hr. Diarization add-on +$0.02/hr. For real-time use, see universal-streaming-english / universal-streaming-multilingual."
+      "notes": "Pre-recorded (file-based) only — broadest AssemblyAI language coverage. Published as $0.15/hr. Diarization add-on +$0.02/hr (standard tier; a +$0.065/hr experimental tier is now also listed). For real-time use, see universal-streaming-english / universal-streaming-multilingual."
     },
     {
       "provider": "AssemblyAI",
@@ -134,7 +134,7 @@
       "deprecated_at": "2026-07-02",
       "replaced_by_model_id": "universal-streaming-english",
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-05",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -152,7 +152,7 @@
       "realtime": true,
       "diarization": "extra-cost",
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -165,17 +165,17 @@
       "model_id": "universal-3-pro",
       "display_name": "Universal-3.5 Pro",
       "price_per_minute_usd": "0.0035",
-      "languages": ["en", "es", "pt", "de", "fr", "it"],
+      "languages": ["en", "es", "fr", "de", "it", "pt", "ar", "da", "nl", "fi", "he", "hi", "ja", "zh", "no", "sv", "tr", "vi"],
       "streaming": false,
       "realtime": false,
       "diarization": "extra-cost",
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-26",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://www.assemblyai.com/pricing",
-      "notes": "AssemblyAI's highest-accuracy pre-recorded model with native code-switching across EN/ES/PT/DE/FR/IT. Published as $0.21/hr. Vendor pricing page now labels this row \"Universal-3.5 Pro\" (marketing rebrand); API model_id remains `universal-3-pro` per docs.assemblyai.com/docs/getting-started/models. For real-time use see universal-3-pro-streaming."
+      "notes": "AssemblyAI's highest-accuracy pre-recorded model with native code-switching, now documented at 18 languages (expanded from the 6 tracked at last verification) per assemblyai.com/docs/getting-started/models and assemblyai.com/llms/models.md; unsupported languages fall back to Universal-2. Published as $0.21/hr, unchanged. Vendor pricing page labels this row \"Universal-3.5 Pro\" (marketing rebrand); API model_id remains `universal-3-pro` per assemblyai.com/llms/models.md quick reference (a separate docs landing page's code sample showed `universal-3-5-pro`, but the quick-reference and pricing page agree on `universal-3-pro`, so the existing model_id is kept). For real-time use see universal-3-pro-streaming."
     },
     {
       "provider": "AssemblyAI",
@@ -183,17 +183,18 @@
       "model_id": "universal-3-pro-streaming",
       "display_name": "Universal-3 Pro Streaming",
       "price_per_minute_usd": "0.0075",
-      "languages": ["en", "es", "pt", "de", "fr", "it"],
+      "languages": ["en", "es", "fr", "de", "it", "pt", "ar", "da", "nl", "fi", "he", "hi", "ja", "zh", "no", "sv", "tr", "vi"],
       "streaming": true,
       "realtime": true,
       "diarization": "extra-cost",
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "confidence": "medium",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-26",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://www.assemblyai.com/pricing",
-      "notes": "Real-time streaming variant of Universal-3 Pro, positioned for voice agents. Multilingual with native code-switching across EN/ES/PT/DE/FR/IT. Published as $0.45/hr (confirmed unchanged via AssemblyAI's 2026-07 Universal-3.5 Pro Realtime announcement, which states base pricing is \"unchanged from the previous Universal-3 Pro Realtime version\"). Vendor appears to be rebranding this tier to \"Universal-3.5 Pro Realtime\" with a still-ambiguous model_id (pricing page shows `u3-rt-pro`/alias `u3-pro`; docs/blog code samples show `universal-3-5-pro`) — left unresolved pending a stable single id; see AssemblyAI defer note this refresh."
+      "notes": "Real-time streaming variant of Universal-3 Pro, positioned for voice agents. Now documented at 18 languages, matching the pre-recorded universal-3-pro coverage (same source pair as that row). Published as $0.45/hr, unchanged this refresh. Vendor has rebranded this tier \"Universal-3.5 Pro Realtime\"; both the pricing page and the assemblyai.com/llms/models.md quick reference this refresh consistently give `u3-rt-pro` (alias `u3-pro`) as the API identifier, but no vendor source uses the literal string `universal-3-pro-streaming` that this row's model_id carries. Keeping the existing model_id unchanged this cycle rather than renaming on a single refresh's evidence; confidence:medium pending a repeat confirmation before renaming/deprecating in favor of `u3-rt-pro`."
     },
     {
       "provider": "AssemblyAI",
@@ -206,7 +207,7 @@
       "realtime": true,
       "diarization": "extra-cost",
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-26",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -226,12 +227,12 @@
       "deployment_options": ["native"],
       "deprecated_at": "2026-07-02",
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-26",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://www.assemblyai.com/pricing",
-      "notes": "OpenAI Whisper served via AssemblyAI's streaming infrastructure with 99+ language coverage. Published as $0.30/hr as of last verification, but no longer listed on the pricing page, docs/getting-started/models, or the changelog as of 2026-07-02 — treated as silently discontinued. No in-file replacement (no surviving streaming model offers 99+ language coverage); confidence:medium since no explicit vendor deprecation notice was found, only absence across all checked sources."
+      "notes": "OpenAI Whisper served via AssemblyAI's streaming infrastructure with 99+ language coverage. Published as $0.30/hr as of last verification, but no longer listed on the pricing page, docs/getting-started/models, the llms/models.md quick reference, or the changelog — still absent as of 2026-07-13, reconfirming silent discontinuation. No in-file replacement (no surviving streaming model offers 99+ language coverage); confidence:medium since no explicit vendor deprecation notice was found, only absence across all checked sources."
     },
     {
       "provider": "Cartesia",
@@ -245,12 +246,12 @@
       "realtime": true,
       "diarization": "unsupported",
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://cartesia.ai/pricing",
-      "notes": "model_id corrected from the invented 'ink-1' to the actual API identifier 'ink-whisper' (docs.cartesia.ai STT AsyncAPI spec enumerates only ink-2 and ink-whisper; latest dated snapshot is ink-whisper-2025-06-04). cartesia.ai/pricing no longer publishes an explicit $/min table -- STT is now billed in credits (docs.cartesia.ai/pricing.md: ink-whisper = 1 credit/sec streaming, 1 credit per 2 sec via the batch endpoint) with credit value varying by plan tier. Converting at the Pro-tier rate ($5/mo for 100,000 credits = $0.00005/credit, the same rate implied by the prior $0.003/min figure) yields $0.003/min streaming (unchanged) and $0.0015/min batch (new price_per_minute_batch_usd field, derived not published, hence confidence: medium). Languages widened from '42+' to '99+' per docs.cartesia.ai/build-with-cartesia/stt/older-models. Still the same STT product as the Sonic TTS provider; supports both batch (/stt) and manual realtime websocket."
+      "notes": "model_id corrected from the invented 'ink-1' to the actual API identifier 'ink-whisper' (docs.cartesia.ai STT AsyncAPI spec enumerates only ink-2 and ink-whisper; latest dated snapshot is ink-whisper-2025-06-04). cartesia.ai/pricing no longer publishes an explicit $/min table -- STT is now billed in credits (docs.cartesia.ai/pricing.md: ink-whisper = 1 credit/sec streaming, 1 credit per 2 sec via the batch endpoint) with credit value varying by plan tier. Converting at the Pro-tier rate ($5/mo for 100,000 credits = $0.00005/credit, the same rate implied by the prior $0.003/min figure) yields $0.003/min streaming (unchanged) and $0.0015/min batch (new price_per_minute_batch_usd field, derived not published, hence confidence: medium). Languages widened from '42+' to '99+' per docs.cartesia.ai/build-with-cartesia/stt/older-models. Still the same STT product as the Sonic TTS provider; supports both batch (/stt) and manual realtime websocket. 2026-07-13 re-verify: still active, no deprecation banner; docs.cartesia.ai/build-with-cartesia/stt/older-models confirms 99-language support and ink-whisper-2025-06-04 as latest snapshot unchanged; docs.cartesia.ai/pricing.md credit rates (1 credit/sec streaming, 1 credit/2sec batch) and cartesia.ai/pricing Pro-tier allotment ($5/mo, ~9h16m ink-2 hours implying $0.00005/credit) unchanged, so both prices confirmed unchanged."
     },
     {
       "provider": "Cartesia",
@@ -262,12 +263,12 @@
       "streaming": true,
       "realtime": true,
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://cartesia.ai/pricing",
-      "notes": "New model launched 2026-05-22 (docs.cartesia.ai/build-with-cartesia/stt/latest): Cartesia's fastest streaming STT with built-in turn detection, replacing the need for separate VAD. English only ('en') as of this refresh; batch (/stt) support listed as 'coming soon', so only the streaming/auto-websocket endpoint is priced here (no price_per_minute_batch_usd yet). Billed at 3 credits/sec (docs.cartesia.ai/pricing.md); converted at the Pro-tier rate of $0.00005/credit ($5/mo for 100,000 credits) = $0.009/min, consistent with the ~9h16m Ink-2 allotment shown for the $5 Pro plan on cartesia.ai/pricing (9.27h => ~$0.009/min). Diarization support unconfirmed in docs, field omitted pending verification. Not a replacement for ink-whisper -- both remain listed as stable/active models."
+      "notes": "New model launched 2026-05-22 (docs.cartesia.ai/build-with-cartesia/stt/latest): Cartesia's fastest streaming STT with built-in turn detection, replacing the need for separate VAD. English only ('en') as of this refresh; batch (/stt) support listed as 'coming soon', so only the streaming/auto-websocket endpoint is priced here (no price_per_minute_batch_usd yet). Billed at 3 credits/sec (docs.cartesia.ai/pricing.md); converted at the Pro-tier rate of $0.00005/credit ($5/mo for 100,000 credits) = $0.009/min, consistent with the ~9h16m Ink-2 allotment shown for the $5 Pro plan on cartesia.ai/pricing (9.27h => ~$0.009/min). Diarization support unconfirmed in docs, field omitted pending verification. Not a replacement for ink-whisper -- both remain listed as stable/active models. 2026-07-13 re-verify: still active/stable, still English-only, batch endpoint still listed as not yet available, turn-detection lifecycle events (turn.start/update/eager_end/resume/end) confirmed live on docs.cartesia.ai/build-with-cartesia/stt/latest; credit rate (3 credits/sec) and Pro-tier allotment (~9h16m for $5) unchanged, so $0.009/min confirmed unchanged."
     },
     {
       "provider": "OpenAI",
@@ -279,12 +280,66 @@
       "streaming": false,
       "realtime": false,
       "diarization": "unsupported",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-05",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://developers.openai.com/api/docs/pricing",
       "notes": "Billed to the nearest second. Pre-recorded only. Price unchanged at $0.006/min. openai.com/api/pricing/ still 403s and platform.openai.com/docs/pricing now 301-redirects to developers.openai.com/api/docs/pricing; Whisper is a collapsed/hidden row on that pricing table but present at the same rate, cross-verified against developers.openai.com/api/docs/models (not deprecated; no entry on /api/docs/deprecations)."
+    },
+    {
+      "provider": "OpenAI",
+      "provider_url": "https://openai.com",
+      "model_id": "gpt-4o-transcribe",
+      "display_name": "GPT-4o Transcribe",
+      "price_per_minute_usd": "0.006",
+      "languages": "99+",
+      "streaming": false,
+      "realtime": false,
+      "diarization": "unsupported",
+      "confidence": "medium",
+      "last_verified": "2026-07-13",
+      "last_changed_at": "2026-07-13",
+      "verification_method": "manual-confirmed",
+      "verified_by": "r13i",
+      "source_url": "https://developers.openai.com/api/docs/pricing",
+      "notes": "New row this refresh. GPT-4o-powered transcription model served via the same /v1/audio/transcriptions endpoint as whisper-1; higher quality with prompting support for improved accuracy. Billed per-token ($2.50/1M input audio tokens, $10.00/1M output tokens); developers.openai.com/api/docs/pricing publishes this as an 'Estimated cost' of $0.006/minute (confidence: medium — the real bill tracks token usage, not a flat per-minute rate like whisper-1). 25 MB file-size limit. Supports `stream=true` for incremental text output on an already-uploaded file, which is not the same as live/realtime audio-in — OpenAI's Realtime API instead designates a separate `gpt-realtime-whisper` model for that; deferred, see notes on that decision in this refresh's report (categorization as STT vs. realtime/audio-modality product needs a call before adding). Same supported-language set as whisper-1 per developers.openai.com/api/docs/guides/speech-to-text 'Supported languages' section (page notes ISO 639-3 codes are additionally accepted for GPT-4o-based models). Not listed on /api/docs/deprecations. Cross-verified model existence via developers.openai.com/api/docs/models."
+    },
+    {
+      "provider": "OpenAI",
+      "provider_url": "https://openai.com",
+      "model_id": "gpt-4o-mini-transcribe",
+      "display_name": "GPT-4o mini Transcribe",
+      "price_per_minute_usd": "0.003",
+      "languages": "99+",
+      "streaming": false,
+      "realtime": false,
+      "diarization": "unsupported",
+      "confidence": "medium",
+      "last_verified": "2026-07-13",
+      "last_changed_at": "2026-07-13",
+      "verification_method": "manual-confirmed",
+      "verified_by": "r13i",
+      "source_url": "https://developers.openai.com/api/docs/pricing",
+      "notes": "New row this refresh. Cost-efficient sibling of gpt-4o-transcribe with the same prompting and (non-realtime) streaming-of-output capabilities; same /v1/audio/transcriptions endpoint and 25 MB file-size limit. Billed per-token ($1.25/1M input audio tokens, $5.00/1M output tokens); developers.openai.com/api/docs/pricing publishes this as an 'Estimated cost' of $0.003/minute (confidence: medium, same token-vs-flat-rate caveat as gpt-4o-transcribe). Same supported-language set as whisper-1 per the speech-to-text guide's 'Supported languages' section. Not listed on /api/docs/deprecations. Cross-verified model existence via developers.openai.com/api/docs/models."
+    },
+    {
+      "provider": "OpenAI",
+      "provider_url": "https://openai.com",
+      "model_id": "gpt-4o-transcribe-diarize",
+      "display_name": "GPT-4o Transcribe Diarize",
+      "price_per_minute_usd": "0.006",
+      "languages": "99+",
+      "streaming": false,
+      "realtime": false,
+      "diarization": "included",
+      "confidence": "medium",
+      "last_verified": "2026-07-13",
+      "last_changed_at": "2026-07-13",
+      "verification_method": "manual-confirmed",
+      "verified_by": "r13i",
+      "source_url": "https://developers.openai.com/api/docs/pricing",
+      "notes": "New row this refresh. Speaker-aware transcription variant for meeting recordings / multi-speaker audio: emits `transcript.text.segment` events with speaker labels (up to 4 known-speaker reference clips accepted), no separate diarization fee — priced identically to gpt-4o-transcribe. developers.openai.com/api/docs/pricing lists it as a hidden-by-default row (same collapsed-row pattern as whisper-1) at the same $2.50/$10.00 per-1M-token rate, 'Estimated cost' $0.006/minute (confidence: medium, same token-vs-flat-rate caveat). Requires `chunking_strategy` (auto or VAD config) for audio longer than 30 seconds; does not support the `prompt` or `logprobs` parameters. 25 MB file-size limit. Cross-verified model existence via developers.openai.com/api/docs/models and developers.openai.com/api/docs/guides/speech-to-text."
     },
     {
       "provider": "Groq",
@@ -297,12 +352,12 @@
       "realtime": false,
       "diarization": "unsupported",
       "min_billed_seconds": 10,
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-05",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://groq.com/pricing/",
-      "notes": "Whisper V3 Large hosted on Groq. Published as $0.111/hr. Speed factor 217x realtime."
+      "notes": "Whisper V3 Large hosted on Groq. Published as $0.111/hr. Speed factor 217x realtime. Re-verified 2026-07-13: model_id, price ($0.111/hr = $0.00185/min), and 10s minimum billing unchanged. Cross-verified against console.groq.com/docs/models and console.groq.com/docs/speech-to-text (groq.com/groqcloud-models secondary URL now 404s)."
     },
     {
       "provider": "Groq",
@@ -315,12 +370,12 @@
       "realtime": false,
       "diarization": "unsupported",
       "min_billed_seconds": 10,
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-05",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://groq.com/pricing/",
-      "notes": "Whisper Large v3 Turbo hosted on Groq — faster variant. Published as $0.04/hr. Speed factor 228x realtime."
+      "notes": "Whisper Large v3 Turbo hosted on Groq — faster variant. Published as $0.04/hr. Speed factor 228x realtime. Re-verified 2026-07-13: model_id and price ($0.04/hr = $0.000667/min) unchanged. Cross-verified against console.groq.com/docs/models and console.groq.com/docs/speech-to-text (groq.com/groqcloud-models secondary URL now 404s)."
     },
     {
       "provider": "Microsoft Azure",
@@ -333,12 +388,13 @@
       "realtime": true,
       "diarization": "included",
       "deployment_options": ["azure"],
-      "last_verified": "2026-05-19",
+      "confidence": "medium",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://azure.microsoft.com/en-us/pricing/details/speech/",
-      "notes": "Azure Speech Standard (S0) real-time speech-to-text. Published as $1.00/hr pay-as-you-go (= $0.016667/min); custom real-time endpoint is $1.20/hr ($0.02/min). Commitment tiers reduce effective rate (2,000 hrs/mo $0.80/hr; 10,000 hrs/mo $0.65/hr; 50,000 hrs/mo $0.50/hr). Real-time diarization is included up to 240 min/session per Microsoft Learn quotas/limits doc. Languages: 100+ per Azure language support docs. Cross-verified via https://learn.microsoft.com/en-us/answers/questions/2155625/speech-to-text-costing-1-hr-is-crazy-no-bulk-avail."
+      "notes": "Azure Speech Standard (S0) real-time speech-to-text. Published as $1.00/hr pay-as-you-go (= $0.016667/min); custom real-time endpoint is $1.20/hr ($0.02/min). Commitment tiers reduce effective rate (2,000 hrs/mo $0.80/hr; 10,000 hrs/mo $0.65/hr; 50,000 hrs/mo $0.50/hr). Real-time diarization is included up to 240 min/session per Microsoft Learn quotas/limits doc. Languages: 100+ per Azure language support docs. Cross-verified via https://learn.microsoft.com/en-us/answers/questions/2155625/speech-to-text-costing-1-hr-is-crazy-no-bulk-avail. 2026-07-13 pass: primary azure.microsoft.com pricing page timed out on WebFetch (5 attempts across 2 URL variants); figures re-confirmed unchanged via the Q&A above plus techcommunity.microsoft.com/blog/azure-ai-foundry-blog/updates-to-azure-ai-speech-service-pricing/3928425 (same $1.20/hr custom real-time baseline in effect since Oct 2023, no newer revision found); confidence set to medium pending a successful direct fetch of the primary page next pass."
     },
     {
       "provider": "Microsoft Azure",
@@ -351,12 +407,13 @@
       "realtime": false,
       "diarization": "included",
       "deployment_options": ["azure"],
-      "last_verified": "2026-05-19",
+      "confidence": "medium",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://azure.microsoft.com/en-us/pricing/details/speech/",
-      "notes": "Azure Speech Standard (S0) batch transcription. Published as $0.36/hr (= $0.006/min); custom batch endpoint is $0.45/hr ($0.0075/min). Fast transcription (REST API, sync) is a separate $0.66/hr ($0.011/min) tier, not modelled here. Batch diarization is included (up to 240 min/file). Cross-verified via https://learn.microsoft.com/en-us/answers/questions/2155625/speech-to-text-costing-1-hr-is-crazy-no-bulk-avail."
+      "notes": "Azure Speech Standard (S0) batch transcription. Published as $0.36/hr (= $0.006/min); custom batch endpoint is $0.45/hr ($0.0075/min). Fast transcription (REST API, sync) is a separate $0.66/hr ($0.011/min) tier, not modelled here. Batch diarization is included (up to 240 min/file). Cross-verified via https://learn.microsoft.com/en-us/answers/questions/2155625/speech-to-text-costing-1-hr-is-crazy-no-bulk-avail. 2026-07-13 pass: primary azure.microsoft.com pricing page timed out on WebFetch (5 attempts across 2 URL variants); figures re-confirmed unchanged via the Q&A above (explicitly states Standard Batch $0.36/hr, Custom Batch $0.45/hr) plus techcommunity.microsoft.com/blog/azure-ai-foundry-blog/updates-to-azure-ai-speech-service-pricing/3928425 (same baseline since Oct 2023, no newer revision found); confidence set to medium pending a successful direct fetch of the primary page next pass."
     },
     {
       "provider": "Google",
@@ -369,12 +426,12 @@
       "realtime": true,
       "diarization": "included",
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://cloud.google.com/speech-to-text/pricing",
-      "notes": "Google Cloud Speech-to-Text v2 multilingual model. Standard tier $0.016/min for both real-time and batch (down from v1's $0.024/min, per https://cloud.google.com/blog/products/ai-machine-learning/google-cloud-speech-to-text-v2-api). Dynamic Batch tier (up to 24h SLA) is 75% lower at $0.004/min — not modelled as price_per_minute_batch_usd because standard batch is the same as real-time. Standard volume tiers can reduce effective rate to as low as $0.004/min. Supports StreamingRecognize (~20 languages), Recognize, and BatchRecognize (broadest language coverage) per https://docs.cloud.google.com/speech-to-text/docs/models/chirp-2. GA in us-central1, europe-west4, asia-southeast1. 2026-07-02 re-verify: pricing page (primary) truncates on WebFetch — known issue; cross-checked model still GA via https://docs.cloud.google.com/speech-to-text/v2/docs/transcription-model (secondary) and confirmed $0.016/min + 75%-off Dynamic Batch figures unchanged via a search snippet quoting the pricing page's own text. No price change."
+      "notes": "Google Cloud Speech-to-Text v2 multilingual model. Standard tier $0.016/min for both real-time and batch (down from v1's $0.024/min, per https://cloud.google.com/blog/products/ai-machine-learning/google-cloud-speech-to-text-v2-api). Dynamic Batch tier (up to 24h SLA) is 75% lower at $0.004/min — not modelled as price_per_minute_batch_usd because standard batch is the same as real-time. Standard volume tiers can reduce effective rate to as low as $0.004/min. Supports StreamingRecognize (~20 languages), Recognize, and BatchRecognize (broadest language coverage) per https://docs.cloud.google.com/speech-to-text/docs/models/chirp-2. GA in us-central1, europe-west4, asia-southeast1. 2026-07-13 re-verify: pricing page (primary) still truncates on WebFetch — same known issue; cross-checked via https://docs.cloud.google.com/speech-to-text/v2/docs/transcription-model (secondary, model still listed GA, not deprecated) and two independent web-search snippets quoting the pricing page's own text, both confirming $0.016/min standard + $0.004/min (75% off) Dynamic Batch unchanged. No price change. Language-count sub-field left untouched this pass — repeated WebFetch summaries of the supported-languages table returned inconsistent counts (72/90+/150+) due to table truncation, so it does not meet the two-source bar for a non-price-field edit."
     },
     {
       "provider": "Google",
@@ -387,12 +444,12 @@
       "realtime": true,
       "diarization": "included",
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://cloud.google.com/speech-to-text/pricing",
-      "notes": "Google Cloud Speech-to-Text v2 latest-generation generative ASR model. Standard tier $0.016/min for both real-time and batch; Dynamic Batch tier (up to 24h SLA) at $0.004/min (75% off) — not modelled as price_per_minute_batch_usd because standard batch is the same as real-time. Adds automatic language detection and diarization vs Chirp 2 per https://docs.cloud.google.com/speech-to-text/docs/models/chirp-3. 98+ languages and locales (24 GA + 74 preview); supports StreamingRecognize and BatchRecognize. 2026-07-02 re-verify: pricing page (primary) truncates on WebFetch — known issue; cross-checked model still GA via https://docs.cloud.google.com/speech-to-text/v2/docs/transcription-model (secondary) and confirmed $0.016/min + 75%-off Dynamic Batch figures unchanged via a search snippet quoting the pricing page's own text. No price change."
+      "notes": "Google Cloud Speech-to-Text v2 latest-generation generative ASR model. Standard tier $0.016/min for both real-time and batch; Dynamic Batch tier (up to 24h SLA) at $0.004/min (75% off) — not modelled as price_per_minute_batch_usd because standard batch is the same as real-time. Adds automatic language detection and diarization vs Chirp 2 per https://docs.cloud.google.com/speech-to-text/docs/models/chirp-3. 98+ languages and locales (24 GA + 74 preview) per prior verification; supports StreamingRecognize and BatchRecognize. 2026-07-13 re-verify: pricing page (primary) still truncates on WebFetch — same known issue; cross-checked via https://docs.cloud.google.com/speech-to-text/v2/docs/transcription-model (secondary, model still listed GA, not deprecated) and two independent web-search snippets quoting the pricing page's own text, both confirming $0.016/min standard + $0.004/min (75% off) Dynamic Batch unchanged. No price change. Language-count sub-field left untouched this pass — repeated WebFetch summaries of the chirp-3 model page and supported-languages table returned inconsistent GA/preview splits (24+48 vs 24+74) and inconsistent totals (72/90+/100+) due to table truncation, so it does not meet the two-source bar for a non-price-field edit; existing 98+ figure retained pending a cleaner source."
     },
     {
       "provider": "Speechmatics",
@@ -406,12 +463,12 @@
       "diarization": "included",
       "deployment_options": ["native"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://www.speechmatics.com/pricing",
-      "notes": "Speechmatics offers three operating points — `enhanced` (highest accuracy), `standard` (faster/cheaper), and the newer `melia-1` (multilingual, batch-only) — selected via the `operating_point` API parameter on both Batch and Real-time APIs (Melia 1 is batch-only). Pricing page lists Pro tier from $0.129/hr ($0.00215/min) on PAYG (price cut from $0.24/hr at last check) with an automatic 20% volume discount above 500 hrs/month; the same flat rate is used for both real-time and batch and is not broken out per operating point. Free plan now includes 3,000 minutes (50 hrs)/month, up from 480 min (not modelled as `free_tier` because schema expects per-day/per-token quotas). Confidence is medium because the pricing page exposes tier names rather than per-model SKU rates; verify against contract for production. Cross-verified product structure via https://docs.speechmatics.com/."
+      "notes": "Speechmatics offers three operating points — `enhanced` (highest accuracy), `standard` (faster/cheaper), and the newer `melia-1` (multilingual, batch-only) — selected via the `operating_point` API parameter on both Batch and Real-time APIs (Melia 1 is batch-only). Pricing page lists Pro tier from $0.129/hr ($0.00215/min) on PAYG (price cut from $0.24/hr at last check) with an automatic 20% volume discount above 500 hrs/month; the same flat rate is used for both real-time and batch and is not broken out per operating point. Free plan now includes 3,000 minutes (50 hrs)/month, up from 480 min (not modelled as `free_tier` because schema expects per-day/per-token quotas). Confidence is medium because the pricing page exposes tier names rather than per-model SKU rates; verify against contract for production. Cross-verified product structure via https://docs.speechmatics.com/. 2026-07-13 re-verify: pricing page still shows Pro tier $0.129/hr ($0.00215/min) PAYG with the same 20% >500 hrs/month discount and 3,000 min (50 hrs)/month free tier; 56+ languages confirmed. Cross-checked https://docs.speechmatics.com/speech-to-text/models (secondary) — Enhanced still active, batch+real-time, EU/US/AU. Docs note the `operating_point` request parameter has been superseded by a `model` parameter (legacy `operating_point` values remain functional) — naming change only, no effect on this row's model_id or price. No price change."
     },
     {
       "provider": "Speechmatics",
@@ -425,12 +482,12 @@
       "diarization": "included",
       "deployment_options": ["native"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://www.speechmatics.com/pricing",
-      "notes": "New `operating_point=melia-1` model added since last refresh: early-access, multilingual model that auto-detects and transcribes code-switched audio into one continuous transcript without language-pack selection, per https://docs.speechmatics.com/speech-to-text/models. Batch-only (no real-time API support) — Enhanced and Standard remain active and unaffected. Matches Standard's accuracy tier; lacks custom dictionaries, confidence scores, and speaker/intelligence features available on Enhanced/Standard, though diarization and word timings are supported. Available only in EU/US regions (not AU). `68+` languages is a derived count (the docs table lists 72 entries: ~68 individual languages plus 4 bilingual packs which Melia 1 does not use) — not an officially published per-model figure. Billed at the same flat Pro-tier rate as Enhanced/Standard per https://www.speechmatics.com/pricing — the pricing page does not publish a per-model rate, hence confidence: medium."
+      "notes": "New `operating_point=melia-1` model added since last refresh: early-access, multilingual model that auto-detects and transcribes code-switched audio into one continuous transcript without language-pack selection, per https://docs.speechmatics.com/speech-to-text/models. Batch-only (no real-time API support) — Enhanced and Standard remain active and unaffected. Matches Standard's accuracy tier; lacks custom dictionaries, confidence scores, and speaker/intelligence features available on Enhanced/Standard, though diarization and word timings are supported. Available only in EU/US regions (not AU). `68+` languages is a derived count (the docs table lists 72 entries: ~68 individual languages plus 4 bilingual packs which Melia 1 does not use) — not an officially published per-model figure. Billed at the same flat Pro-tier rate as Enhanced/Standard per https://www.speechmatics.com/pricing — the pricing page does not publish a per-model rate, hence confidence: medium. 2026-07-13 re-verify: still listed as early-access, batch-only, EU/US-only per https://docs.speechmatics.com/speech-to-text/models (secondary); flat Pro-tier rate ($0.129/hr / $0.00215/min) unchanged on the pricing page (primary). No price change; not deprecated."
     },
     {
       "provider": "Rev.ai",
@@ -443,12 +500,12 @@
       "realtime": true,
       "diarization": "included",
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://www.rev.ai/pricing",
-      "notes": "Rev.ai's streaming transcription product, branded `Whisper Fusion` on the pricing page at $0.005/min; the parallel Whisper Large streaming tier is also $0.005/min. Free credits equivalent to 5 hours of Reverb ASR (cross-applicable across products). Reverb (batch) is modelled separately; see https://docs.rev.ai/ for the full API surface. English-primary; foreign language support is a distinct Reverb Foreign Language product line."
+      "notes": "Rev.ai's streaming transcription product, branded `Whisper Fusion` on the pricing page at $0.005/min; the parallel Whisper Large streaming tier is also $0.005/min. Free credits equivalent to 5 hours of Reverb ASR (cross-applicable across products). Reverb (batch) is modelled separately; see https://docs.rev.ai/ for the full API surface. English-primary; foreign language support is a distinct Reverb Foreign Language product line. 2026-07-13 re-verify: still listed at $0.005/min on the pricing page (primary); no price change. Note for context: the async job API's `transcriber` enum uses `fusion`/`machine`/`low_cost` rather than these marketing names (per docs.rev.ai, secondary) — model_id here follows this dataset's pricing-page-branding convention, unchanged from prior refresh."
     },
     {
       "provider": "Rev.ai",
@@ -461,12 +518,12 @@
       "realtime": false,
       "diarization": "included",
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://www.rev.ai/pricing",
-      "notes": "Rev.ai's async/batch ASR model branded `Reverb` at $0.20/hr ($0.0033/min). A `Reverb Turbo` tier exists at $0.10/hr ($0.0017/min) — not modelled as a separate row since it's a latency/quality dial on the same product; `Reverb Foreign Language` ($0.30/hr, $0.005/min, 57+ languages) is also priced separately and could be added if needed. Free credits equivalent to 5 hours of Reverb ASR. See https://docs.rev.ai/ for the async transcription API."
+      "notes": "Rev.ai's async/batch ASR model branded `Reverb` at $0.20/hr ($0.0033/min). A `Reverb Turbo` tier exists at $0.10/hr ($0.0017/min) — not modelled as a separate row since it's a latency/quality dial on the same product; `Reverb Foreign Language` ($0.30/hr, $0.005/min, 57+ languages) is also priced separately and could be added if needed. Free credits equivalent to 5 hours of Reverb ASR. See https://docs.rev.ai/ for the async transcription API. 2026-07-13 re-verify: still listed at $0.20/hr on the pricing page (primary); no price change. Reverb Turbo and Reverb Foreign Language remain distinct pricing tiers, still not modelled as separate rows (unchanged decision)."
     },
     {
       "provider": "Gladia",
@@ -481,12 +538,12 @@
       "realtime_latency_ms": 300,
       "diarization": "included",
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://www.gladia.io/pricing",
-      "notes": "Gladia's first-generation universal STT model `solaria-1`, supporting 100+ languages with automatic language detection and code-switching. Default model when `model` param is omitted (confirmed via docs.gladia.io pre-recorded transcription reference). Starter (PAYG) pricing: real-time $0.75/hr ($0.0125/min), async $0.61/hr (~$0.01017/min). Growth (committed) plan lowers real-time to $0.25/hr ($0.0042/min) and async to $0.20/hr ($0.0033/min). Sub-300ms streaming latency claimed on the pricing page. Speaker diarization and word-level timestamps included on all tiers. Starter includes 10 free hours per month. Model name confirmed via https://docs.gladia.io/."
+      "notes": "Gladia's first-generation universal STT model `solaria-1`, supporting 100+ languages with automatic language detection and code-switching. Default model when `model` param is omitted (confirmed via docs.gladia.io pre-recorded transcription reference). Starter (PAYG) pricing: real-time $0.75/hr ($0.0125/min), async $0.61/hr (~$0.01017/min). Growth (committed) plan lowers real-time to $0.25/hr ($0.0042/min) and async to $0.20/hr ($0.0033/min). Sub-300ms streaming latency claimed on the pricing page. Speaker diarization and word-level timestamps included on all tiers. Starter includes 10 free hours per month. Model name confirmed via https://docs.gladia.io/. 2026-07-13 re-verify: still listed at the same rates on the pricing page (primary) and docs.gladia.io (secondary); no price change."
     },
     {
       "provider": "Gladia",
@@ -500,12 +557,12 @@
       "diarization": "included",
       "deployment_options": ["native"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://www.gladia.io/pricing",
-      "notes": "New model launched since last refresh. Gladia's higher-accuracy model for European real-world audio (English, French, German, Spanish, Italian); async/pre-recorded only, requires exactly one language in `language_config.languages` (no code-switching). Confirmed as a valid `model` param value via https://docs.gladia.io (pre-recorded transcription API reference). The pricing page does not break out per-model rates, so the Starter async rate ($0.61/hr ≈ $0.01017/min) is assumed to apply; `confidence: medium` reflects that this price is not explicitly stated per-model on the pricing page. No real-time/streaming support documented for this model."
+      "notes": "Gladia's higher-accuracy model for European real-world audio (English, French, German, Spanish, Italian); async/pre-recorded only, requires exactly one language in `language_config.languages` (no code-switching). Confirmed as a valid `model` param value via https://docs.gladia.io (pre-recorded transcription API reference). The pricing page does not break out per-model rates, so the Starter async rate ($0.61/hr ≈ $0.01017/min) is assumed to apply; `confidence: medium` reflects that this price is not explicitly stated per-model on the pricing page. No real-time/streaming support documented for this model. 2026-07-13 re-verify: still active, async-only, and priced the same on both primary and secondary sources; no price change."
     },
     {
       "provider": "Soniox",
@@ -521,12 +578,12 @@
       "deprecated_at": "2026-06-30",
       "replaced_by_model_id": "stt-rt-v5",
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://soniox.com/pricing",
-      "notes": "Soniox real-time STT model `stt-rt-v4`. Primary billing metric is input audio tokens at $2.00 per 1M tokens; vendor approximates ~$0.12/hour which we use as $0.002/min for comparability. Aliased from `stt-rt-v3` (deprecated 2026-02-05; removed 2026-02-28 per https://soniox.com/docs/stt/models). Removed 2026-06-30 per https://soniox.com/docs/stt/models: requests using `stt-rt-v4` now auto-route to `stt-rt-v5` with no service interruption. 60+ languages with automatic language detection. Confidence medium because per-minute is an approximation of token-based pricing; actual cost varies with audio content density."
+      "notes": "Soniox real-time STT model `stt-rt-v4`. Primary billing metric is input audio tokens at $2.00 per 1M tokens; vendor approximates ~$0.12/hour which we use as $0.002/min for comparability. Aliased from `stt-rt-v3` (deprecated 2026-02-05; removed 2026-02-28 per https://soniox.com/docs/stt/models). Removed 2026-06-30 per https://soniox.com/docs/stt/models: requests using `stt-rt-v4` now auto-route to `stt-rt-v5` with no service interruption. 60+ languages with automatic language detection. Confidence medium because per-minute is an approximation of token-based pricing; actual cost varies with audio content density. 2026-07-13 re-verify: still deprecated/auto-routing to stt-rt-v5 per soniox.com/docs/stt/models (secondary); pricing page (primary) still quotes $2.00/1M input audio tokens for real-time; no price change."
     },
     {
       "provider": "Soniox",
@@ -540,12 +597,12 @@
       "diarization": "included",
       "deployment_options": ["native"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://soniox.com/pricing",
-      "notes": "Soniox real-time STT model `stt-rt-v4` (deprecated 2026-06-30; auto-routes to `stt-rt-v5`) per https://soniox.com/docs/stt/models: `stt-rt-v5` released 2026-06-16 with reworked speaker separation and improved spoken-language identification. Soniox's pricing page bills real-time by input audio tokens at $2.00 per 1M tokens regardless of model version (~$0.12/hour, used here as $0.002/min for comparability); the docs page confirms pricing continuity across the v4→v5 auto-route (\"no service interruption\"). 60+ languages with automatic language detection. Confidence medium because (a) per-minute is an approximation of token-based pricing and (b) the pricing page does not itemize a v5-specific rate distinct from the general real-time rate."
+      "notes": "Soniox real-time STT model `stt-rt-v4` (deprecated 2026-06-30; auto-routes to `stt-rt-v5`) per https://soniox.com/docs/stt/models: `stt-rt-v5` released 2026-06-16 with reworked speaker separation and improved spoken-language identification. Soniox's pricing page bills real-time by input audio tokens at $2.00 per 1M tokens regardless of model version (~$0.12/hour, used here as $0.002/min for comparability); the docs page confirms pricing continuity across the v4→v5 auto-route (\"no service interruption\"). 60+ languages with automatic language detection. Confidence medium because (a) per-minute is an approximation of token-based pricing and (b) the pricing page does not itemize a v5-specific rate distinct from the general real-time rate. 2026-07-13 re-verify: still the current active real-time model per soniox.com/docs/stt/models (secondary), no newer version listed; pricing page (primary) still quotes $2.00/1M input audio tokens; no price change."
     },
     {
       "provider": "Soniox",
@@ -562,12 +619,12 @@
       "deprecated_at": "2026-06-30",
       "replaced_by_model_id": "stt-async-v5",
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://soniox.com/pricing",
-      "notes": "Soniox async (file) STT model `stt-async-v4`. Primary billing metric is input audio tokens at $1.50 per 1M tokens; vendor approximates ~$0.10/hour which we use as $0.00167/min for comparability. Aliased from `stt-async-v3` (deprecated 2026-02-05; removed 2026-02-28 per https://soniox.com/docs/stt/models). Removed 2026-06-30 per https://soniox.com/docs/stt/models: requests using `stt-async-v4` now auto-route to `stt-async-v5` with no service interruption. Supports up to 5 hours of audio per request. 60+ languages with automatic language detection. Confidence medium because per-minute is an approximation of token-based pricing."
+      "notes": "Soniox async (file) STT model `stt-async-v4`. Primary billing metric is input audio tokens at $1.50 per 1M tokens; vendor approximates ~$0.10/hour which we use as $0.00167/min for comparability. Aliased from `stt-async-v3` (deprecated 2026-02-05; removed 2026-02-28 per https://soniox.com/docs/stt/models). Removed 2026-06-30 per https://soniox.com/docs/stt/models: requests using `stt-async-v4` now auto-route to `stt-async-v5` with no service interruption. Supports up to 5 hours of audio per request. 60+ languages with automatic language detection. Confidence medium because per-minute is an approximation of token-based pricing. 2026-07-13 re-verify: still deprecated/auto-routing to stt-async-v5 per soniox.com/docs/stt/models (secondary); pricing page (primary) still quotes $1.50/1M input audio tokens for async; no price change."
     },
     {
       "provider": "Soniox",
@@ -582,12 +639,12 @@
       "max_audio_minutes_per_file": 300,
       "deployment_options": ["native"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://soniox.com/pricing",
-      "notes": "Soniox async (file) STT model `stt-async-v4` (deprecated 2026-06-30; auto-routes to `stt-async-v5`) per https://soniox.com/docs/stt/models: `stt-async-v5` released 2026-06-11 with reengineered speaker separation and improved spoken-language identification. Soniox's pricing page bills async by input audio tokens at $1.50 per 1M tokens regardless of model version (~$0.10/hour, used here as $0.00167/min for comparability); the docs page confirms pricing continuity across the v4→v5 auto-route (\"no service interruption\"). Supports up to 5 hours of audio per request (carried over from v4; not independently re-stated for v5 in the docs excerpt). 60+ languages with automatic language detection. Confidence medium because (a) per-minute is an approximation of token-based pricing and (b) the max-audio-duration and pricing figures are inferred from vendor continuity statements rather than v5-specific line items."
+      "notes": "Soniox async (file) STT model `stt-async-v4` (deprecated 2026-06-30; auto-routes to `stt-async-v5`) per https://soniox.com/docs/stt/models: `stt-async-v5` released 2026-06-11 with reengineered speaker separation and improved spoken-language identification. Soniox's pricing page bills async by input audio tokens at $1.50 per 1M tokens regardless of model version (~$0.10/hour, used here as $0.00167/min for comparability); the docs page confirms pricing continuity across the v4→v5 auto-route (\"no service interruption\"). Supports up to 5 hours of audio per request (carried over from v4; not independently re-stated for v5 in the docs excerpt). 60+ languages with automatic language detection. Confidence medium because (a) per-minute is an approximation of token-based pricing and (b) the max-audio-duration and pricing figures are inferred from vendor continuity statements rather than v5-specific line items. 2026-07-13 re-verify: still the current active async model per soniox.com/docs/stt/models (secondary), no newer version listed; pricing page (primary) still quotes $1.50/1M input audio tokens; no price change."
     }
   ]
 }

--- a/costs/tts.json
+++ b/costs/tts.json
@@ -21,7 +21,7 @@
         "alaw_8000"
       ],
       "time_to_first_byte_ms": 75,
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-05",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -38,7 +38,7 @@
       "languages": "29+",
       "ssml_supported": false,
       "voice_cloning": true,
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -56,7 +56,7 @@
       "ssml_supported": false,
       "emotion_control_supported": true,
       "voice_cloning": true,
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -75,7 +75,7 @@
       "voice_cloning": true,
       "deprecated_at": "2026-05-19",
       "replaced_by_model_id": "eleven_flash_v2_5",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -93,7 +93,7 @@
       "ssml_supported": false,
       "voice_cloning": true,
       "time_to_first_byte_ms": 75,
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
@@ -110,12 +110,12 @@
       "languages": ["en"],
       "ssml_supported": false,
       "voice_cloning": false,
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-05",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://developers.openai.com/api/docs/models/tts-1",
-      "notes": "Standard quality. Price unchanged at $15/1M chars as of 2026-07-02 refresh; confirmed via model detail page (openai.com/api/pricing/ now redirects through platform.openai.com/docs/models to developers.openai.com)."
+      "notes": "Standard quality. Price unchanged at $15/1M chars as of 2026-07-13 refresh; confirmed via model detail page (openai.com/api/pricing/ now redirects through platform.openai.com/docs/models to developers.openai.com)."
     },
     {
       "provider": "OpenAI",
@@ -127,12 +127,12 @@
       "languages": ["en"],
       "ssml_supported": false,
       "voice_cloning": false,
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-05",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://developers.openai.com/api/docs/models/tts-1-hd",
-      "notes": "High-definition tier — 2x the price of tts-1 for higher quality output. Price unchanged at $30/1M chars as of 2026-07-02 refresh; confirmed via model detail page (openai.com/api/pricing/ now redirects through platform.openai.com/docs/models to developers.openai.com)."
+      "notes": "High-definition tier — 2x the price of tts-1 for higher quality output. Price unchanged at $30/1M chars as of 2026-07-13 refresh; confirmed via model detail page (openai.com/api/pricing/ now redirects through platform.openai.com/docs/models to developers.openai.com)."
     },
     {
       "provider": "OpenAI",
@@ -144,12 +144,12 @@
       "languages": ["en"],
       "ssml_supported": false,
       "voice_cloning": false,
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://developers.openai.com/api/docs/models/gpt-4o-mini-tts",
-      "notes": "OpenAI's newer GPT-4o-based TTS. Native pricing is token-based — $0.60/1M text-input tokens + $12/1M audio-output tokens — not per character. OpenAI's published estimate is ~$0.015 per minute of audio; converted to ~$20/1M chars assuming ~150 WPM (~750 chars/min) for consistency with the Cartesia row. Actual $/1M chars varies with speech rate and language. Supports voice steering via natural-language instructions (style/emotion) instead of SSML. Latest snapshot gpt-4o-mini-tts-2025-12-15; unchanged as of 2026-07-02 refresh. Only the older gpt-4o-mini-tts-2025-03-20 snapshot is marked deprecated — the default model_id remains active. Max input 2,000 tokens per request."
+      "notes": "OpenAI's newer GPT-4o-based TTS. Native pricing is token-based — $0.60/1M text-input tokens + $12/1M audio-output tokens — not per character. OpenAI's published estimate is ~$0.015 per minute of audio; converted to ~$20/1M chars assuming ~150 WPM (~750 chars/min) for consistency with the Cartesia row. Actual $/1M chars varies with speech rate and language. Supports voice steering via natural-language instructions (style/emotion) instead of SSML. Latest snapshot gpt-4o-mini-tts-2025-12-15; unchanged as of 2026-07-13 refresh. Only the older gpt-4o-mini-tts-2025-03-20 snapshot is marked deprecated — the default model_id remains active. Max input 2,000 tokens per request."
     },
     {
       "provider": "Cartesia",
@@ -170,12 +170,12 @@
         "mp3"
       ],
       "time_to_first_byte_ms": 90,
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-05",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://cartesia.ai/pricing",
-      "notes": "Cartesia publishes Sonic pricing as $1 per 25 minutes of audio output (~$0.04/min). Converted to ~$50/1M chars assuming ~150 WPM (~750 chars/min). Actual $/1M chars varies with speech rate; verify by sampling. IVC voice cloning included (no clone fee). 90ms TTFB. SSML speed/volume tags confirmed available on sonic-3.5 per https://docs.cartesia.ai/build-with-cartesia/sonic-3/ssml-tags (re-checked 2026-07-02); previously logged as temporarily disabled, now re-enabled upstream. Emotion tags remain beta."
+      "notes": "Cartesia publishes Sonic pricing as $1 per 25 minutes of audio output (~$0.04/min). Converted to ~$50/1M chars assuming ~150 WPM (~750 chars/min). Actual $/1M chars varies with speech rate; verify by sampling. IVC voice cloning included (no clone fee). 90ms TTFB. SSML speed/volume tags confirmed available on sonic-3.5 per https://docs.cartesia.ai/build-with-cartesia/sonic-3/ssml-tags (re-checked 2026-07-02); previously logged as temporarily disabled, now re-enabled upstream. Emotion tags remain beta. Re-verified 2026-07-13: still Cartesia's current-recommended model, pricing page still credit/subscription-based with no published per-char rate (no structured price change)."
     },
     {
       "provider": "Cartesia",
@@ -189,12 +189,12 @@
       "voice_cloning": true,
       "replaced_by_model_id": "sonic-3.5",
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://docs.cartesia.ai/build-with-cartesia/tts-models/older-models",
-      "notes": "Newly added row: predecessor to sonic-3.5, still stable and a valid model_id on the TTS API. Latest snapshot sonic-3-2026-01-12; 43 languages. Cartesia recommends sonic-3.5 for best results, most languages, and naturalness. SSML speed/volume tags confirmed available per https://docs.cartesia.ai/build-with-cartesia/sonic-3/ssml-tags. TTFB not published for this specific snapshot. Pricing assumed equal to sonic-3.5 (15 credits/sec of audio); confidence medium because Cartesia does not publish a separate per-model rate on the pricing page. Verify by sampling if cost-critical."
+      "notes": "Predecessor to sonic-3.5, still stable and a valid model_id on the TTS API. Latest snapshot sonic-3-2026-01-12; 43 languages. Cartesia recommends sonic-3.5 for best results, most languages, and naturalness. SSML speed/volume tags confirmed available per https://docs.cartesia.ai/build-with-cartesia/sonic-3/ssml-tags. TTFB not published for this specific snapshot. Pricing assumed equal to sonic-3.5 (15 credits/sec of audio); confidence medium because Cartesia does not publish a separate per-model rate on the pricing page. Verify by sampling if cost-critical. Re-verified 2026-07-13: still stable, same 43-language count, no price change."
     },
     {
       "provider": "Cartesia",
@@ -209,12 +209,12 @@
       "time_to_first_byte_ms": 90,
       "replaced_by_model_id": "sonic-3.5",
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://docs.cartesia.ai/build-with-cartesia/tts-models/older-models",
-      "notes": "Predecessor to sonic-3.5; still stable and callable, but Cartesia recommends sonic-3.5 for new builds. Latest snapshot sonic-2-2025-06-11, supporting 8 core languages (en, fr, de, es, pt, zh, ja, ko). The 7 additional languages previously carrying a 2026-06-01 EOL are no longer listed as supported on this snapshot as of 2026-07-02; languages field reduced from 15+ accordingly. 90ms model latency. Higher-fidelity voice cloning capability. Pricing assumed equal to sonic-3.5 (15 credits/sec of audio); confidence medium because Cartesia did not publish a separate per-model rate. Verify by sampling if cost-critical."
+      "notes": "Predecessor to sonic-3.5; still stable and callable, but Cartesia recommends sonic-3.5 for new builds. Latest snapshot sonic-2-2025-06-11, supporting 8 core languages (en, fr, de, es, pt, zh, ja, ko). The 7 additional languages previously carrying a 2026-06-01 EOL are no longer listed as supported on this snapshot as of 2026-07-02; languages field reduced from 15+ accordingly. 90ms model latency. Higher-fidelity voice cloning capability. Pricing assumed equal to sonic-3.5 (15 credits/sec of audio); confidence medium because Cartesia did not publish a separate per-model rate. Verify by sampling if cost-critical. Re-verified 2026-07-13: snapshot and 8-language count unchanged, no price change."
     },
     {
       "provider": "Cartesia",
@@ -229,12 +229,12 @@
       "time_to_first_byte_ms": 40,
       "replaced_by_model_id": "sonic-3.5",
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://docs.cartesia.ai/build-with-cartesia/tts-models/older-models",
-      "notes": "Lowest-latency Sonic variant (~40ms TTFB). Still stable and callable, but Cartesia recommends sonic-3.5 for new builds. Latest snapshot sonic-turbo-2025-06-04, supporting 9 languages (en, fr, de, es, pt, zh, ja, hi, ko). The 6 additional languages previously carrying a 2026-06-01 EOL are no longer listed as supported on this snapshot as of 2026-07-02; languages field reduced from 15+ accordingly. Pricing assumed equal to sonic-3.5 (15 credits/sec of audio); confidence medium because Cartesia did not publish a separate per-model rate. Verify by sampling if cost-critical."
+      "notes": "Lowest-latency Sonic variant (~40ms TTFB). Still stable and callable, but Cartesia recommends sonic-3.5 for new builds. Latest snapshot sonic-turbo-2025-06-04, supporting 9 languages (en, fr, de, es, pt, zh, ja, hi, ko). The 6 additional languages previously carrying a 2026-06-01 EOL are no longer listed as supported on this snapshot as of 2026-07-02; languages field reduced from 15+ accordingly. Pricing assumed equal to sonic-3.5 (15 credits/sec of audio); confidence medium because Cartesia did not publish a separate per-model rate. Verify by sampling if cost-critical. Re-verified 2026-07-13: snapshot and 9-language count unchanged, no price change."
     },
     {
       "provider": "Groq",
@@ -244,12 +244,12 @@
       "price_per_1m_chars_usd": "22.0",
       "voice_quality": "neural",
       "languages": ["en"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-05",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://groq.com/pricing/",
-      "notes": "Hosted on Groq. Output speed ~100 characters/second. Vendor API model_id is canopylabs/orpheus-v1-english per console.groq.com/docs/models; this row keeps the pre-existing Hail slug for stability."
+      "notes": "Hosted on Groq. Output speed ~100 characters/second. Vendor API model_id is canopylabs/orpheus-v1-english per console.groq.com/docs/models; this row keeps the pre-existing Hail slug for stability. Re-verified 2026-07-13 against groq.com/pricing and console.groq.com/docs/models: price and model_id unchanged; still listed as a preview model."
     },
     {
       "provider": "Groq",
@@ -259,12 +259,12 @@
       "price_per_1m_chars_usd": "40.0",
       "voice_quality": "neural",
       "languages": ["ar-SA"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-05",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://groq.com/pricing/",
-      "notes": "Hosted on Groq. Saudi Arabic variant. Output speed ~100 characters/second. Vendor API model_id is canopylabs/orpheus-arabic-saudi per console.groq.com/docs/models; this row keeps the pre-existing Hail slug for stability."
+      "notes": "Hosted on Groq. Saudi Arabic variant. Output speed ~100 characters/second. Vendor API model_id is canopylabs/orpheus-arabic-saudi per console.groq.com/docs/models; this row keeps the pre-existing Hail slug for stability. Re-verified 2026-07-13 against groq.com/pricing and console.groq.com/docs/models: price and model_id unchanged; still listed as a preview model."
     },
     {
       "provider": "Google",
@@ -278,12 +278,12 @@
       "voice_cloning": false,
       "deployment_options": ["native", "vertex"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://cloud.google.com/text-to-speech/pricing",
-      "notes": "Google's premium TTS tier for professional media production (long-form narration, advertising). Vendor price $0.000160/char = $160/1M chars; the single-speaker Studio class is GA and the multispeaker class is experimental per https://docs.cloud.google.com/text-to-speech/docs/voices. SSML supported except <mark>, <emphasis>, <prosody pitch>, and <lang>. Model_id is a Hail-coined tier slug (Google bills per-voice-tier rather than per API model name). Free tier: first 100K chars/month included (not representable as tokens_per_day in schema). 2026-07-02: primary pricing page returned truncated/nav-heavy content via WebFetch on 5 retries (no pricing table extracted); tier confirmed still active and GA/experimental split unchanged via secondary docs.cloud.google.com/text-to-speech/docs/voices, and price cross-checked against third-party aggregator costbench.com (matches $160). confidence downgraded to medium pending a clean primary-source refetch."
+      "notes": "Google's premium TTS tier for professional media production (long-form narration, advertising). Vendor price $0.000160/char = $160/1M chars; the single-speaker Studio class is GA and the multispeaker class is experimental per https://docs.cloud.google.com/text-to-speech/docs/voices. SSML supported except <mark>, <emphasis>, <prosody pitch>, and <lang>. Model_id is a Hail-coined tier slug (Google bills per-voice-tier rather than per API model name). Free tier: first 100K chars/month included (not representable as tokens_per_day in schema). 2026-07-13 refresh: primary pricing page again returned truncated/nav-heavy content via WebFetch (2 retries, no pricing table extracted); tier confirmed still active and GA/experimental split unchanged via secondary docs.cloud.google.com/text-to-speech/docs/voices (re-fetched, unchanged), and price cross-checked via search-indexed vendor/aggregator content (costbench.com, both confirm $160/1M). confidence remains medium pending a clean primary-source refetch. Price unchanged."
     },
     {
       "provider": "Google",
@@ -297,12 +297,12 @@
       "voice_cloning": false,
       "deployment_options": ["native", "vertex"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://cloud.google.com/text-to-speech/pricing",
-      "notes": "Google's recommended general-purpose neural tier; same per-char rate as WaveNet but newer architecture. Vendor price $0.000016/char = $16/1M chars. SSML fully supported. Model_id is a Hail-coined tier slug (Google bills per-voice-tier rather than per API model name). Free tier: first 1M chars/month included (not representable as tokens_per_day in schema). 2026-07-02: primary pricing page returned truncated/nav-heavy content via WebFetch on 5 retries (no pricing table extracted); tier confirmed still active via secondary docs.cloud.google.com/text-to-speech/docs/voices, and price cross-checked against third-party aggregator costbench.com (matches $16). confidence downgraded to medium pending a clean primary-source refetch."
+      "notes": "Google's recommended general-purpose neural tier; same per-char rate as WaveNet but newer architecture. Vendor price $0.000016/char = $16/1M chars. SSML fully supported. Model_id is a Hail-coined tier slug (Google bills per-voice-tier rather than per API model name). Free tier: first 1M chars/month included (not representable as tokens_per_day in schema). 2026-07-13 refresh: primary pricing page again returned truncated/nav-heavy content via WebFetch (2 retries, no pricing table extracted); tier confirmed still active via secondary docs.cloud.google.com/text-to-speech/docs/voices (re-fetched, unchanged), and price cross-checked via search-indexed vendor/aggregator content (costbench.com, matches $16). confidence remains medium pending a clean primary-source refetch. Price unchanged."
     },
     {
       "provider": "Google",
@@ -316,12 +316,12 @@
       "voice_cloning": false,
       "deployment_options": ["native", "vertex"],
       "confidence": "medium",
-      "last_verified": "2026-05-19",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://cloud.google.com/text-to-speech/pricing",
-      "notes": "Original neural-net voice family from DeepMind; not deprecated as of 2026-05-19 per Cloud TTS release notes (https://docs.cloud.google.com/text-to-speech/docs/release-notes) but Google recommends Neural2 for new projects at the same $16/1M chars rate. SSML fully supported. Model_id is a Hail-coined tier slug. Free tier: first 1M chars/month included. 2026-07-02 refresh: DEFERRED, last_verified intentionally NOT bumped. Primary pricing page returned truncated/nav-heavy content via WebFetch (5 retries, no pricing table extracted). Secondary docs.cloud.google.com/text-to-speech/docs/voices confirms tier still active, SSML support unchanged, no deprecation banner. However two independent third-party aggregators (costbench.com, and a search-engine snippet of cloud.google.com/text-to-speech/pricing) both state WaveNet is priced at $4/1M chars with a 4M-char free tier grouped with Standard voices, not $16/1M chars with a 1M-char free tier as currently recorded — a conflict with this row's existing figures that a vendor-primary refetch must resolve before changing the price field. Kept existing $16 value; do not treat this as confirmed."
+      "notes": "Original neural-net voice family from DeepMind; not deprecated as of 2026-05-19 per Cloud TTS release notes (https://docs.cloud.google.com/text-to-speech/docs/release-notes) but Google recommends Neural2 for new projects at the same $16/1M chars rate. SSML fully supported. Model_id is a Hail-coined tier slug. Free tier: first 1M chars/month included. 2026-07-13 refresh: primary pricing page again returned truncated/nav-heavy content via WebFetch (2 retries, no pricing table extracted). Secondary docs.cloud.google.com/text-to-speech/docs/voices confirms tier still active (GA), SSML support unchanged, no deprecation banner. Prior week's conflict resolved: the 2026-07-02 aggregator claim of $4/1M (grouped with Standard voices) was a mismatch of tiers — Google's own WaveNet doc page (docs.cloud.google.com/text-to-speech/docs/wavenet, surfaced via search) states WaveNet voices get 1M free chars/month then bill at $16.00/1M, matching this row's existing figures; the $4/1M rate belongs to the separate Standard voice tier, not WaveNet. Treating $16/1M chars and the 1M-char free tier as confirmed via secondary + search-indexed vendor doc; last_verified bumped, price unchanged."
     },
     {
       "provider": "Google",
@@ -336,19 +336,19 @@
       "voice_cloning": false,
       "deployment_options": ["native", "vertex"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://cloud.google.com/text-to-speech/pricing",
-      "notes": "Google's newest-generation TTS family with 30 voice styles in 30+ languages. Vendor price $0.000030/char = $30/1M chars. Per https://docs.cloud.google.com/text-to-speech/docs/chirp3-hd, Chirp 3: HD explicitly does NOT support SSML, speaking-rate adjustments, or pitch parameters; streaming synthesis IS supported. Model_id is a Hail-coined tier slug. Free tier: first 1M chars/month included. 2026-07-02: primary pricing page returned truncated/nav-heavy content via WebFetch on 5 retries (no pricing table extracted); tier confirmed still active with unchanged SSML/streaming behavior via secondary docs.cloud.google.com/text-to-speech/docs/voices, and price cross-checked against third-party aggregator costbench.com (matches $30). confidence downgraded to medium pending a clean primary-source refetch."
+      "notes": "Google's newest-generation TTS family with 30 voice styles in 30+ languages. Vendor price $0.000030/char = $30/1M chars. Per https://docs.cloud.google.com/text-to-speech/docs/chirp3-hd, Chirp 3: HD explicitly does NOT support SSML, speaking-rate adjustments, or pitch parameters; streaming synthesis IS supported. Model_id is a Hail-coined tier slug. Free tier: first 1M chars/month included. 2026-07-13 refresh: primary pricing page again returned truncated/nav-heavy content via WebFetch (2 retries, no pricing table extracted); tier confirmed still active (GA) with unchanged SSML/streaming behavior via secondary docs.cloud.google.com/text-to-speech/docs/voices (re-fetched, unchanged), and price cross-checked via search-indexed vendor/aggregator content (costbench.com, matches $30). confidence remains medium pending a clean primary-source refetch. Price unchanged."
     },
     {
       "provider": "Microsoft Azure",
       "provider_url": "https://azure.microsoft.com",
       "model_id": "azure-tts-neural",
       "display_name": "Azure AI Speech — Neural",
-      "price_per_1m_chars_usd": "16.0",
+      "price_per_1m_chars_usd": "15.0",
       "voice_quality": "neural",
       "languages": "100+",
       "ssml_supported": true,
@@ -356,12 +356,12 @@
       "voice_cloning": false,
       "deployment_options": ["azure"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
-      "last_changed_at": "2026-05-19",
+      "last_verified": "2026-07-13",
+      "last_changed_at": "2026-07-13",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services/",
-      "notes": "Azure's standard neural TTS tier (called 'Neural' on the pricing page; 'Standard voice' in docs). 500+ prebuilt voices across 100+ locales per https://learn.microsoft.com/en-us/azure/ai-services/speech-service/text-to-speech. S0 pay-as-you-go price $16/1M chars for both real-time and batch synthesis (HD, AOAI, Custom Neural Voice, and Personal Voice priced separately). Full SSML support. Chinese characters counted as 2 chars for billing. Free tier (F0): 500K chars/month. 2026-07-02 refresh: primary pricing page unreachable via WebFetch (ETIMEDOUT/ECONNREFUSED across 7 attempts on multiple URL variants — likely a session-side connectivity issue with azure.microsoft.com, not a vendor-side change). Price cross-checked and confirmed unchanged at $16/1M via two independent third-party aggregators (costbench.com/software/ai-voice-tools/microsoft-speech/, last-verified-on-page Apr 24 2026; texttolab.com/blog/azure-text-to-speech-pricing) plus a search-engine snippet quoting the vendor page directly. Free tier (500K chars/month) also corroborated by both aggregators. confidence downgraded to medium pending a clean primary-source refetch."
+      "notes": "Azure's standard neural TTS tier (called 'Neural' on the pricing page; 'Standard voice' in docs). 500+ prebuilt voices across 100+ locales per https://learn.microsoft.com/en-us/azure/ai-services/speech-service/text-to-speech (reconfirmed 2026-07-13: 100+ languages/locales, full SSML support, unchanged). S0 pay-as-you-go price for both real-time and batch synthesis (HD, AOAI, Custom Neural Voice, and Personal Voice priced separately). Chinese characters counted as 2 chars for billing. Free tier (F0): 500K chars/month. 2026-07-13 refresh: primary marketing pricing page again unreachable via WebFetch (timeout across 4 attempts, multiple URL variants — same persistent issue noted in the 2026-07-02 refresh). Queried Microsoft's own public Azure Retail Prices API directly (https://prices.azure.com/api/retail/prices, meterName 'S1 Neural Text To Speech Characters', productName 'Azure Speech', meterId 0f98e708-a16c-407b-8089-a0ed9e14ab49): retailPrice is $15.00/1M chars for the Global meter and all commercial regions (US Gov regions bill $18.75/1M), with effectiveStartDate 2024-02-01 — i.e. this rate has been continuously in effect since Feb 2024, not a fresh vendor price change this week. This is Microsoft's own first-party billing-meter API, more authoritative than the marketing page or any third-party recap. price_per_1m_chars_usd corrected from '16.0' to '15.0' to match the live meter — this appears to fix a stale figure carried forward from earlier refreshes. Note: multiple third-party aggregators (costbench.com, texttolab.com) and general web search still report '$16/1M' as of mid-2026, apparently echoing each other or a stale marketing-page snapshot rather than the live billing meter; none could be reconciled against prices.azure.com. confidence held at medium pending a clean fetch of the live marketing pricing page to confirm its displayed sticker price matches the billing meter."
     },
     {
       "provider": "Microsoft Azure",
@@ -379,12 +379,12 @@
       "voice_cloning": false,
       "deployment_options": ["azure"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-03-01",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services/",
-      "notes": "Azure's premium HD neural tier (DragonHD architecture, 30+ GA voices). Per https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/azure-speech-%E2%80%93-neural-hd-text-to-speech-recent-voice-updates/4505380, Azure reduced Neural HD pricing to $22/1M chars effective March 2026 (down from $30/1M). Latency <300ms, real-time only. SSML support is partial (no <prosody>, <emphasis>, <break>); we mark ssml_supported=false because the elements most callers want are unsupported. Automatic emotion/sentiment detection drives delivery (emotion_control_supported=true). DragonHDOmni (700+ voices, mixed GA/preview) and DragonHDFlash (en-US/zh-CN only) are distinct models tracked separately if added later. Confidence medium because the pricing-page value was sourced via third-party recap (techcommunity blog) — verify on the live Azure pricing page before high-volume use. 2026-07-02 refresh: primary pricing page still unreachable via WebFetch (ETIMEDOUT across 7 attempts, multiple URL variants). $22/1M price and 30+ voice count reconfirmed unchanged via two independent third-party aggregators (costbench.com, texttolab.com — both explicitly state '$22/1M, reduced from $30 in March 2026') plus learn.microsoft.com/en-us/azure/ai-services/speech-service/high-definition-voices, which confirms voice count ('30+ fine-tuned voices'), the en-US/de-DE/es-ES/fr-FR/ja-JP/zh-CN locale set, and partial SSML support (no <prosody> or <emphasis>) are all unchanged. DragonHD Omni (700+ voices) and DragonHD Flash (zh-CN/en-US optimized variants) confirmed to exist and be documented as of this refresh, but no vendor or third-party pricing was found for either — deferred as new rows pending a priced, in-file-verifiable model_id."
+      "notes": "Azure's premium HD neural tier (DragonHD architecture, 30+ GA voices). Per https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/azure-speech-%E2%80%93-neural-hd-text-to-speech-recent-voice-updates/4505380, Azure reduced Neural HD pricing to $22/1M chars effective March 2026 (down from $30/1M). Latency <300ms, real-time only. SSML support is partial; per the current supported/unsupported SSML table at learn.microsoft.com/en-us/azure/ai-services/speech-service/high-definition-voices, DragonHD (non-Omni) supports <voice>, <lang>, <phoneme>, <lexicon> (alias only), <say-as>, <sub>, <break>, <p>, <s>, but NOT <mstts:express-as>, <prosody>, <emphasis>, <audio>, <mstts:audioduration>, <mstts:backgroundaudio>, <math>, <bookmark>, <mstts:silence>, <mstts:viseme>; we mark ssml_supported=false because <prosody>/<emphasis>, the elements most callers want, are unsupported (2026-07-13: corrected note — <break> IS actually supported for DragonHD per the current doc table, unlike what a prior refresh's note implied). Automatic emotion/sentiment detection drives delivery (emotion_control_supported=true). DragonHDOmni (700+ voices, mixed GA/preview) and DragonHDFlash (en-US/zh-CN only) are distinct models tracked separately if added later. Confidence medium because the pricing-page value was originally sourced via third-party recap (techcommunity blog) — verify on the live Azure pricing page before high-volume use. 2026-07-13 refresh: primary marketing pricing page again unreachable via WebFetch (timeout across 4 attempts, multiple URL variants — same persistent issue as 2026-07-02). $22/1M reconfirmed unchanged via Microsoft's own Azure Retail Prices API (https://prices.azure.com/api/retail/prices, meterName 'Neural HD Text to Speech Characters', productName 'Azure Speech', meterId ad55d150-6182-5565-acf9-364d6ed979fb): retailPrice $22.00/1M chars (Global meter), effectiveStartDate 2026-03-01 — matches the March 2026 cut recorded here exactly, confirming no further change since. 30+ voice count, the en-US/de-DE/es-ES/fr-FR/ja-JP/zh-CN locale set, and the SSML support table reconfirmed via a direct fetch of learn.microsoft.com/en-us/azure/ai-services/speech-service/high-definition-voices (28 named DragonHD voices listed, 3 of them Preview status; six locales exactly matching this row). DragonHD Omni (700+ voices) and DragonHD Flash (zh-CN/en-US optimized variants, confirmed via the same doc to list 17 named Flash voices) still have no distinct billing meter in the Azure Retail Prices API (checked directly, no 'Omni' or 'Flash' Speech meters found) — deferred as new rows pending a priced, in-file-verifiable model_id."
     },
     {
       "provider": "Inworld",
@@ -397,12 +397,12 @@
       "streaming_supported": true,
       "voice_cloning": true,
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://inworld.ai/pricing",
-      "notes": "Inworld's flagship Realtime TTS-2 model with natural-language steering and 100+ language support (docs.inworld.ai cites 200+ languages/locales). Pricing tiers restructured since last check: On-Demand (PAYG) rate now $25/1M chars (was $35), Creator $20, Builder $17.50, Developer $15, Growth $12.50, Enterprise as low as $5/1M. Instant voice cloning, custom pronunciation, and enhanced timestamp/viseme alignment included. The older inworld-tts-1 and inworld-tts-1-max were discontinued June 15, 2026 per docs.inworld.ai/tts/tts-models (auto-rerouted to inworld-tts-1.5-mini and inworld-tts-1.5-max respectively, neither of which was previously tracked — added as separate rows this pass)."
+      "notes": "Inworld's flagship Realtime TTS-2 model with natural-language steering and 100+ language support (docs.inworld.ai cites 200+ languages/locales). Pricing tiers restructured since last check: On-Demand (PAYG) rate now $25/1M chars (was $35), Creator $20, Builder $17.50, Developer $15, Growth $12.50, Enterprise as low as $5/1M. Instant voice cloning, custom pronunciation, and enhanced timestamp/viseme alignment included. The older inworld-tts-1 and inworld-tts-1-max were discontinued June 15, 2026 per docs.inworld.ai/tts/tts-models (auto-rerouted to inworld-tts-1.5-mini and inworld-tts-1.5-max respectively, neither of which was previously tracked — added as separate rows this pass). 2026-07-13 refresh: pricing page and docs re-verified via WebFetch, all tiers and rates unchanged; no new models launched; no further deprecation activity."
     },
     {
       "provider": "Inworld",
@@ -431,12 +431,12 @@
       "streaming_supported": true,
       "voice_cloning": true,
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://inworld.ai/pricing",
-      "notes": "Active alternative to TTS-2, tuned for maximum stability across 15 languages. Vendor-reported <200ms median latency. On-Demand (PAYG) rate $35/1M chars; Creator $25, Builder $22.50, Developer $20, Growth $17.50, Enterprise custom. Instant voice cloning and enhanced timestamps included. Successor to discontinued inworld-tts-1-max per https://docs.inworld.ai/tts/tts-models."
+      "notes": "Active alternative to TTS-2, tuned for maximum stability across 15 languages. Vendor-reported <200ms median latency. On-Demand (PAYG) rate $35/1M chars; Creator $25, Builder $22.50, Developer $20, Growth $17.50, Enterprise custom. Instant voice cloning and enhanced timestamps included. Successor to discontinued inworld-tts-1-max per https://docs.inworld.ai/tts/tts-models. 2026-07-13 refresh: rate and language list reconfirmed unchanged via pricing page and docs."
     },
     {
       "provider": "Inworld",
@@ -465,12 +465,12 @@
       "streaming_supported": true,
       "voice_cloning": true,
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://inworld.ai/pricing",
-      "notes": "Low-latency tier across the same 15 languages as 1.5 Max. Vendor-reported ~120ms median latency (~160ms P90 first-chunk). On-Demand (PAYG) rate $15/1M chars; Creator $10, Builder $9, Developer $8, Growth $7, Enterprise custom. Instant voice cloning and enhanced timestamps included; also available for on-premises deployment. Successor to discontinued inworld-tts-1 per https://docs.inworld.ai/tts/tts-models."
+      "notes": "Low-latency tier across the same 15 languages as 1.5 Max. Vendor-reported ~120ms median latency (~160ms P90 first-chunk). On-Demand (PAYG) rate $15/1M chars; Creator $10, Builder $9, Developer $8, Growth $7, Enterprise custom. Instant voice cloning and enhanced timestamps included; also available for on-premises deployment. Successor to discontinued inworld-tts-1 per https://docs.inworld.ai/tts/tts-models. 2026-07-13 refresh: rate and language list reconfirmed unchanged via pricing page and docs."
     },
     {
       "provider": "Smallest.ai",
@@ -502,12 +502,12 @@
       "time_to_first_byte_ms": 200,
       "deployment_options": ["native"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://smallest.ai/pricing",
-      "notes": "Smallest.ai's current standard TTS model (44.1 kHz native, ~200ms TTFB at 40 concurrent requests). 2026-07-02 refresh: canonical API model_id corrected from 'lightning-v3.1' (hyphen, Hail-coined) to 'lightning_v3.1' (underscore) per exact string confirmed in code samples on https://docs.smallest.ai/waves/model-cards/text-to-speech/lightning-v-3-1 ('\"model\": \"lightning_v3.1\"'); old id kept as alias. Price dropped from $25/1M to $17.5/1M chars (~$0.175/10k chars), confirmed via rendered pricing-page text (both AI-summarized and raw-HTML grep of the live page); note the page's stale JSON-LD schema.org markup still advertises the old ~$0.25/10k figure for its 'Pro' *subscription* tier description, so confidence downgraded to medium pending a secondary source that states the exact number (docs.smallest.ai defers pricing to the pricing page and does not restate figures). Output formats corrected to match vendor's exact list (added alaw; mulaw renamed to ulaw per vendor terminology) — sample rates and voice/language counts unchanged. New sibling model added this refresh: lightning_v3.1_pro. Lightning v2 and lightning-large remain deprecated per https://docs.smallest.ai/waves/documentation/getting-started/models — new integrations should use lightning_v3.1 or lightning_v3.1_pro. WebSocket streaming for real-time/conversational use. Instant + professional voice cloning supported. On-prem available on Enterprise plan."
+      "notes": "Smallest.ai's current standard TTS model (44.1 kHz native, ~200ms TTFB at 40 concurrent requests). 2026-07-02 refresh: canonical API model_id corrected from 'lightning-v3.1' (hyphen, Hail-coined) to 'lightning_v3.1' (underscore) per exact string confirmed in code samples on https://docs.smallest.ai/waves/model-cards/text-to-speech/lightning-v-3-1 ('\"model\": \"lightning_v3.1\"'); old id kept as alias. Price dropped from $25/1M to $17.5/1M chars (~$0.175/10k chars), confirmed via rendered pricing-page text (both AI-summarized and raw-HTML grep of the live page); note the page's stale JSON-LD schema.org markup still advertises the old ~$0.25/10k figure for its 'Pro' *subscription* tier description, so confidence downgraded to medium pending a secondary source that states the exact number (docs.smallest.ai defers pricing to the pricing page and does not restate figures). Output formats corrected to match vendor's exact list (added alaw; mulaw renamed to ulaw per vendor terminology) — sample rates and voice/language counts unchanged. New sibling model added this refresh: lightning_v3.1_pro. Lightning v2 and lightning-large remain deprecated per https://docs.smallest.ai/waves/documentation/getting-started/models — new integrations should use lightning_v3.1 or lightning_v3.1_pro. WebSocket streaming for real-time/conversational use. Instant + professional voice cloning supported. On-prem available on Enterprise plan. 2026-07-13 refresh: re-verified via smallest.ai/pricing ($17.5/1M chars unchanged, no deprecation banner) and docs.smallest.ai model card (12-language list, voice cloning support, sample rates/output formats, 200ms TTFB all unchanged). Vendor's getting-started/models catalog still lists only lightning_v3.1 and lightning_v3.1_pro as active — no new TTS model launches found."
     },
     {
       "provider": "Smallest.ai",
@@ -516,7 +516,37 @@
       "display_name": "Lightning v3.1 Pro",
       "price_per_1m_chars_usd": "19.5",
       "voice_quality": "neural",
-      "languages": ["en", "hi"],
+      "languages": [
+        "en",
+        "hi",
+        "mr",
+        "ta",
+        "ml",
+        "te",
+        "kn",
+        "pa",
+        "bn",
+        "or",
+        "gu",
+        "ar",
+        "zh",
+        "id",
+        "ja",
+        "ko",
+        "ms",
+        "tr",
+        "vi",
+        "de",
+        "es",
+        "fr",
+        "it",
+        "pt",
+        "ru",
+        "el",
+        "fi",
+        "no",
+        "pl"
+      ],
       "streaming_supported": true,
       "voice_cloning": false,
       "output_formats": ["pcm", "mp3", "wav", "ulaw", "alaw"],
@@ -524,12 +554,12 @@
       "time_to_first_byte_ms": 200,
       "deployment_options": ["native"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-07-02",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://smallest.ai/pricing",
-      "notes": "New row: premium 44.1 kHz-native pool with a curated voice catalog (American, British, and Indian accents), same ~200ms TTFB latency profile as standard Lightning v3.1. Only English (UK+American accent) and Hindi (Indian-English + Hindi code-switching) supported, vs. 12 languages on the standard model; omitting the language param defaults to en+hi. Voice cloning explicitly NOT available on the Pro pool per https://docs.smallest.ai/waves/model-cards/text-to-speech/lightning-v-3-1-pro ('No voice cloning. Voice cloning is not available on the Pro pool.'). Model_id 'lightning_v3.1_pro' confirmed verbatim in both the pricing page audio-sample caption and the docs model card. Vendor rate ~$0.195/10k chars = $19.5/1M chars, confirmed via rendered pricing-page text (AI-summarized + raw-HTML grep); confidence medium because the secondary docs source does not restate the exact price (defers to pricing page). voices_count omitted — vendor describes a 'curated catalog' without publishing an exact number for this pool."
+      "notes": "New row (2026-07-02): premium 44.1 kHz-native pool with a curated voice catalog (American, British, and Indian accents), same ~200ms TTFB latency profile as standard Lightning v3.1. Voice cloning explicitly NOT available on the Pro pool per https://docs.smallest.ai/waves/model-cards/text-to-speech/lightning-v-3-1-pro ('No voice cloning. Voice cloning is not available on the Pro pool.'). Model_id 'lightning_v3.1_pro' confirmed verbatim in both the pricing page audio-sample caption and the docs model card. Vendor rate ~$0.195/10k chars = $19.5/1M chars, confirmed via rendered pricing-page text (AI-summarized + raw-HTML grep); confidence medium because the secondary docs source does not restate the exact price (defers to pricing page). voices_count omitted — vendor describes a 'curated catalog' without publishing an exact number for this pool. 2026-07-13 refresh: languages field corrected 2->29 — the docs model card (docs.smallest.ai/waves/model-cards/text-to-speech/lightning-v-3-1-pro) now states 'English + Hindi, plus 27 more (9 Indian, 8 Asian & Middle Eastern, 10 European)' vs. the en/hi-only description recorded at row creation; not a price change so last_changed_at not bumped. Price ($19.5/1M), voice-cloning-unavailable status, sample rates/formats, and 200ms TTFB reconfirmed unchanged via smallest.ai/pricing and the docs model card."
     },
     {
       "provider": "Rime",
@@ -545,12 +575,12 @@
       "time_to_first_byte_ms": 37,
       "deployment_options": ["native"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://rime.ai/pricing",
-      "notes": "Rime's current Mist-family flagship; English-only. Model_id, capabilities, voice count (94), and lack of custom pronunciation/pauses on mistv3 reconfirmed unchanged via https://docs.rime.ai/api-reference/models, which now quotes '~37ms P50' TTFA/TTFB for Mist v3 (tightened from the prior 'sub-100ms' figure; time_to_first_byte_ms updated 100->37, not a price field so last_changed_at not bumped). 2026-07-02 refresh: rime.ai/pricing was restructured (page timestamp Jul 1, 2026) from the old per-model $/char table to a flat 'Starter: $0.05/1K characters, Enterprise: custom' layout with no per-model breakdown visible for Mist/Coda/Arcana; three separate fetches of the live page and a web search found no text attributing $0.05/1K specifically to mistv3. A Mar 2025 Rime blog post (rime.ai/resources/new-pricing) shows an unrelated subscription-tier ladder ($5/100k, $19/500k, $99/3M, $249/10M chars/mo) that also doesn't differentiate by model, while an older post (rime.ai/resources/introducing-new-pricing) restates the legacy per-model figures matching this row's existing $30/1M for Mist alongside Arcana $40/1M and Coda $50/1M -- consistent with the value on file but not a fresh primary-source confirmation. Given the primary source no longer states a model-specific rate, kept the existing $30/1M value rather than guess; confidence downgraded to medium pending a vendor page that re-publishes per-model pricing or direct sales confirmation. Coda (184 voices, 6 languages incl. ES/FR/PT/DE/JA) and Arcana (now at v3, 94 voices, multilingual; Rime recommends migrating Arcana deployments to Coda) remain distinct models tracked separately if added later -- deferred again this refresh for the same pricing-opacity reason. Voice cloning not documented for Mist; available via Enterprise plan for custom voices."
+      "notes": "Rime's current Mist-family flagship; English-only. Model_id, capabilities, voice count (94), and lack of custom pronunciation/pauses on mistv3 reconfirmed unchanged via https://docs.rime.ai/api-reference/models, which now quotes '~37ms P50' TTFA/TTFB for Mist v3 (tightened from the prior 'sub-100ms' figure; time_to_first_byte_ms updated 100->37, not a price field so last_changed_at not bumped). 2026-07-02 refresh: rime.ai/pricing was restructured (page timestamp Jul 1, 2026) from the old per-model $/char table to a flat 'Starter: $0.05/1K characters, Enterprise: custom' layout with no per-model breakdown visible for Mist/Coda/Arcana; three separate fetches of the live page and a web search found no text attributing $0.05/1K specifically to mistv3. A Mar 2025 Rime blog post (rime.ai/resources/new-pricing) shows an unrelated subscription-tier ladder ($5/100k, $19/500k, $99/3M, $249/10M chars/mo) that also doesn't differentiate by model, while an older post (rime.ai/resources/introducing-new-pricing) restates the legacy per-model figures matching this row's existing $30/1M for Mist alongside Arcana $40/1M and Coda $50/1M -- consistent with the value on file but not a fresh primary-source confirmation. Given the primary source no longer states a model-specific rate, kept the existing $30/1M value rather than guess; confidence downgraded to medium pending a vendor page that re-publishes per-model pricing or direct sales confirmation. Coda (184 voices, 6 languages incl. ES/FR/PT/DE/JA) and Arcana (now at v3, 94 voices, multilingual; Rime recommends migrating Arcana deployments to Coda) remain distinct models tracked separately if added later -- deferred again this refresh for the same pricing-opacity reason. Voice cloning not documented for Mist; available via Enterprise plan for custom voices. 2026-07-13 refresh: rime.ai/pricing (fetched, page timestamp Jul 10, 2026 6:27pm UTC) still shows only the flat Starter $0.05/1K-chars / Enterprise-custom layout with zero per-model breakdown -- same opacity as the 2026-07-02 pass, so the existing $30/1M value is kept unverified-by-primary and confidence stays medium. docs.rime.ai/api-reference/models reconfirms mistv3 as 'Current (Mar 2026)' with model_id, 94 voices, EN-only, streaming, no voice cloning, and ~37ms P50 latency all unchanged, and additionally documents two more models not in this dataset: mistv2 (model_id 'mistv2', 94 voices, EN+ES, ~70ms on-prem, supports custom pronunciation) and legacy 'mist' (model_id 'mist', deprecated in favor of v2/v3) -- neither is added this pass because, like Coda/Arcana, no source states a per-model price and the two-source price rule can't be met. No deprecation banner on mistv3 itself."
     },
     {
       "provider": "LMNT",
@@ -564,12 +594,12 @@
       "voice_cloning": true,
       "deployment_options": ["native"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://www.lmnt.com/pricing",
-      "notes": "LMNT's flagship Blizzard 2.0 model (canonical model_id 'blizzard' per https://docs.lmnt.com/models/overview). 31 languages with accent control, word timestamps, streaming, voice cloning, and speech sessions. Confidence medium because LMNT publishes plan-bundled pricing (Indie $10/mo for 200K chars + $0.05/1K overage; Pro $49/mo + $0.045/1K overage; Premium $199/mo + $0.035/1K overage) rather than a standalone PAYG per-char rate — $50/1M shown here is the Indie-tier overage rate. Free tier includes 15K characters/month with no overage rate (not representable as tokens_per_day in schema). Premium tier overage is $0.035/1K = $35/1M — large customers should benchmark on their own plan. 2026-07-02 refresh: re-verified via www.lmnt.com/pricing and docs.lmnt.com/models/overview — Indie/Pro/Premium plan pricing, overage rates, and Blizzard 2.0 as sole canonical model_id all unchanged; no new model_ids or deprecation notices found."
+      "notes": "LMNT's flagship Blizzard 2.0 model (canonical model_id 'blizzard' per https://docs.lmnt.com/models/overview). 31 languages with accent control, word timestamps, streaming, voice cloning, and speech sessions. Confidence medium because LMNT publishes plan-bundled pricing (Indie $10/mo for 200K chars + $0.05/1K overage; Pro $49/mo + $0.045/1K overage; Premium $199/mo + $0.035/1K overage) rather than a standalone PAYG per-char rate — $50/1M shown here is the Indie-tier overage rate. Free tier includes 15K characters/month with no overage rate (not representable as tokens_per_day in schema). Premium tier overage is $0.035/1K = $35/1M — large customers should benchmark on their own plan. 2026-07-02 refresh: re-verified via www.lmnt.com/pricing and docs.lmnt.com/models/overview — Indie/Pro/Premium plan pricing, overage rates, and Blizzard 2.0 as sole canonical model_id all unchanged; no new model_ids or deprecation notices found. 2026-07-13 refresh: re-verified via both sources again — Free $0/15K chars, Indie $10/mo+$0.05/1K, Pro $49/mo+$0.045/1K, Premium $199/mo+$0.035/1K, Blizzard 2.0 (model_id 'blizzard') as sole canonical model_id, 31-language/streaming/voice-cloning feature set, all unchanged; no new model_ids or deprecation notices found."
     },
     {
       "provider": "Deepgram",
@@ -583,12 +613,12 @@
       "voice_cloning": false,
       "output_formats": ["wav", "mp3", "linear16", "mulaw", "alaw", "opus"],
       "deployment_options": ["native"],
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-19",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://deepgram.com/pricing",
-      "notes": "Deepgram's current TTS family, addressed as 'aura-2-<voice>-<lang>' (e.g., aura-2-thalia-en) per https://developers.deepgram.com/docs/tts-models. Vendor rate $0.030/1K chars = $30/1M chars on Pay-As-You-Go; Growth tier $0.027/1K = $27/1M. Voice counts by language (90 total): en 40, es 17, nl 9, fr 2, de 7, it 10, ja 5. Free tier ships $200 of signup credit applicable to all products (not representable as tokens_per_day in schema). Aura 1 (legacy, 'aura-<voice>-<lang>', English-only, $0.0150/1K PAYG) remains callable but Deepgram recommends Aura 2 for new integrations; not tracked as a separate row (not a new launch)."
+      "notes": "Deepgram's current TTS family, addressed as 'aura-2-<voice>-<lang>' (e.g., aura-2-thalia-en) per https://developers.deepgram.com/docs/tts-models. Vendor rate $0.030/1K chars = $30/1M chars on Pay-As-You-Go; Growth tier $0.027/1K = $27/1M. Voice counts by language (90 total): en 40, es 17, nl 9, fr 2, de 7, it 10, ja 5. Free tier ships $200 of signup credit applicable to all products (not representable as tokens_per_day in schema). Aura 1 (legacy, 'aura-<voice>-<lang>', English-only, $0.0150/1K PAYG) remains callable but Deepgram recommends Aura 2 for new integrations; not tracked as a separate row (not a new launch). 2026-07-13 refresh: re-verified via deepgram.com/pricing and developers.deepgram.com/docs/tts-models — PAYG/Growth rates, 7-language/90-voice count, output formats, and streaming support all unchanged; no new Deepgram TTS model_ids found and no deprecation notice for Aura 1 or Aura 2."
     },
     {
       "provider": "Resemble AI",
@@ -601,12 +631,12 @@
       "voice_cloning": true,
       "deployment_options": ["native"],
       "confidence": "medium",
-      "last_verified": "2026-07-02",
+      "last_verified": "2026-07-13",
       "last_changed_at": "2026-05-26",
       "verification_method": "manual-confirmed",
       "verified_by": "r13i",
       "source_url": "https://www.resemble.ai/pricing",
-      "notes": "Resemble bills TTS per second of generated audio at a flat $0.0005/sec on their Flex (pay-as-you-go) plan; the rate is not split per model. Chatterbox Turbo is Resemble's flagship English TTS per https://www.resemble.ai (also open-sourced at https://github.com/resemble-ai/chatterbox, 'SoTA open-source TTS'). Confidence medium because the pricing page lists the rate against the service category 'Text-to-speech' rather than naming Chatterbox Turbo specifically, and the API's exact 'model' parameter slug was not verified against live docs. Multilingual ('Chatterbox Multilingual') and dramatic-read ('DramaBox') variants are marketed separately; modeled here as the English flagship only. Re-verified 2026-07-02: rate unchanged at $0.0005/sec, model still listed as active on both resemble.ai/pricing and github.com/resemble-ai/chatterbox; no per-model pricing split found, so the model-id ambiguity noted above persists."
+      "notes": "Resemble bills TTS per second of generated audio at a flat $0.0005/sec on their Flex (pay-as-you-go) plan; the rate is not split per model. Chatterbox Turbo is Resemble's flagship English TTS per https://www.resemble.ai (also open-sourced at https://github.com/resemble-ai/chatterbox, 'SoTA open-source TTS'). Confidence medium because the pricing page lists the rate against the service category 'Text-to-speech' rather than naming Chatterbox Turbo specifically, and the API's exact 'model' parameter slug was not verified against live docs. Multilingual ('Chatterbox Multilingual') and dramatic-read ('DramaBox') variants are marketed separately; modeled here as the English flagship only. Re-verified 2026-07-02: rate unchanged at $0.0005/sec, model still listed as active on both resemble.ai/pricing and github.com/resemble-ai/chatterbox; no per-model pricing split found, so the model-id ambiguity noted above persists. Re-verified 2026-07-13: rate still $0.0005/sec flat on resemble.ai/pricing; Chatterbox Turbo (350M params, English, paralinguistic tags) confirmed still current per github.com/resemble-ai/chatterbox. Also checked docs.resemble.ai (TTS overview + API reference) for a documented 'model' request parameter that would resolve the model-id ambiguity — none found; no per-model pricing split exists. Pricing/marketing copy also names 'Chatterbox Nano' and 'Chatterbox Flash' alongside Turbo/Multilingual/DramaBox, but none have a discoverable canonical API model_id or distinct price, so not added as rows per the two-source + canonical-model_id rule."
     }
   ]
 }

--- a/docs/operations/refresh-costs.md
+++ b/docs/operations/refresh-costs.md
@@ -32,7 +32,7 @@ These are non-negotiable per the project's tenets and the v0.2 design spec. Read
 4. **Two source verifies = the bar.** "Vendor pricing page is unreachable" or "model_id not in docs" means defer with a documented reason. Do not guess.
 5. **`last_verified` always bumps** on touched rows. **`last_changed_at` only bumps** if a structured price field actually moved.
 6. **Field order convention** (see "Field order" below). Match exactly.
-7. **No `git commit`.** Stage changes; produce a commit message; let the operator commit.
+7. **No destructive git in the shared tree.** This runbook's default model has every provider-agent editing the **same** working tree, so a subagent must never run a git command that reverts or discards it — `git checkout`, `git restore`, `git stash`, `git reset` — nor `git commit`/`git add`. A `checkout`/`restore` on a shared `costs/*.json` reverts the whole file and silently wipes every other provider's in-flight edits — it cost a full LLM sweep once. Fix broken formatting with the `Edit` tool or `pnpm exec prettier --write costs/<category>.json`, never git. Leave files modified-but-unstaged; produce a commit message; let the operator commit. (Giving each provider its **own** git worktree makes git safe per-agent — but then add a step to collate each worktree's single-file edit back, which is why the default is one shared tree + sequential dispatch.)
 
 ## Per-row data model (cheat sheet)
 
@@ -279,8 +279,9 @@ You are running a weekly cost-data refresh for {provider} in the Hail Costs Data
 
 ## Workflow constraints
 
-- NEVER run `git commit`.
+- You share ONE working tree with the other provider-agents. Never run a git command that reverts or discards it — `git checkout`, `git restore`, `git stash`, `git reset` — nor `git commit`/`git add`. A `checkout`/`restore` on `costs/{category}.json` reverts the whole shared file and destroys other providers' uncommitted edits. Fix broken formatting with the `Edit` tool or `pnpm exec prettier --write costs/{category}.json` — never with git.
 - You may edit `costs/{category}.json` and leave it modified-but-unstaged.
+- The controller runs providers **sequentially**, never in parallel — they all edit the same file.
 
 ## Project context
 
@@ -345,7 +346,7 @@ If the primary page is unreachable via WebFetch, fall back to the secondary. If 
 
 7. Run `pnpm site:build`. Must pass.
 
-8. Do NOT stage or commit.
+8. Do NOT run any git command — no stage, commit, checkout, restore, stash, or reset.
 
 ## Report
 


### PR DESCRIPTION
Full-catalog re-verification of all 36 providers against live vendor pricing pages. All 134 rows bumped last_verified to 2026-07-13.

New rows (12; most confidence:medium — review before trusting):
- OpenAI LLM: gpt-5.6-sol ($5/$30), gpt-5.6-terra ($2.5/$15), gpt-5.6-luna ($1/$6), gpt-5.5-pro ($30/$180), gpt-5.4-pro ($30/$180)
- xAI LLM: grok-4.5 ($2/$6), grok-build-0.1 ($1/$2)
- Alibaba LLM: qwen3.6-flash ($0.25/$1.5), qwen3.7-plus ($0.4/$1.6)
- OpenAI STT: gpt-4o-transcribe ($0.006/min), gpt-4o-mini-transcribe ($0.003/min), gpt-4o-transcribe-diarize ($0.006/min)

Price changes on existing rows (1):
- Azure TTS azure-tts-neural: $16.0 -> $15.0 per 1M chars

Field corrections (no price move):
- OpenAI gpt-4o replaced_by_model_id: gpt-4.1 -> gpt-5.5
- OpenAI o4-mini replaced_by_model_id: gpt-5-mini -> gpt-5.4-mini
- xAI grok-code-fast-1 now replaced_by grok-build-0.1

New deprecations marked: none beyond the above.

Defers: OpenAI chat-latest (rolling alias), gpt-5.3-codex (coding- specialized, out of scope), bare gpt-5.6 alias (unconfirmed); Hume, PlayHT, Unreal Speech TTS remain deferred (no canonical API model_id).

Validation: check-jsonschema ok on all three; jq referential checks clean; pnpm site:build passes.