### PR TITLE
fix(api): voicebot agent sends honor platform agent caps and kill switch

### DIFF
--- a/api/hailhq/api/routes/internal/agent.py
+++ b/api/hailhq/api/routes/internal/agent.py
@@ -38,8 +38,13 @@ from hailhq.core.agent_tools.send_email import (
     MAX_SUBJECT_CHARS,
 )
 from hailhq.core.agent_tools.send_sms import MAX_BODY_CHARS as SMS_MAX_BODY_CHARS
+from hailhq.core.agent_caps import check_agent_send_allowed
 from hailhq.core.billing import CALL_META_BILLED, has_funds
-from hailhq.core.compliance_gate import check_email_allowed, check_sms_allowed
+from hailhq.core.compliance_gate import (
+    check_email_allowed,
+    check_sms_allowed,
+    normalize_recipient,
+)
 from hailhq.core.db import get_session
 from hailhq.core.directory import resolve_member_emails
 from hailhq.core.models import Call, Email, Sms
@@ -255,6 +260,23 @@ async def agent_send_sms(
             payload={**_meta(body), "reason": gate.reason, "checks": gate.checks},
         )
 
+    # Platform agent-caps gate (velocity + kill switch): voicebot sends must
+    # count toward the same per-recipient caps the public routes enforce —
+    # no-op for human-origin orgs. Same recipient set as the gate above.
+    cap_denial = await check_agent_send_allowed(db, org, "sms", [call.to_e164])
+    if cap_denial is not None:
+        return await _deny(
+            org,
+            action="agent.sms.blocked",
+            resource_type="sms",
+            spoken=_SPOKEN_NOT_ALLOWED,
+            payload={
+                **_meta(body),
+                "reason": "agent_caps",
+                "detail": cap_denial.reason,
+            },
+        )
+
     from_number = await resolve_org_number(db, org, None, capability="sms")
     if from_number is None:
         return AgentSendResponse(ok=False, spoken=_SPOKEN_SMS_UNCONFIGURED)
@@ -371,6 +393,24 @@ async def agent_send_email(
             resource_type="email",
             spoken=_SPOKEN_NOT_ALLOWED,
             payload={**_meta(body), "reason": gate.reason, "checks": gate.checks},
+        )
+
+    # Same agent-caps gate as the public /emails route — one normalized
+    # recipient for voicebot sends (no cc/bcc fan-out on this path).
+    cap_denial = await check_agent_send_allowed(
+        db, org, "email", [normalize_recipient(recipient)]
+    )
+    if cap_denial is not None:
+        return await _deny(
+            org,
+            action="agent.email.blocked",
+            resource_type="email",
+            spoken=_SPOKEN_NOT_ALLOWED,
+            payload={
+                **_meta(body),
+                "reason": "agent_caps",
+                "detail": cap_denial.reason,
+            },
         )
 
     try:

--- a/api/tests/test_internal_agent_send.py
+++ b/api/tests/test_internal_agent_send.py
@@ -16,6 +16,7 @@ from hailhq.api.main import app
 from hailhq.core import hmac_signing
 from hailhq.core.compliance_gate import add_suppression
 from hailhq.core.db import get_session
+from hailhq.core.agent_caps import AGENT_OUTBOUND_DISABLED_FLAG
 from hailhq.core.billing import CALL_META_BILLED
 from hailhq.core.config import settings
 from hailhq.core.models import (
@@ -23,7 +24,9 @@ from hailhq.core.models import (
     Call,
     Email,
     EmailDomain,
+    Organization,
     OrganizationMember,
+    PlatformFlag,
     Sms,
     User,
 )
@@ -504,3 +507,44 @@ async def test_send_sms_provider_failure_writes_send_failed_audit(
     assert len(rows) == 1
     assert rows[0].organization_id == org
     assert rows[0].payload["end_reason"] == "provider_error"
+
+
+async def test_send_sms_blocked_by_agent_kill_switch(
+    client, async_session, sms_mock, add_phone_number
+):
+    """Voicebot sends must honor the platform agent caps: an agent-origin
+    org with the kill switch on gets a vague spoken denial and no row."""
+    org = uuid.uuid4()
+    call = await _insert_live_call(async_session, org, add_phone_number)
+    async_session.add(Organization(id=org, origin="agent"))
+    async_session.add(PlatformFlag(key=AGENT_OUTBOUND_DISABLED_FLAG, value="true"))
+    await async_session.commit()
+
+    body = _sms_payload(call.id)
+    resp = await client.post(
+        "/internal/agent/send-sms", content=body, headers=_signed(body)
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is False
+    assert "kill" not in data["spoken"].lower()
+    assert "disabled" not in data["spoken"].lower()
+    rows = (await async_session.execute(Sms.__table__.select())).fetchall()
+    assert rows == []
+
+
+async def test_send_sms_agent_caps_noop_for_human_org(
+    client, async_session, sms_mock, add_phone_number
+):
+    """Kill switch on, but the org is human-origin: send goes through."""
+    org = uuid.uuid4()
+    call = await _insert_live_call(async_session, org, add_phone_number)
+    async_session.add(Organization(id=org, origin="human"))
+    async_session.add(PlatformFlag(key=AGENT_OUTBOUND_DISABLED_FLAG, value="true"))
+    await async_session.commit()
+
+    body = _sms_payload(call.id)
+    resp = await client.post(
+        "/internal/agent/send-sms", content=body, headers=_signed(body)
+    )
+    assert resp.json()["ok"] is True


### PR DESCRIPTION
The abuse guardrails (per-recipient velocity caps + kill switch) gated only the public create routes; the voicebot's /internal/agent sends bypassed them. Both internal routes now run check_agent_send_allowed with the same recipient set as their compliance gate — a no-op for human-origin orgs.