### PR TITLE
fix(deploy): bound alembic dry-print traceback noise in deploy logs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,8 +116,15 @@ jobs:
             # transaction pooling, which rejects libpq PGOPTIONS at startup).
             echo "=== current schema revision ==="
             $COMPOSE run --rm api alembic current
-            echo "=== migrations to apply (dry-print) ==="
-            $COMPOSE run --rm api alembic upgrade head --sql | head -200 || true
+            # Best-effort preview: --sql runs in Alembic's offline mode, which
+            # has no live DB connection. Any migration with a runtime
+            # data-dependent guard (a real SELECT via op.get_bind()) throws
+            # there and aborts the preview early — expected, not a deploy
+            # failure. Stderr is folded into the same pipe as stdout so that
+            # a traceback gets bounded by head -200 like normal output does,
+            # instead of dumping unbounded into the log.
+            echo "=== migrations to apply (dry-print, best-effort) ==="
+            $COMPOSE run --rm api alembic upgrade head --sql 2>&1 | head -200 || true
             echo "=== applying ==="
             $COMPOSE run --rm api alembic upgrade head
 

--- a/api/migrations/versions/0013_drop_per_domain_webhook.py
+++ b/api/migrations/versions/0013_drop_per_domain_webhook.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from typing import Sequence, Union
 
 import sqlalchemy as sa
-from alembic import op
+from alembic import context, op
 
 revision: str = "0013"
 down_revision: Union[str, None] = "0012"
@@ -31,16 +31,21 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    conn = op.get_bind()
     # Guard: refuse to drop if any per-domain webhook is actually configured.
-    n = conn.execute(
-        sa.text("SELECT count(*) FROM email_domains WHERE webhook_url IS NOT NULL")
-    ).scalar_one()
-    if n:
-        raise RuntimeError(
-            f"{n} email_domains row(s) still use webhook_url; migrate them to "
-            "WebhookSubscription before dropping per-domain webhooks."
-        )
+    # Skipped in offline mode (`alembic upgrade head --sql`, used for the
+    # deploy dry-print): there's no live connection to query there, and the
+    # check is meaningless for a SQL preview — it only needs to run against
+    # a real database.
+    if not context.is_offline_mode():
+        conn = op.get_bind()
+        n = conn.execute(
+            sa.text("SELECT count(*) FROM email_domains WHERE webhook_url IS NOT NULL")
+        ).scalar_one()
+        if n:
+            raise RuntimeError(
+                f"{n} email_domains row(s) still use webhook_url; migrate them to "
+                "WebhookSubscription before dropping per-domain webhooks."
+            )
 
     # Re-express the inbound-action invariant without webhook_url.
     op.drop_constraint("email_domains_inbound_action", "email_domains", type_="check")

--- a/uv.lock
+++ b/uv.lock
@@ -1009,7 +1009,7 @@ wheels = [
 
 [[package]]
 name = "hail-sdk"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "sdk" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Offline mode (--sql) has no live DB connection, so migrations with a runtime data-dependent guard (e.g. 0013) throw there and abort the preview early. That traceback went to stderr, unbounded, past the head -200 that only bounded stdout. Fold stderr into the same pipe so it truncates too, and label the step best-effort.