### PR TITLE
fix(cli): stop the generated 422 parser from swallowing custom error …

### DIFF
--- a/cli/internal/cmd/email.go
+++ b/cli/internal/cmd/email.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -206,17 +208,36 @@ func runEmailSend(ctx context.Context, cmd *cobra.Command, opts *Options, f *ema
 		body.AttachmentIds = &ids
 	}
 
-	resp, err := apiClient.CreateEmailEmailsPostWithResponse(
+	// Deliberately the raw (non-WithResponse) client method here, not
+	// CreateEmailEmailsPostWithResponse: its generated parser eagerly
+	// unmarshals ANY non-2xx JSON body into the OpenAPI-declared
+	// HTTPValidationError shape ({"detail": []ValidationError}) and
+	// discards the raw body if that unmarshal fails — which it does for
+	// any of this route's plain-string-detail 422s (the attachment
+	// size-cap rejection, "not a verified sender", "pending DKIM
+	// verification", etc.), surfacing a raw Go json.Unmarshal error
+	// instead of the real message. Parsing the response ourselves keeps
+	// the real body available for apiError's safe fallback.
+	httpResp, err := apiClient.CreateEmailEmailsPost(
 		ctx, &client.CreateEmailEmailsPostParams{}, body,
 	)
 	if err != nil {
 		return fmt.Errorf("email API: %w", err)
 	}
-	if resp.HTTPResponse.StatusCode != http.StatusCreated || resp.JSON201 == nil {
-		return apiError(resp.HTTPResponse.StatusCode, resp.Body)
+	defer httpResp.Body.Close()
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return fmt.Errorf("email API: read response: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusCreated {
+		return apiError(httpResp.StatusCode, respBody)
+	}
+	var email client.EmailResponse
+	if err := json.Unmarshal(respBody, &email); err != nil {
+		return fmt.Errorf("email API: parse response: %w", err)
 	}
 
-	return printEmail(opts, resp.JSON201)
+	return printEmail(opts, &email)
 }
 
 // normalizeRecipients trims whitespace from each entry and drops empty

--- a/cli/internal/cmd/email_attachment_upload.go
+++ b/cli/internal/cmd/email_attachment_upload.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -77,22 +79,43 @@ func uploadEmailAttachment(
 		return nil, fmt.Errorf("build upload: %w", err)
 	}
 
-	// UploadEmailAttachmentWithBodyWithResponse takes an extra *params
-	// argument beyond what the task brief predicted — oapi-codegen v2
-	// generates one for every route carrying the shared optional
-	// `authorization` header parameter (see UploadEmailAttachmentParams),
-	// the same shape CreateCallCallsPostWithResponse and
-	// CreateEmailEmailsPostWithResponse already take elsewhere in this
-	// package. Real auth goes through the request-editor-injected
-	// Authorization header on the client, so this is always the zero value.
-	resp, err := apiClient.UploadEmailAttachmentWithBodyWithResponse(
+	// Deliberately the raw (non-WithResponse) client method here, not
+	// UploadEmailAttachmentWithBodyWithResponse: its generated parser
+	// (ParseUploadEmailAttachmentResponse) eagerly unmarshals ANY non-2xx
+	// JSON body into the OpenAPI-declared HTTPValidationError shape
+	// ({"detail": []ValidationError}) and discards the raw body if that
+	// unmarshal fails — which it always does for this endpoint's size-cap
+	// rejection, since that returns a plain string detail
+	// ({"detail": "..."}) instead. That mismatch surfaced as a raw Go
+	// `json: cannot unmarshal string into ... []client.ValidationError`
+	// error instead of the actual "too large" message. Parsing the
+	// response ourselves keeps the real body available for apiError's
+	// safe (already-handles-both-shapes) fallback.
+	//
+	// UploadEmailAttachmentWithBody takes an extra *params argument beyond
+	// what the task brief predicted — oapi-codegen v2 generates one for
+	// every route carrying the shared optional `authorization` header
+	// parameter (see UploadEmailAttachmentParams), the same shape other
+	// routes take elsewhere in this package. Real auth goes through the
+	// request-editor-injected Authorization header on the client, so this
+	// is always the zero value.
+	httpResp, err := apiClient.UploadEmailAttachmentWithBody(
 		ctx, &client.UploadEmailAttachmentParams{}, w.FormDataContentType(), &buf,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("attachment upload API: %w", err)
 	}
-	if resp.HTTPResponse.StatusCode != http.StatusCreated || resp.JSON201 == nil {
-		return nil, apiError(resp.HTTPResponse.StatusCode, resp.Body)
+	defer httpResp.Body.Close()
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("attachment upload API: read response: %w", err)
 	}
-	return resp.JSON201, nil
+	if httpResp.StatusCode != http.StatusCreated {
+		return nil, apiError(httpResp.StatusCode, body)
+	}
+	var att client.EmailAttachmentUploadResponse
+	if err := json.Unmarshal(body, &att); err != nil {
+		return nil, fmt.Errorf("attachment upload API: parse response: %w", err)
+	}
+	return &att, nil
 }

--- a/cli/internal/cmd/email_attachment_upload_test.go
+++ b/cli/internal/cmd/email_attachment_upload_test.go
@@ -36,3 +36,36 @@ func TestEmailAttachmentUpload_HappyPath(t *testing.T) {
 		t.Fatalf("unexpected route: %s", srv.lastReq.URL.Path)
 	}
 }
