### PR TITLE
fix(infra): terragrunt.hcl still read the renamed mail-prefix env var's old name

### DIFF
--- a/infra/terragrunt.hcl
+++ b/infra/terragrunt.hcl
@@ -10,7 +10,7 @@ locals {
   state_region          = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$${HAIL_TERRAFORM_STATE_REGION:-$${AWS_REGION:-us-east-1}}\"")
   state_bucket          = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_TERRAFORM_STATE_BUCKET\"")
   lock_table            = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_TERRAFORM_LOCK_TABLE\"")
-  name_prefix           = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_INBOUND_EMAIL_NAME_PREFIX\"")
+  name_prefix           = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_MAIL_NAME_PREFIX\"")
   iam_user_name         = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_IAM_USER_NAME\"")
   hail_api_url          = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_API_URL\"")
   hail_inbound_secret   = run_cmd("--terragrunt-quiet", "bash", "-c", "source ${local.env_file} && echo -n \"$HAIL_INBOUND_HMAC_SECRET\"")


### PR DESCRIPTION
## Summary
- `infra/terragrunt.hcl`'s `name_prefix` local sourced `HAIL_INBOUND_EMAIL_NAME_PREFIX`, which PR #19's S3 bucket/client rename replaced with `HAIL_MAIL_NAME_PREFIX` everywhere else.
- Missed at the time because it's a `.hcl` file, outside the `.py`/`.go`/`.tf` stray-reference grep that PR ran.
- Once a real `.env` is updated to the new var name, `local.name_prefix` silently resolves to an empty string, cascading into blank-prefixed resource names — which made a real `terraform apply` try to replace the SES receipt rule set (and AWS refuses to delete an active rule set via the API), among other things.

## Test plan
- [x] `terragrunt hcl format` (pre-commit hook) accepts the file with no syntax errors
- [ ] Re-run `terragrunt plan` against real AWS with `HAIL_MAIL_NAME_PREFIX` set in `.env` and confirm the plan no longer wants to replace the SES receipt rule set / other resources