### PR TITLE
fix(voicebot): end_call must delete the room, not just end the agent job

### DIFF
--- a/voicebot/hailhq/voicebot/agent.py
+++ b/voicebot/hailhq/voicebot/agent.py
@@ -154,10 +154,25 @@ def make_agent_hangup(
     successful agent-initiated hangup. Status is left untouched (``None``)
     so ``on_call_end`` falls back to its ``"completed"`` default — matching
     a normal, callee-initiated hangup.
+
+    Deletes the room, not just the job: ``ctx.shutdown()`` alone ends the
+    agent while the SIP participant keeps hearing silence until they hang
+    up themselves (docs.livekit.io/telephony/making-calls/outbound-calls,
+    "Hang up"). ``delete_room`` disconnects the phone leg; the resulting
+    ``ROOM_DELETED`` disconnect is in ``_SDK_AUTO_CLOSE_REASONS`` and is
+    not mapped to a status override, so the stamped ``normal_hangup`` /
+    default ``completed`` outcome is preserved. ``ctx.shutdown()`` still
+    runs afterwards as a belt-and-braces job release — and as the only
+    path to ``on_call_end`` if the delete fails (the room then dies via
+    LiveKit's empty-timeout instead).
     """
 
     async def _hangup() -> None:
         captured["end_reason"] = CallEndReason.NORMAL_HANGUP.value
+        try:
+            await ctx.delete_room()
+        except Exception:
+            logger.exception("delete_room failed during agent hangup")
         ctx.shutdown(reason="agent_end_call")
 
     return _hangup

--- a/voicebot/tests/_fakes.py
+++ b/voicebot/tests/_fakes.py
@@ -16,6 +16,7 @@ output, we'll need to vendor a fake TTS too.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from livekit.agents.llm import (
@@ -145,15 +146,27 @@ class FakeAnnouncingSession:
 class FakeJobContext:
     """Stand-in for livekit.agents.JobContext.
 
-    Verified shape against .venv/lib/python3.11/site-packages/livekit/agents/job.py:
-    we only need ``ctx.shutdown(reason=…)``.
+    Verified shape against livekit/agents/job.py: we need
+    ``ctx.shutdown(reason=…)`` and ``ctx.delete_room()`` (returns an
+    awaitable resolving to the DeleteRoomResponse; a completed Future here).
     """
 
     def __init__(self) -> None:
         self.shutdown_calls: list[str] = []
+        self.delete_room_calls: int = 0
+        self.delete_room_error: Exception | None = None
 
     def shutdown(self, reason: str = "") -> None:
         self.shutdown_calls.append(reason)
+
+    def delete_room(self) -> "asyncio.Future[None]":
+        self.delete_room_calls += 1
+        fut: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+        if self.delete_room_error is not None:
+            fut.set_exception(self.delete_room_error)
+        else:
+            fut.set_result(None)
+        return fut
 
 
 __all__ = [

--- a/voicebot/tests/test_agent.py
+++ b/voicebot/tests/test_agent.py
@@ -1075,6 +1075,26 @@ async def test_agent_hangup_marks_normal_hangup() -> None:
     assert captured["end_reason"] == CallEndReason.NORMAL_HANGUP.value
     assert captured["status"] is None
     assert ctx.shutdown_calls == ["agent_end_call"]
+    # ctx.shutdown() only ends the agent job — per LiveKit docs the SIP
+    # participant keeps hearing silence until the ROOM is deleted. The
+    # hangup handle must delete the room to actually end the phone call.
+    assert ctx.delete_room_calls == 1
+
+
+async def test_agent_hangup_still_shuts_down_when_delete_room_fails() -> None:
+    """A delete_room failure (API blip) must not strand the job: shutdown
+    still runs so on_call_end finalizes the row; the room then dies via
+    LiveKit's empty-timeout instead."""
+    captured: dict[str, str | None] = {"status": None, "end_reason": None}
+    ctx = FakeJobContext()
+    ctx.delete_room_error = RuntimeError("twirp unavailable")
+    hangup = make_agent_hangup(ctx, captured)  # type: ignore[arg-type]
+
+    await hangup()
+
+    assert captured["end_reason"] == CallEndReason.NORMAL_HANGUP.value
+    assert ctx.delete_room_calls == 1
+    assert ctx.shutdown_calls == ["agent_end_call"]
 
 
 async def test_build_tools_safely_degrades_on_failure(


### PR DESCRIPTION
ctx.shutdown() alone leaves the SIP participant hearing silence until they hang up themselves (LiveKit docs, outbound-calls Hang up). The end_call hangup handle now deletes the room to disconnect the phone leg, keeping ctx.shutdown() as the job-release fallback when the delete fails.