+
+// TestEmailAttachmentUpload_OversizeRejection guards against a real bug: the
+// server's size-cap rejection returns a plain string `detail`
+// ({"detail": "..."}), not FastAPI's list-shaped validation-error detail
+// ({"detail": [...]}) that the generated WithResponse parser expects for
+// every 422. Using that generated parser directly made the real "too large"
+// message get replaced by a raw Go json.Unmarshal error. This must surface
+// the actual server message instead.
+func TestEmailAttachmentUpload_OversizeRejection(t *testing.T) {
+	srv := newFakeServer(t, http.StatusUnprocessableEntity, map[string]string{
+		"detail": "attachment(s) too large — host the file externally and include a link in the body instead",
+	})
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "big.pdf")
+	if err := os.WriteFile(filePath, []byte("pdf bytes"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	_, _, err := runRoot(t,
+		map[string]string{"HAIL_API_KEY": "sk_test", "HAIL_API_URL": srv.URL},
+		"email", "attachment-upload", filePath,
+	)
+	if err == nil {
+		t.Fatal("expected error on 422")
+	}
+	if strings.Contains(err.Error(), "cannot unmarshal") {
+		t.Fatalf("leaked raw json unmarshal error instead of the server message: %v", err)
+	}
+	if !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("expected the real oversize message, got: %v", err)
+	}
+}

--- a/cli/internal/cmd/email_test.go
+++ b/cli/internal/cmd/email_test.go
@@ -218,6 +218,37 @@ func TestEmailSend_APIError(t *testing.T) {
 	}
 }
 
+// TestEmailSend_OversizeAttachmentRejection guards against a real bug: the
+// server's attachment size-cap rejection returns a plain string `detail`
+// ({"detail": "..."}), not FastAPI's list-shaped validation-error detail
+// that the generated WithResponse parser expects for every 422. Using that
+// generated parser directly made the real "too large" message get replaced
+// by a raw Go json.Unmarshal error. This must surface the actual server
+// message instead.
+func TestEmailSend_OversizeAttachmentRejection(t *testing.T) {
+	srv := newFakeServer(t, http.StatusUnprocessableEntity, map[string]string{
+		"detail": "attachment(s) too large — host the file externally and include a link in the body instead",
+	})
+
+	_, _, err := runRoot(t,
+		map[string]string{"HAIL_API_KEY": "sk_test", "HAIL_API_URL": srv.URL},
+		"email", "send",
+		"--to", "x@example.com",
+		"--subject", "hi",
+		"--body", "hello",
+		"--recipient-consent",
+	)
+	if err == nil {
+		t.Fatal("expected error on 422")
+	}
+	if strings.Contains(err.Error(), "cannot unmarshal") {
+		t.Fatalf("leaked raw json unmarshal error instead of the server message: %v", err)
+	}
+	if !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("expected the real oversize message, got: %v", err)
+	}
+}
+
 func TestEmailSendSubcommand_SendsConsentFlags(t *testing.T) {
 	srv := newFakeServer(t, http.StatusCreated, sampleEmailResponse())
 


### PR DESCRIPTION
…details

Both `hail email attachment-upload` and `hail email send` used the generated *WithResponse client methods, whose parser eagerly unmarshals any non-2xx JSON body into the OpenAPI-declared HTTPValidationError shape ({"detail": []ValidationError}) and discards the raw body if that fails. Both routes can also return a plain string detail ({"detail": "..."}) for hand-raised 422s (the attachment size cap, "not a verified sender", "pending DKIM verification", etc.), which crashed the parser and surfaced a raw Go json.Unmarshal error instead of the real message.

Switched both call sites to the raw (non-WithResponse) client methods and parse the response manually, so apiError's existing shape-tolerant fallback actually gets a chance to run.