### PR TITLE
feat(voicebot): answering machine detection and agent DTMF

### DIFF
--- a/api/migrations/versions/0038_amd_call_end_reasons.py
+++ b/api/migrations/versions/0038_amd_call_end_reasons.py
@@ -1,0 +1,35 @@
+"""Add the answering-machine-detection values to the call_end_reason ENUM.
+
+`voicemail_reached` and `machine_unavailable` are stamped by the voicebot when
+AMD decides a machine picked up; both map to status='no_answer'.
+
+`ALTER TYPE ... ADD VALUE` cannot run inside a transaction, hence the
+autocommit block (same shape as 0024).
+
+Revision ID: 0038
+Revises: 0037
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0038"
+down_revision = "0037"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "ALTER TYPE call_end_reason ADD VALUE IF NOT EXISTS 'voicemail_reached'"
+        )
+        op.execute(
+            "ALTER TYPE call_end_reason ADD VALUE IF NOT EXISTS 'machine_unavailable'"
+        )
+
+
+def downgrade() -> None:
+    # Postgres cannot drop a single ENUM value; leaving it is harmless.
+    pass

--- a/core/hailhq/core/agent_tools/registry.py
+++ b/core/hailhq/core/agent_tools/registry.py
@@ -2,12 +2,24 @@
 
 from __future__ import annotations
 
-from hailhq.core.agent_tools import end_call, list_contacts, send_email, send_sms
+from hailhq.core.agent_tools import (
+    end_call,
+    list_contacts,
+    send_dtmf,
+    send_email,
+    send_sms,
+)
 from hailhq.core.agent_tools.spec import ToolSpec
 
 
 def all_tools() -> tuple[ToolSpec, ...]:
-    return (end_call.SPEC, list_contacts.SPEC, send_sms.SPEC, send_email.SPEC)
+    return (
+        end_call.SPEC,
+        send_dtmf.SPEC,
+        list_contacts.SPEC,
+        send_sms.SPEC,
+        send_email.SPEC,
+    )
 
 
 __all__ = ["all_tools"]

--- a/core/hailhq/core/agent_tools/send_dtmf.py
+++ b/core/hailhq/core/agent_tools/send_dtmf.py
@@ -1,0 +1,104 @@
+"""send_dtmf — press keypad digits on the live call.
+
+session_control tier: purely local (the voicebot's ``send_dtmf`` handle),
+no API call, affects only its own call. The voicebot wrapper waits for the
+agent's pre-tool speech to finish playing so tones never go out over TTS.
+
+LiveKit's own ``send_dtmf_events`` tool only exists after AMD returns a
+``machine-ivr`` verdict (``AMD._run`` force-disables session-level
+``ivr_detection`` and owns the IVR lifecycle), so a phone tree reached
+mid-call would otherwise be unpressable. This tool is always available and
+inherits the registry's allowlist, availability gate, failure wrapper, and
+``tool_call`` event logging.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from hailhq.core.agent_tools.spec import ToolContext, ToolSpec
+
+# RFC 4733 named telephone events: digits 0-9 map to their own value, then
+# `*`, `#`, and the rarely-used A-D tones.
+DTMF_CODES: dict[str, int] = {
+    **{str(d): d for d in range(10)},
+    "*": 10,
+    "#": 11,
+    "A": 12,
+    "B": 13,
+    "C": 14,
+    "D": 15,
+}
+
+# Matches LiveKit's DEFAULT_DTMF_PUBLISH_DELAY.
+DIGIT_DELAY_SECONDS = 0.3
+
+MAX_DIGITS = 32
+
+
+def normalize_digits(raw: Any) -> str | None:
+    """Uppercase + validate ``raw``; ``None`` when it is not a sendable string."""
+    if not isinstance(raw, str):
+        return None
+    digits = raw.strip().upper()
+    if not digits or len(digits) > MAX_DIGITS:
+        return None
+    if any(ch not in DTMF_CODES for ch in digits):
+        return None
+    return digits
+
+
+async def _always(_org: uuid.UUID, _session: AsyncSession) -> bool:
+    return True
+
+
+async def _execute(ctx: ToolContext, args: dict[str, Any]) -> str:
+    if ctx.send_dtmf is None:
+        return "I can't press any keys on this call right now."
+    digits = normalize_digits(args.get("digits"))
+    if digits is None:
+        return (
+            "I can only press the digits zero through nine, star, pound, or "
+            f"the letters A through D, up to {MAX_DIGITS} at a time."
+        )
+    for index, digit in enumerate(digits):
+        if index:
+            await asyncio.sleep(DIGIT_DELAY_SECONDS)
+        await ctx.send_dtmf(digit)
+    return "Done, I pressed those keys."
+
+
+SPEC = ToolSpec(
+    name="send_dtmf",
+    description=(
+        "Press keypad digits on this phone call — use it to answer an "
+        "automated menu, enter an extension, or type a code. Pass the digits "
+        "in the order they should be pressed, e.g. '1' or '4321#'. Allowed "
+        "characters: 0-9, *, #, and the rarely-needed A-D tones."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "digits": {
+                "type": "string",
+                "description": "Digits to press in order, e.g. '123#'.",
+            }
+        },
+        "required": ["digits"],
+    },
+    risk_tier="session_control",
+    is_available=_always,
+    execute=_execute,
+)
+
+__all__ = [
+    "DIGIT_DELAY_SECONDS",
+    "DTMF_CODES",
+    "MAX_DIGITS",
+    "SPEC",
+    "normalize_digits",
+]

--- a/core/hailhq/core/agent_tools/spec.py
+++ b/core/hailhq/core/agent_tools/spec.py
@@ -30,13 +30,19 @@ class ToolContext:
     """Capability handles the voicebot supplies per call.
 
     ``api`` is None when HAIL_INTERNAL_SECRET is unset (send tools are
-    unavailable then); ``hangup`` is None outside a live session.
+    unavailable then); ``hangup`` and ``send_dtmf`` are None outside a live
+    session.
+
+    ``send_dtmf`` takes the already-validated digit string and publishes it to
+    the SIP leg. Keeping it a handle (rather than importing ``livekit`` here)
+    is what keeps ``core`` free of transport dependencies.
     """
 
     call_id: uuid.UUID
     organization_id: uuid.UUID
     api: AgentApiClient | None
     hangup: Callable[[], Awaitable[None]] | None
+    send_dtmf: Callable[[str], Awaitable[None]] | None
 
 
 @dataclass(frozen=True)

--- a/core/hailhq/core/call_end_reasons.py
+++ b/core/hailhq/core/call_end_reasons.py
@@ -28,6 +28,10 @@ class CallEndReason(StrEnum):
     USER_UNAVAILABLE = "user_unavailable"  # → status=no_answer
     USER_REJECTED = "user_rejected"  # → status=busy
 
+    # answering machine detection (callee picked up, but not a person)
+    VOICEMAIL_REACHED = "voicemail_reached"  # → status=no_answer
+    MACHINE_UNAVAILABLE = "machine_unavailable"  # → status=no_answer
+
     # SIP failures (transport / media / trunk)
     SIP_TRUNK_FAILURE = "sip_trunk_failure"
     CONNECTION_TIMEOUT = "connection_timeout"

--- a/core/tests/test_agent_tools.py
+++ b/core/tests/test_agent_tools.py
@@ -18,6 +18,7 @@ def _ctx(**overrides):
         organization_id=uuid.uuid4(),
         api=None,
         hangup=None,
+        send_dtmf=None,
     )
     defaults.update(overrides)
     return ToolContext(**defaults)
@@ -25,8 +26,15 @@ def _ctx(**overrides):
 
 def test_registry_names_and_tiers():
     tools = {t.name: t for t in all_tools()}
-    assert set(tools) == {"end_call", "list_contacts", "send_sms", "send_email"}
+    assert set(tools) == {
+        "end_call",
+        "send_dtmf",
+        "list_contacts",
+        "send_sms",
+        "send_email",
+    }
     assert tools["end_call"].risk_tier == "session_control"
+    assert tools["send_dtmf"].risk_tier == "session_control"
     assert tools["list_contacts"].risk_tier == "read_only"
     assert tools["send_sms"].risk_tier == "outbound_send"
     assert tools["send_email"].risk_tier == "outbound_send"

--- a/core/tests/test_send_dtmf.py
+++ b/core/tests/test_send_dtmf.py
@@ -1,0 +1,132 @@
+"""send_dtmf: RFC 4733 codes, validation, ordering, and missing handle."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from hailhq.core.agent_tools.send_dtmf import (
+    DTMF_CODES,
+    MAX_DIGITS,
+    SPEC,
+    normalize_digits,
+)
+from hailhq.core.agent_tools.spec import ToolContext
+
+
+@pytest.fixture(autouse=True)
+def _no_pacing(monkeypatch):
+    """Collapse the 0.3s inter-digit delay so the suite stays fast."""
+    import hailhq.core.agent_tools.send_dtmf as mod
+
+    monkeypatch.setattr(mod, "DIGIT_DELAY_SECONDS", 0)
+
+
+def _ctx(send_dtmf):
+    return ToolContext(
+        call_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        api=None,
+        hangup=None,
+        send_dtmf=send_dtmf,
+    )
+
+
+def test_rfc4733_code_mapping() -> None:
+    expected = {
+        "0": 0,
+        "1": 1,
+        "2": 2,
+        "3": 3,
+        "4": 4,
+        "5": 5,
+        "6": 6,
+        "7": 7,
+        "8": 8,
+        "9": 9,
+        "*": 10,
+        "#": 11,
+        "A": 12,
+        "B": 13,
+        "C": 14,
+        "D": 15,
+    }
+    assert DTMF_CODES == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("123#", "123#"),
+        ("*0", "*0"),
+        ("  42  ", "42"),
+        ("abcd", "ABCD"),
+    ],
+)
+def test_normalize_accepts_legal_digits(raw: str, expected: str) -> None:
+    assert normalize_digits(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "   ",
+        "12 34",
+        "1,2",
+        "hello",
+        "1" * (MAX_DIGITS + 1),
+        None,
+        123,
+    ],
+)
+def test_normalize_rejects_illegal_input(raw: object) -> None:
+    assert normalize_digits(raw) is None
+
+
+async def test_publishes_digits_in_order() -> None:
+    pressed: list[str] = []
+
+    async def _send(digit: str) -> None:
+        pressed.append(digit)
+
+    spoken = await SPEC.execute(_ctx(_send), {"digits": "4321#"})
+
+    assert pressed == ["4", "3", "2", "1", "#"]
+    assert isinstance(spoken, str) and spoken
+
+
+async def test_lowercase_letters_are_upcased_before_publishing() -> None:
+    pressed: list[str] = []
+
+    async def _send(digit: str) -> None:
+        pressed.append(digit)
+
+    await SPEC.execute(_ctx(_send), {"digits": "a*d"})
+
+    assert pressed == ["A", "*", "D"]
+
+
+@pytest.mark.parametrize("digits", ["", "12 34", "1" * (MAX_DIGITS + 1), None])
+async def test_rejects_return_speakable_text_without_publishing(digits: object) -> None:
+    pressed: list[str] = []
+
+    async def _send(digit: str) -> None:  # pragma: no cover — must not run
+        pressed.append(digit)
+
+    spoken = await SPEC.execute(_ctx(_send), {"digits": digits})
+
+    assert pressed == []
+    assert isinstance(spoken, str) and spoken
+    # A speakable sentence, not a stack trace or a schema error.
+    assert "Error" not in spoken and "Traceback" not in spoken
+
+
+async def test_missing_handle_returns_speakable_line() -> None:
+    spoken = await SPEC.execute(_ctx(None), {"digits": "1"})
+    assert isinstance(spoken, str) and spoken
+
+
+async def test_is_available_is_unconditional() -> None:
+    assert await SPEC.is_available(uuid.uuid4(), None) is True  # type: ignore[arg-type]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,8 +31,16 @@ LiveKit Cloud is external. The `hail` Go CLI is a human-facing scriptable tool, 
 1. Caller (agent via MCP, or CLI, or direct HTTP) → `POST /calls` with `{to, from, first_message?, …llm}`.
 2. Hail API creates a LiveKit room and dispatches the voicebot into it.
 3. Voicebot joins; LiveKit places a SIP outbound via the Twilio trunk to `to`.
-4. On pickup, voicebot speaks `first_message` (if set), then runs the STT → LLM → TTS loop.
+4. On pickup, voicebot classifies who answered before saying anything (see below), then speaks the AI disclosure and `first_message` (if set) and runs the STT → LLM → TTS loop.
 5. On hangup, voicebot writes the call record to Postgres and uploads the recording to S3.
+
+### Answering machine detection and DTMF
+
+Every outbound call runs LiveKit's AMD ([`voicebot/hailhq/voicebot/amd.py`](../voicebot/hailhq/voicebot/amd.py)) against the greeting, classifying on the session's own LLM and STT rather than LiveKit Inference. `machine-vm` and `machine-unavailable` hang up without speaking — no message is ever left — and record `status=no_answer` with `end_reason=voicemail_reached` / `machine_unavailable`. `human`, `uncertain`, and `machine-ivr` proceed normally; `machine-ivr` also starts LiveKit's IVR navigation. The verdict lands in `call_events` as an `amd_result` row on every call. A detection failure is non-fatal: the call proceeds as if a human answered.
+
+Billing no longer requires a `completed` status: a call is billed when `answered_at` is set (the SIP leg went active) **or** the call completed normally. The first clause bills a machine-answered call and one that failed mid-conversation; the second keeps billing a completed call whose answer signal never landed.
+
+The agent can press keypad digits at any point via the `send_dtmf` tool ([`core/hailhq/core/agent_tools/send_dtmf.py`](../core/hailhq/core/agent_tools/send_dtmf.py)) — not just after an IVR verdict — so phone trees reached mid-call are navigable.
 
 ## LLM modes
 

--- a/docs/superpowers/plans/2026-07-21-voicebot-amd-dtmf.md
+++ b/docs/superpowers/plans/2026-07-21-voicebot-amd-dtmf.md
@@ -1,0 +1,99 @@
+# Plan — voicebot AMD + agent DTMF
+
+Spec: [2026-07-21-voicebot-amd-dtmf-design.md](../specs/2026-07-21-voicebot-amd-dtmf-design.md)
+
+Status legend: `[ ]` todo · `[x]` done
+
+## 1. Dependency bump to livekit-agents 1.6.6
+
+- [x] `uv lock --upgrade-package …` for `livekit-agents` + the 8 `livekit-plugins-*`.
+      No `pyproject.toml` edit (`>=1.5,<2` already allows it).
+      Files: `uv.lock`
+- [x] Baseline (1.5.6) suites recorded, then re-run on 1.6.6:
+      `cd voicebot && uv run pytest -q`, `cd core && …`, `cd api && …`
+- [x] Re-verify the two flagged upstream changes: - `CloseReason` is still `str, Enum` with `error` / `job_shutdown` →
+      `_on_session_close`'s `reason == "error"` comparison still holds. - `silero.VAD.load()` (now ONNX) still loads in-process.
+
+## 2. AMD module
+
+- [x] New `voicebot/hailhq/voicebot/amd.py` exporting
+      `MACHINE_HANGUP_CATEGORIES`, `amd_end_reason`, `run_amd`.
+      `run_amd` builds `AMD(session, llm=…, stt=…, participant_identity=
+    f"caller-{call_id}", detection_options={"no_speech_threshold": 6.0},
+    suppress_compatibility_warning=True)` and returns `await detector.execute()`
+      inside `async with`; any exception → log + `None`.
+- [x] Verify: `cd voicebot && uv run pytest tests/test_amd.py -q`
+
+## 3. New CallEndReason values + migration
+
+- [x] `core/hailhq/core/call_end_reasons.py`: add `VOICEMAIL_REACHED`,
+      `MACHINE_UNAVAILABLE`.
+- [x] `api/migrations/versions/0038_amd_call_end_reasons.py` — `autocommit_block` + `ALTER TYPE call_end_reason ADD VALUE IF NOT EXISTS …` for both
+      (mirrors `0024_provider_key_error_reason.py`).
+- [x] Verify: `cd api && uv run pytest -q` (fixtures build the enum from the
+      Python `StrEnum`, so a mismatch surfaces there).
+
+## 4. Entrypoint wiring
+
+- [x] `voicebot/hailhq/voicebot/agent.py` `entrypoint`: between `session.start()`
+      and `speak_greeting`, run AMD, write the `amd_result` call event on every
+      path, and hang up (delete_room + shutdown) for the two machine categories.
+
+## 5. Billing guard
+
+- [x] `agent.py` `on_call_end`: bill when `answered_at is not None` instead of
+      `final_status == "completed"`.
+- [x] Existing billing tests that bill off `started_at` alone must be updated to
+      stamp `answered_at` — the new contract is "the SIP leg went active".
+
+## 6. send_dtmf tool
+
+- [x] `core/hailhq/core/agent_tools/spec.py`: `ToolContext.send_dtmf` field.
+- [x] `core/hailhq/core/agent_tools/send_dtmf.py` — validation, RFC 4733 codes,
+      0.3s pacing, `session_control` tier, always available.
+- [x] `core/hailhq/core/agent_tools/registry.py`: one line.
+- [x] `voicebot/hailhq/voicebot/tools.py`: accept + thread a `send_dtmf` handle.
+- [x] `agent.py`: `make_agent_send_dtmf(ctx)` closure over
+      `ctx.room.local_participant.publish_dtmf`; passed through
+      `build_tools_safely`.
+- [x] Verify: `cd core && uv run pytest tests/test_send_dtmf.py tests/test_agent_tools.py -q`
+      and `cd voicebot && uv run pytest tests/test_tools.py -q`
+
+## 7. Tests
+
+- [x] `voicebot/tests/test_amd.py` — five categories, `amd_result` event always
+      written, `run_amd` failure → `None` + call proceeds, AMD constructed with
+      the session's own `llm`/`stt` and the right `participant_identity`.
+- [x] `core/tests/test_send_dtmf.py` — code mapping, rejects, ordering,
+      `send_dtmf is None`.
+- [x] Billing assertions in `voicebot/tests/test_agent.py`.
+
+## 8. Docs
+
+- [x] `docs/architecture.md` voicebot paragraph.
+
+## 9. Full verification
+
+- [x] `cd voicebot && uv run pytest`
+- [x] `cd core && uv run pytest`
+- [x] `cd api && uv run pytest`
+- [x] `uv run ruff check --fix . && uv run black .`
+- [x] `uv run mypy` per package
+
+## Deviations from the spec
+
+1. **Shutdown-callback ordering.** The spec's entrypoint snippet `return`s from
+   the AMD hangup path before `ctx.add_shutdown_callback(_shutdown)` is
+   registered, which would leave the Call row unfinalized and the pool number
+   leaked. The registration (and `room_name`) moved above the AMD block; the
+   soft-cap task still starts only after the greeting.
+2. **`run_amd` guards on `session.stt is None`** in addition to the spec's
+   `isinstance` narrowing of `session.llm` — `AMD(stt=None)` is "given" as far
+   as `is_given` is concerned and would fail downstream.
+3. **`test_on_call_end_inserts_usage_event` updated** to stamp `answered_at`.
+   It billed off `started_at` alone, which the new billing guard deliberately
+   no longer does. Intended consequence of the spec's change, not a workaround.
+4. **CI does not run mypy** (`.github/workflows/ci.yml` runs ruff, black, and
+   pytest only), and `uv run mypy .` per package fails on main already with
+   "Source file found twice under different module names". Type-checked the
+   changed files with `--explicit-package-bases`; no new errors.

--- a/docs/superpowers/specs/2026-07-21-voicebot-amd-dtmf-design.md
+++ b/docs/superpowers/specs/2026-07-21-voicebot-amd-dtmf-design.md
@@ -1,0 +1,288 @@
+# Voicebot: answering machine detection + agent DTMF
+
+**Date:** 2026-07-21
+**Status:** approved, not yet implemented
+**Scope:** `voicebot/`, `core/`, one alembic migration
+
+Two capabilities for outbound voice calls:
+
+1. **AMD** — classify who answered (person, IVR, voicemail, dead mailbox) and
+   hang up instead of talking to a machine.
+2. **`send_dtmf`** — let the agent press keypad digits at any point in a call.
+
+No API surface change: no new `POST /calls` fields, no `openapi.yaml` regen, no
+CLI codegen.
+
+## Background
+
+`voicebot/hailhq/voicebot/agent.py` owns the call lifecycle. Today every call
+speaks the mandatory AI disclosure immediately after `session.start()`,
+regardless of who — or what — picked up. A voicemail greeting gets a full
+conversation attempt.
+
+The API service, not the voicebot, creates the SIP participant
+(`api/hailhq/api/routes/calls.py:375`) with identity `caller-{call_id}`. So the
+LiveKit docs' pattern of wrapping `create_sip_participant` in the AMD context
+manager does not apply here; AMD attaches to the already-present participant by
+identity instead.
+
+## Dependency bump
+
+The lock pins `livekit-agents==1.5.6`; latest is `1.6.6`. `pyproject.toml`
+already declares `>=1.5,<2`, so this is `uv lock --upgrade` for
+`livekit-agents` and the eight `livekit-plugins-*` packages — no manifest edit.
+
+Two upstream fixes land directly on these features:
+
+- **1.5.17** — `fix(amd): start listening on lost publisher, forward realtime
+transcripts, harden attribute wait` (#5918).
+- **1.6.5** — `fix: send DTMF to the active session room` (#6360).
+
+  1.6.6 also adds the `participant_identity`, `detection_options`, `stt`, and
+  `suppress_compatibility_warning` parameters that 1.5.6 lacks.
+
+The bump ships in the same commits as the features. Two behavior changes in the
+range touch existing voicebot code and must be re-verified against the current
+test suite:
+
+- #6284 "set default shutdown reason" — the `session.on("close")` →
+  `CallEndReason` mapping at `agent.py:780` reads `ev.reason`.
+- `silero.VAD.load()` switched to ONNX — `prewarm` must still load.
+
+## AMD
+
+### New module: `voicebot/hailhq/voicebot/amd.py`
+
+`agent.py` is 866 lines; AMD gets its own module rather than growing it.
+
+Exports:
+
+- `MACHINE_HANGUP_CATEGORIES: frozenset[str]` — `{"machine-vm", "machine-unavailable"}`.
+- `amd_end_reason(category: str) -> str` — maps those two to `CallEndReason` values.
+- `run_amd(session, call_id) -> AMDPredictionEvent | None`.
+
+`run_amd` constructs the detector as:
+
+```python
+AMD(
+    session,
+    llm=session.llm,
+    stt=session.stt,
+    participant_identity=f"caller-{call_id}",
+    detection_options={"no_speech_threshold": 6.0},
+    suppress_compatibility_warning=True,
+)
+```
+
+and runs it as `async with ... as detector: return await detector.execute()`.
+
+Everything is wrapped in `try/except Exception → log + return None`. An AMD
+failure must never kill a call — the same posture as `build_tools_safely`.
+
+Rationale for each argument:
+
+- **`llm` / `stt` passed explicitly.** On 1.6.6, leaving them unset makes AMD
+  auto-select LiveKit Inference (`google/gemini-3.1-flash-lite` +
+  `cartesia/ink-whisper`) whenever `LIVEKIT_URL` is Cloud and the API key and
+  secret are set (`amd/detector.py:175-186`) — which is Hail's deployed
+  config. That would send the greeting transcript to a vendor we do not
+  otherwise use, bill it outside the `usage_events` model, and override the BYO
+  provider precedence that `pipeline.py` exists to enforce. Passing the
+  session's own layers keeps classification on the brain the org chose.
+  `session.llm` is typed `LLM | RealtimeModel | None`; Hail never uses
+  `RealtimeModel`, so an `isinstance` narrowing satisfies mypy.
+- **`suppress_compatibility_warning=True`.** Follows from the above: the
+  session LLM is not on LiveKit's evaluated list, so the warning would fire on
+  every call. Hail's house STT is Deepgram, which _is_ on the list.
+- **`participant_identity`.** Matches the identity the API sets at
+  `routes/calls.py:379`. Without it AMD attaches to the first remote audio
+  track, which is non-deterministic if the room ever holds another participant.
+- **`no_speech_threshold: 6.0`** (default 10.0). This is the ceiling on how
+  long a live-but-silent callee waits before hearing the disclosure. Ten
+  seconds of dead air is a worse regression than a slightly less certain
+  verdict.
+- **`ivr_detection`** left at its default `True`, so a `machine-ivr` verdict
+  automatically starts LiveKit's IVR navigation.
+
+### Entrypoint wiring
+
+In `entrypoint`, between `await session.start(...)` and `speak_greeting`. The
+soft-cap task and `ctx.add_shutdown_callback(_shutdown)` must both be set up
+_before_ this block: the hangup path returns early, and without the callback
+registered the Call row would never finalize and the pool number would leak.
+Arming the soft cap first also keeps it bounding the call from pickup rather
+than from after detection and greeting playout.
+
+```
+result = await run_amd(session, call_id)          # own timeout backstop
+await write_call_event(call_id, "amd_result", {category, transcript[:500]})
+if result and result.category in MACHINE_HANGUP_CATEGORIES:
+    captured["status"] = "no_answer"
+    captured["end_reason"] = amd_end_reason(result.category)
+    await ctx.delete_room()
+    ctx.shutdown(reason=captured["end_reason"])
+    return
+try:
+    await speak_greeting(session, metadata)       # session may have died
+except Exception:
+    log
+```
+
+`speak_greeting` is guarded because AMD holds it for the length of the
+detection window, and the callee can hang up inside that window —
+`AgentSession.say` raises once the activity is torn down.
+
+`run_amd` wraps `detector.execute()` in `asyncio.wait_for`. AMD's own 20s
+budget is armed only after the SIP audio track publishes, and the wait for
+that publication takes no timeout, so a leg that never publishes would
+otherwise block `entrypoint` indefinitely.
+
+The `amd_result` event is written on every call, machine or not — `CallEvent.kind`
+is free `Text` (`core/hailhq/core/models.py:150`), so this needs no schema change
+and gives per-call observability into classification quality.
+
+Hanging up mirrors `make_agent_hangup`: `delete_room` disconnects the phone leg,
+then `ctx.shutdown` releases the job and drives `_shutdown` → `on_call_end`.
+
+### Behavior per category
+
+| Category              | Action                                                                                                                                                               |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `human`               | Speak disclosure + `first_message`, proceed normally.                                                                                                                |
+| `uncertain`           | Same as `human`.                                                                                                                                                     |
+| `machine-ivr`         | Same as `human`; AMD has already started IVR navigation. The disclosure goes into the phone tree, which is harmless and covers a tree that later routes to a person. |
+| `machine-vm`          | Hang up without speaking. `status=no_answer`, `end_reason=voicemail_reached`.                                                                                        |
+| `machine-unavailable` | Hang up without speaking. `status=no_answer`, `end_reason=machine_unavailable`.                                                                                      |
+
+No voicemail message is ever left. A partial line on someone's voicemail is
+worse than silence, and leaving one would need a new `POST /calls` field.
+
+## Outcome recording and billing
+
+### New end reasons
+
+`CallEndReason` (`core/hailhq/core/call_end_reasons.py`) gains:
+
+- `VOICEMAIL_REACHED = "voicemail_reached"`
+- `MACHINE_UNAVAILABLE = "machine_unavailable"`
+
+Plus an alembic migration adding both to the `call_end_reason` Postgres ENUM.
+`ALTER TYPE ... ADD VALUE` cannot run inside a transaction, so the migration
+uses an `autocommit_block`.
+
+Both map to the existing `no_answer` status. No `CallStatus`,
+`TERMINAL_CALL_STATUSES`, OpenAPI, or CLI change — a machine picking up is
+still "no person answered."
+
+### Billing guard
+
+`on_call_end` currently writes a `usage_events` row only when
+`final_status == "completed"` (`agent.py:581`). A machine-answered call is
+terminal as `no_answer`, so it would go unbilled — but the minutes were real.
+
+Change the condition to `answered_at is not None or final_status == "completed"`.
+
+The first clause is the new one: billing already runs from `answered_at`
+(pickup), so "the SIP leg went active" is exactly the condition under which
+there is something to bill. The second clause is the historical test, kept
+deliberately — `mark_call_answered` can miss (a DB blip, a dropped
+`sip.callStatus` event), legacy rows predate `answered_at`, and the
+`recording_duration_ms` fallback has no pickup stamp at all; dropping it would
+silently stop billing those completed calls. A genuine no-answer satisfies
+neither clause and stays unbilled.
+
+**Deliberate widening:** this also starts billing a call that answered and then
+failed mid-conversation (`status=failed`). That is intended — those minutes
+were consumed too.
+
+## `send_dtmf` tool
+
+### Why a Hail tool rather than LiveKit's
+
+`AgentSession(ivr_detection=True)` normally injects LiveKit's own
+`send_dtmf_events` tool for the whole call. But `AMD._run()` force-disables
+session-level `ivr_detection` and takes over the IVR lifecycle
+(`amd/detector.py:365`, unchanged in 1.6.6). With AMD on, LiveKit's DTMF tool
+therefore exists **only** after a `machine-ivr` verdict — so a phone tree
+reached mid-call, or after a human transfer, would be unpressable.
+
+A Hail-registered tool is always available, uses only public API, and inherits
+the registry's `body.tools` allowlist, per-org availability gate, unified
+failure wrapper, and `call_events` `tool_call` logging.
+
+### Shape
+
+New `core/hailhq/core/agent_tools/send_dtmf.py`, one line added to
+`registry.py`. Follows `end_call.py` exactly.
+
+`ToolContext` gains:
+
+```python
+send_dtmf: Callable[[str], Awaitable[None]] | None
+```
+
+The voicebot builds this closure over
+`ctx.room.local_participant.publish_dtmf`, the same way it builds `hangup`.
+This keeps `core/` free of `livekit` imports, matching the existing capability-
+handle pattern.
+
+Spec:
+
+- **Parameters:** `{"digits": {"type": "string"}}`, e.g. `"123#"`.
+- **Validation:** characters restricted to `0-9`, `*`, `#`, `A-D`; max 32
+  characters. A reject returns a speakable sentence, not an exception.
+- **Codes:** RFC 4733 — `0-9` → `0-9`, `*` → 10, `#` → 11, `A-D` → 12-15.
+- **Pacing:** 0.3s between digits, matching LiveKit's own
+  `DEFAULT_DTMF_PUBLISH_DELAY`.
+- **`risk_tier`:** `session_control`. Same as `end_call`, so the voicebot
+  wrapper's `context.wait_for_playout()` runs first and the agent never sends
+  tones over its own TTS.
+- **`is_available`:** always `True`.
+- **Returns:** a short spoken confirmation, or `SPOKEN_FALLBACK` on failure.
+
+AMD's automatic IVR navigation still runs on top of this for calls that reach a
+phone tree at pickup.
+
+## Testing
+
+**`voicebot/tests/test_amd.py`**
+
+- Each of the five categories: hangup vs. proceed, `captured` status and
+  `end_reason` stamped correctly, disclosure spoken or suppressed.
+- `amd_result` call event written on every path.
+- `run_amd` raising → returns `None` and the call proceeds normally.
+- AMD constructed with the session's own `llm`/`stt` and the right
+  `participant_identity`.
+
+**`core/tests/test_send_dtmf.py`**
+
+- Digit-to-code mapping across `0-9 * # A-D`.
+- Validation rejects (empty, over-length, illegal characters) return speakable
+  text.
+- Digits are published in order.
+- `ctx.send_dtmf is None` → speakable line, no raise.
+
+**Billing**
+
+- `answered_at` set + `status=no_answer` → `usage_events` row written.
+- `answered_at` `None` → no row.
+
+**Regression (dependency bump)**
+
+- Existing `voicebot/`, `core/`, and `api/` suites pass on 1.6.6.
+- `session.on("close")` reason mapping still produces the expected
+  `CallEndReason` values.
+
+## Documentation
+
+`docs/architecture.md` voicebot section gains a short AMD + DTMF paragraph.
+
+No `.env.example` change (no new env vars), no `openapi.yaml` regen, no CLI
+codegen.
+
+## Out of scope
+
+- Leaving voicemail messages.
+- A per-call AMD opt-out. AMD runs on every outbound call.
+- A new `voicemail` call status.
+- Inbound calls.

--- a/uv.lock
+++ b/uv.lock
@@ -1009,7 +1009,7 @@ wheels = [
 
 [[package]]
 name = "hail-sdk"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "sdk" }
 dependencies = [
     { name = "httpx" },
@@ -1488,6 +1488,15 @@ wheels = [
 ]
 
 [[package]]
+name = "json-repair"
+version = "0.60.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a6/d69888cb4ffde30e80db1e6c32caaadd2f984a80067d5ea72c2cb3f61c3f/json_repair-0.60.1.tar.gz", hash = "sha256:841661cdd2df507c9a4e189097f38ca6bc372e06d4b4e36d72e590f68176c290", size = 49451, upload-time = "2026-06-03T17:28:44.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/1f/2a2b5eea8ef5762a86ad3f8fddddaaba2c0d76dd44e644b9158900868bec/json_repair-0.60.1-py3-none-any.whl", hash = "sha256:ba6ff974f2a8bef2f7768144a7f03f870a816443f03da27a49cdd0ec31a78049", size = 48045, upload-time = "2026-06-03T17:28:43.038Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1589,7 +1598,7 @@ wheels = [
 
 [[package]]
 name = "livekit"
-version = "1.1.5"
+version = "1.1.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1597,18 +1606,18 @@ dependencies = [
     { name = "protobuf" },
     { name = "types-protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/e8/101379a874e8d7ad75659d0165fef4d58cfe58c2799c6e7476787446fcbc/livekit-1.1.5.tar.gz", hash = "sha256:bf2e5154bdcd99f7c32da045bbde8b76592f9ac33902ea62944178d5d278a6c4", size = 330482, upload-time = "2026-04-03T19:21:03.139Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/92/dcd4f295913533ddd0d48153cc28f1358d550bea651460bd895256981c4d/livekit-1.1.13.tar.gz", hash = "sha256:aa2bd89cf0c2ebcaa71a240275964c23900a0422a2a3d43d274e88a211a0ecfc", size = 370211, upload-time = "2026-06-30T11:54:00.321Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/74/af8c9622d3c5090bd6908f51485466c7d991b31cfd826d58965982a77b17/livekit-1.1.5-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:79f5f56dc1f3e81f738a8260809cfbe90daee3bb174361e7f8f806a87e4380ce", size = 10110595, upload-time = "2026-04-03T19:20:50.935Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/b2/14a76e90d9ceaf8b9a0d6781fef8e2e979a3b23405fcb653dc901f7f85bf/livekit-1.1.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:75cebfe58aab52e740fd89d342ad3bd3e046adf717827d677b4f89cb10bf4a48", size = 8931838, upload-time = "2026-04-03T19:20:53.375Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/35/b2434dc9bd66c57657900e48acd77c9284cb216875694574b8e0706e57ea/livekit-1.1.5-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:b2ef18f71ad36d9b4a2f66d9ba79b205b9010a3e8c93b91d62157fb4ffbd5865", size = 9936475, upload-time = "2026-04-03T19:20:55.52Z" },
-    { url = "https://files.pythonhosted.org/packages/42/b9/9313bf6ec2ca3dbf572674b2f8fb8d4f75d9093e1c2bd8fbba0cfa652e0f/livekit-1.1.5-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f1150617c7d41efb83e770b0af04747e3b8881889ff20f08e56cb56c13c1b7d4", size = 11336865, upload-time = "2026-04-03T19:20:58.183Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/11/7f8dd10248e1b064b03223f97cdc4579e6b181a492ffaf3bc52a76c163ea/livekit-1.1.5-py3-none-win_amd64.whl", hash = "sha256:7334aa31107a9556fbb6a6cc73bc3f7b6edfc8cb8932f0552cabbf1c1034ff3f", size = 10682067, upload-time = "2026-04-03T19:21:00.655Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/bd/15100217109595aedbb9bcfdfc1c77513c0f44940d72644d16b611476941/livekit-1.1.13-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:2a19b023de9a573fe5da629e3ee514f2962c87e1afec95a6b19bbbdb6ea8f703", size = 10147642, upload-time = "2026-06-30T11:53:48.781Z" },
+    { url = "https://files.pythonhosted.org/packages/97/dd/4f001a9c5ccde361a53437a09bc04dc9cad8003c6711c2bcc0734e18e626/livekit-1.1.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:90b6796e0c4515bc1e8a1e109a40b88d82c36b12452b7ae01fe35be7ee8357ba", size = 8968740, upload-time = "2026-06-30T11:53:51.223Z" },
+    { url = "https://files.pythonhosted.org/packages/26/1a/7e97a45a4b6e10ce3a4e9938e3d3fa0a6512a6557f5990685eab4f6e88d1/livekit-1.1.13-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:43779c0f3bb27589cd517d60c442c674c2f967a97db158829a533974a29a3997", size = 9980507, upload-time = "2026-06-30T11:53:53.349Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/9d/389bbdf39ccd2c464a4749ba7be1584dea608518c32a5ddbc511db6b0cf7/livekit-1.1.13-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f4e83f0e272f4b2e9cc39dbefd7bb23b75bd8c105478d867c2869254ca4e149a", size = 11367692, upload-time = "2026-06-30T11:53:55.409Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ce/a3d3e0566dbd2586c325240d44afec6d44421eb794bcf8dbaca15463a7b7/livekit-1.1.13-py3-none-win_amd64.whl", hash = "sha256:22dff7a39cb3d590a4757e20d3ce5d326ab882350386f5070f45cbd6d9ccf839", size = 10717013, upload-time = "2026-06-30T11:53:57.701Z" },
 ]
 
 [[package]]
 name = "livekit-agents"
-version = "1.5.6"
+version = "1.6.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1619,9 +1628,11 @@ dependencies = [
     { name = "colorama" },
     { name = "docstring-parser" },
     { name = "eval-type-backport" },
+    { name = "json-repair" },
     { name = "livekit" },
     { name = "livekit-api" },
     { name = "livekit-blingfire" },
+    { name = "livekit-local-inference" },
     { name = "livekit-protocol" },
     { name = "nest-asyncio" },
     { name = "numpy" },
@@ -1634,15 +1645,16 @@ dependencies = [
     { name = "psutil" },
     { name = "pydantic" },
     { name = "pyjwt" },
+    { name = "pyyaml" },
     { name = "sounddevice" },
     { name = "typer" },
     { name = "types-protobuf" },
     { name = "typing-extensions" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/05/44a505c2173f60156f04f10b38996dbe41d39d2443fb0207c7269779c7f9/livekit_agents-1.5.6.tar.gz", hash = "sha256:a35a77889f2347fbb1cad6020d748bae66838d30e7a8f592f4928209bc957194", size = 2485827, upload-time = "2026-04-22T20:21:31.521Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/03/7b44243407b788429c2754dcdce6421c30c31f084577c4c858d49ee69f73/livekit_agents-1.6.6.tar.gz", hash = "sha256:6d41bc279b3e34d9c68d3f3b8a428eff919b03f1a383ad6ff808d90faad387db", size = 2616940, upload-time = "2026-07-18T04:17:04.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/22/e0a5fc0f3f4145c46fbf5a373c2c199571685b57ac275fdcbb42444862ab/livekit_agents-1.5.6-py3-none-any.whl", hash = "sha256:8c4cf05e20a5b2c7127d3d2ad8f8fa0e6f3aa753cfa00b4099b8a59471bd428c", size = 2585534, upload-time = "2026-04-22T20:21:29.412Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2e/6f7b6ac3b7d147cafc0c361cfc701677ec19745a76b0bcf9738df9ab57bd/livekit_agents-1.6.6-py3-none-any.whl", hash = "sha256:c511553f6d4dd0e97c6b0953bdcc2471155ca0a72080d58518beabbbec1c5099", size = 2727054, upload-time = "2026-07-18T04:17:02.914Z" },
 ]
 
 [package.optional-dependencies]
@@ -1655,7 +1667,7 @@ images = [
 
 [[package]]
 name = "livekit-api"
-version = "1.1.0"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1664,9 +1676,9 @@ dependencies = [
     { name = "pyjwt" },
     { name = "types-protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/0a/ad3cce124e608c056d6390244ec4dd18c8a4b5f055693a95831da2119af7/livekit_api-1.1.0.tar.gz", hash = "sha256:f94c000534d3a9b506e6aed2f35eb88db1b23bdea33bb322f0144c4e9f73934e", size = 16649, upload-time = "2025-12-02T19:37:11.452Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/19/36ff6712ec638a4b7dad4d8f03795952e401dc31db0b04cddec7892650da/livekit_api-1.2.0.tar.gz", hash = "sha256:a89817b3bca9584873786ff07209839308217537a42f95ecb2609aafaa109ddc", size = 20778, upload-time = "2026-07-11T23:20:54.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/b9/8d8515e3e0e629ab07d399cf858b8fc7e0a02bbf6384a6592b285264b4b9/livekit_api-1.1.0-py3-none-any.whl", hash = "sha256:bfc1c2c65392eb3f580a2c28108269f0e79873f053578a677eee7bb1de8aa8fb", size = 19620, upload-time = "2025-12-02T19:37:10.075Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e7/8926f16d4bc1b2e0ae46d4a507321bb899396d263a757f1adaabcd3b3867/livekit_api-1.2.0-py3-none-any.whl", hash = "sha256:307f8e5cfb0358c3ca091814ab768af55896022151bcd7f951954ccefa036a24", size = 26499, upload-time = "2026-07-11T23:20:53.736Z" },
 ]
 
 [[package]]
@@ -1702,59 +1714,86 @@ wheels = [
 ]
 
 [[package]]
+name = "livekit-local-inference"
+version = "0.2.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/1c/8010498321cb78111194dce2a1b400fd4548a6df9b88b469c3cf2787efd9/livekit_local_inference-0.2.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d31c99cfcb486b7183381289e72f6f75594c44449f5f28e04fbdd202d4200f2c", size = 34833439, upload-time = "2026-06-24T16:54:48.636Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c5/c371b7f1e36dfeab9d240a3e607320918c2564b51db7d2edb8f5064073c8/livekit_local_inference-0.2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56f0641306bc5451502f2f6597bac9b77e56487311d49a1ed356c5ed8ce01da6", size = 35099320, upload-time = "2026-06-24T16:54:51.761Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/04/914b672e43b619f0f6023641cd4ff539354ef07b12d79c2e0a538c219069/livekit_local_inference-0.2.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c684ee2d2f22c0a24ff471cdd5d873ee010135a9469d791c2cd2d3f83b219b51", size = 34821645, upload-time = "2026-06-24T16:54:57.782Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a7/2d19b23b872a8e8b80efc612c3bfcc2f4733b24ca159c9d9426eff2d4eac/livekit_local_inference-0.2.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6379f9d5ee4753919d10a2cedd2e16e1cbf634e496ad21fb54564513b731e69", size = 34865997, upload-time = "2026-06-24T16:55:01.294Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/66/250dbc92f4dd26b7c91c3f1c17ad238117339399006476728bfbabb5fb46/livekit_local_inference-0.2.6-cp311-cp311-win_amd64.whl", hash = "sha256:e5026b2cfd5aa2c85d677cce426b39bab88ee114acbaa814941d3aca8612ba7e", size = 34905736, upload-time = "2026-06-24T16:55:04.213Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/aa/7d6cfa6a2fe6baee8a443820d61b0e7df0cc7b9246762cab8f47c17ddcd3/livekit_local_inference-0.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cb11919621cc542148ebed92408f0567b758057881c7e40d852d9738415a8eae", size = 34835713, upload-time = "2026-06-24T16:55:07.043Z" },
+    { url = "https://files.pythonhosted.org/packages/be/57/e284fb2663bceb78f24496edf6d9468c861797fd24e655381c17fafe300f/livekit_local_inference-0.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:274ea4046e24377e0744056db051c53976d04bd159c12f8c482246d44089ae79", size = 35100531, upload-time = "2026-06-24T16:55:10.65Z" },
+    { url = "https://files.pythonhosted.org/packages/76/6f/9a580a0d3f0c4bb63e7ab627467aeaf66980d21ea52e5946eb054e6f8150/livekit_local_inference-0.2.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:425469dff5505b35a3fab587993b320c829826d041a85c17c53475f64b99f444", size = 34823583, upload-time = "2026-06-24T16:55:13.728Z" },
+    { url = "https://files.pythonhosted.org/packages/72/3d/c4a73813247faa704e9eef1cbf52ebc0f8070ad08b295419033ec3bcea5c/livekit_local_inference-0.2.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0cc28d6e2e1431940b37a8c6d931e4dac914806e2c874a05513db6b65a01d7e", size = 34868325, upload-time = "2026-06-24T16:55:16.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/44/4f5a633f962142480a54eff1e4aea96848e4b54972c617da65e234d51b7d/livekit_local_inference-0.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:5dc4a0574dc2e4a0745e8fcf29c26ca9f3983b885e63ada9761d26311a778d7b", size = 34906570, upload-time = "2026-06-24T16:55:19.914Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ae/5080f01d9c412a0702972efbfc8e4aca48f81baca494027aefcff5e4c8cc/livekit_local_inference-0.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:63beb204b64cdcbb3bc5b1caa1dbff2a9049998b6f897cf6b68285bb6b15926e", size = 34835783, upload-time = "2026-06-24T16:55:22.927Z" },
+    { url = "https://files.pythonhosted.org/packages/25/17/53ee00d6abf7b9c7ad9036356c38f40634aa83f74b8484f40678a92264ad/livekit_local_inference-0.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:26e397fe543abac838c12101267e46974afd268b6475642fdf116391eee8bd43", size = 35100553, upload-time = "2026-06-24T16:55:26.351Z" },
+    { url = "https://files.pythonhosted.org/packages/df/68/1fbbc4d22cbe28800380cdb1c51b8fadbf81bfacb0e966326fc7ee5c1298/livekit_local_inference-0.2.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:188457491cd59ed201d08ec3012fbc2a35d1fa5ac7bd4f4501553b16f5fc7d5b", size = 34823608, upload-time = "2026-06-24T16:55:29.4Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7a/f62bc8dbdd6a4f32abe056bff1c4c4ad7ef30c780a43564594c72af120c2/livekit_local_inference-0.2.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10e1866f23ff6ee694a360e8a032078de3df189d100a748295c30fd1013aef34", size = 34868352, upload-time = "2026-06-24T16:55:32.611Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/86/cd258845ad0b52e3ba68f776f3bc40eebf03d1dde31b2bdcd4d0a1fcb46a/livekit_local_inference-0.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:69bc8976d8feef5a9c31e2c7bbd10d84e5494e1ecf85aedc75ebecef04fc9c08", size = 34906535, upload-time = "2026-06-24T16:55:35.78Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1d/d17f9ca55285689a47d69534cd31543a96e64282be7ab9513590957e00e8/livekit_local_inference-0.2.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:bc4b3363dd307cf0b38203ef93d1750469db3bb1f99659ed40537fe473689761", size = 34836123, upload-time = "2026-06-24T16:55:38.902Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3c/8b8921b77daed54c012588aa3419c56ebd71d975e292f4cc4b36baeec892/livekit_local_inference-0.2.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:635904e6aef00fe2544bd55f1a526368fe7687f569a8d39c8f317b51e3539fe6", size = 35100892, upload-time = "2026-06-24T16:55:41.807Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/9a/7cdf1a77d5fd80e06533d4f2584c45d2c978f1249338969f814502db45ad/livekit_local_inference-0.2.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:80dc582413d816c86a0620410c2bfc3234e782a49d2b07b4bed0ff6285bdf4a1", size = 34824215, upload-time = "2026-06-24T16:55:45.02Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f2/0207071f236f639cf9515838ce98cfc3a8c1b19db8e6f46350e7231f2200/livekit_local_inference-0.2.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c148ec2735e903dc00e37dc2580e0417f67ec7ee4be119dca7844b104afbfe9", size = 34868380, upload-time = "2026-06-24T16:55:48.119Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/91/c194db20c8e9272cadf0913d42392cda5eec5e78a14820a3fa678e42e4b6/livekit_local_inference-0.2.6-cp314-cp314-win_amd64.whl", hash = "sha256:4140e4fd60dd7b7d69a55e1d454d5d893f8ffe026c30e0d7cd31fa42b10d5621", size = 34914243, upload-time = "2026-06-24T16:55:51.322Z" },
+]
+
+[[package]]
 name = "livekit-plugins-anthropic"
-version = "1.5.6"
+version = "1.6.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "httpx" },
     { name = "livekit-agents" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/99/4ae4a9741b99aaf3c7627f610e2b8d7ac166ff4c04155eb33bb57919a545/livekit_plugins_anthropic-1.5.6.tar.gz", hash = "sha256:e5d60f4843db83d833bac6e813eefe2823ef1479c988b41b07f1be5c4ae281bb", size = 9011, upload-time = "2026-04-22T20:21:33.397Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/33/68d84121fbc69e144f3432222fe87304992e140f7029c23bcfde06fc7aaa/livekit_plugins_anthropic-1.6.6.tar.gz", hash = "sha256:235e790ee62d16e71b1d6c55997e2fca1e9ab6567a6e69d255d50480d7e44d15", size = 9286, upload-time = "2026-07-18T04:17:04.967Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/d7/2329015e7e32aa72fadfeed54e318f457c069e1c6eb39ea47cd2132b6438/livekit_plugins_anthropic-1.5.6-py3-none-any.whl", hash = "sha256:ffe0777898acc9975112acd0a2e35ba79c0bbca0bb110241577cb4b7abb8e7e8", size = 10752, upload-time = "2026-04-22T20:21:32.236Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/3d/edfd499f457fc1aca5f1c7ff38bff4180a2b745ad6d7f4aa3927609162f6/livekit_plugins_anthropic-1.6.6-py3-none-any.whl", hash = "sha256:602841a25b4a63c7f732fdba8a9171c2fea0fd88d5860bc4ea9004f6999af51e", size = 11036, upload-time = "2026-07-18T04:17:03.93Z" },
 ]
 
 [[package]]
 name = "livekit-plugins-cartesia"
-version = "1.5.6"
+version = "1.6.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "livekit-agents" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/14/77eea348aaf098a5c8dca838e92497b574af663e74f360a9917ca4cd62cd/livekit_plugins_cartesia-1.5.6.tar.gz", hash = "sha256:85305f6c39ee22f777ab7d092c3009ec90adebfb6e5d620d64eefe9091c89382", size = 12787, upload-time = "2026-04-22T20:21:57.156Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/14/02ecf382dd1bb922f30fb95498d2153dfa743226563d0de8c765df31f38c/livekit_plugins_cartesia-1.6.6.tar.gz", hash = "sha256:e4a784f0d571cbd240291562c65461f6979e775c0f68682f12d653a43db72df6", size = 18312, upload-time = "2026-07-18T04:17:24.282Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/63/ae802a39a6a80a0c5a45b5ec8b0946759639887b24e505fb3c9d1d6fd188/livekit_plugins_cartesia-1.5.6-py3-none-any.whl", hash = "sha256:8a37fc64d3986548578922f4ca27d38cbbf5c46fa853899efb5a39023d2845e4", size = 15706, upload-time = "2026-04-22T20:21:55.898Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/bfaccaabdbdbef523f935fef57ad3872e4352711c0adeb0626d3a46b3c55/livekit_plugins_cartesia-1.6.6-py3-none-any.whl", hash = "sha256:c9369adc612c91b5ec0d1b849a1db3ebc5bcf651e2cc438733ec4dc2fd9cc53e", size = 25681, upload-time = "2026-07-18T04:17:23.154Z" },
 ]
 
 [[package]]
 name = "livekit-plugins-deepgram"
-version = "1.5.6"
+version = "1.6.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "livekit-agents", extra = ["codecs"] },
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/a0/b6927223dc5aee135c413e53c0dd723c26cd905d4167f9313fd593951957/livekit_plugins_deepgram-1.5.6.tar.gz", hash = "sha256:3d8e7a994aad7f32fe74f51408d7b1c792941ada76658f28a3fc9d52ba9a424b", size = 17642, upload-time = "2026-04-22T20:21:54.195Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/3c/fd3f9b2398fa51b410f6dcedd188a72daf92d15b526c042bf47e631e516d/livekit_plugins_deepgram-1.6.6.tar.gz", hash = "sha256:384d38b9098c9262c380208053e07b48e8a4dd1526a42cef889b9d60e76ac0db", size = 22607, upload-time = "2026-07-18T04:17:27.994Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/bc/6a48e32d051e5c34cdbf6ec524d0cb704a908344c690cb371e8aec9f7d4f/livekit_plugins_deepgram-1.5.6-py3-none-any.whl", hash = "sha256:a10cc85b191f1d83480876ddac4af01860bf4c83214edab2419abaafd8d528c2", size = 22487, upload-time = "2026-04-22T20:21:53.071Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e9/4eb44bfd67bc6b9d5f448639def94016a57b08af2ba532d7343c3627e10a/livekit_plugins_deepgram-1.6.6-py3-none-any.whl", hash = "sha256:c6fb33b397495519089f56f049c564cbc7e1f2a9f1a4f656cfab531f68b9e582", size = 26081, upload-time = "2026-07-18T04:17:26.923Z" },
 ]
 
 [[package]]
 name = "livekit-plugins-elevenlabs"
-version = "1.5.6"
+version = "1.6.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "livekit-agents", extra = ["codecs"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/2f/de721a3ee4724b57a36b2d870a5bc8c90d39ecec4f82cefe94c31c677d7e/livekit_plugins_elevenlabs-1.5.6.tar.gz", hash = "sha256:3191793f29aef3f0de41166e21411bf4d107efb2ae8bc2ef15e9a40fda877e2c", size = 17325, upload-time = "2026-04-22T20:21:58.273Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/ee/761c44b5ebb3327225676a6695387e22c2fa6f958be037718dbec0ed07bc/livekit_plugins_elevenlabs-1.6.6.tar.gz", hash = "sha256:51f7f441f3adadf5683858f72ab1550d07c6570af6c2fac9058f1f7728a6754e", size = 18691, upload-time = "2026-07-18T04:17:28.417Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/a5/a634dc3d92ea74a90630bff2919e165dd2b25f5a050434532d872f20a81d/livekit_plugins_elevenlabs-1.5.6-py3-none-any.whl", hash = "sha256:44b3521fd53505e6dcf6c67a78a451b4075773060bdc9b528a1b6c253d9015fb", size = 19993, upload-time = "2026-04-22T20:21:56.945Z" },
+    { url = "https://files.pythonhosted.org/packages/75/20/5224d2fc889a58e2dd84a1ab345f72f3b7f3373d7f3c811e7c357bd27f4d/livekit_plugins_elevenlabs-1.6.6-py3-none-any.whl", hash = "sha256:9e0af2f361d4f22d64971dc84cc45803d1048828c25ff6c714483caba80e6d2b", size = 21431, upload-time = "2026-07-18T04:17:27.354Z" },
 ]
 
 [[package]]
 name = "livekit-plugins-google"
-version = "1.5.6"
+version = "1.6.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
@@ -1763,41 +1802,41 @@ dependencies = [
     { name = "google-genai" },
     { name = "livekit-agents" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/8c/219a619f136bfa814f6dbfe1beff7ed6391de8b5ddcdf00d2540a2a0df1f/livekit_plugins_google-1.5.6.tar.gz", hash = "sha256:f3841bc0cc4cf856b6aa724729b49686d94c349b2593af3fa776eab3f2d31d8a", size = 40711, upload-time = "2026-04-22T20:22:19.614Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/a8/29ec57b841a4bc42665d00835ab59099f74129719cd3baa2c53facccb67b/livekit_plugins_google-1.6.6.tar.gz", hash = "sha256:b3eb01e134246bc1057381eb25e36ae4ddc911e25faf238393a5b9cc2164eec7", size = 48677, upload-time = "2026-07-18T04:17:49.013Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/d2/f4cd5b8b658a8e20b09645c6a681eda6f4841277d698c334cbacbe11f196/livekit_plugins_google-1.5.6-py3-none-any.whl", hash = "sha256:10ad60c24b24df577efe6214a8c805b7c5e33e10d7e395d362508c9d78b972b7", size = 47330, upload-time = "2026-04-22T20:22:18.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/68/d571551dd0193a524df7de244f7d102cdcca32bd0413dd9aeb581ffeb22c/livekit_plugins_google-1.6.6-py3-none-any.whl", hash = "sha256:f897656cf432e38400356b1d2f0fd101788290ea3082557c953a7ef82010e8b5", size = 56404, upload-time = "2026-07-18T04:17:47.97Z" },
 ]
 
 [[package]]
 name = "livekit-plugins-openai"
-version = "1.5.6"
+version = "1.6.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "livekit-agents", extra = ["codecs", "images"] },
     { name = "openai", extra = ["realtime"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/90/11573bd130ce6bb173c3ae24a2dc23b3f040504ddb99ea4d47548d7a4e0a/livekit_plugins_openai-1.5.6.tar.gz", hash = "sha256:e6c8fa6560f5adcbb47b61d674749805b9e7df64b3dd44421ddc2529b506f12c", size = 43026, upload-time = "2026-04-22T20:23:01.512Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/8b/c6616f56097a000cded518257dd70bf679175726893f3d3bacdf81a94c63/livekit_plugins_openai-1.6.6.tar.gz", hash = "sha256:e52505ec478ceab7dcca87f32bf7e59406a68c9838f5f6e717d6609d8240fa49", size = 48505, upload-time = "2026-07-18T04:18:33.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/0a/0f55f595ea6075a80234df26cdadf3d863de051cd2211d8fc3e4139c9622/livekit_plugins_openai-1.5.6-py3-none-any.whl", hash = "sha256:f7e8c14cbafbe837b271ff5c0e6fff7292ef536d50c00f48da3b23823e1aaea9", size = 49797, upload-time = "2026-04-22T20:23:00.253Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/26/637e4ef8584675cdfbc228fac6ccfc8ffe3fde84ae472df08f02b9ee29ad/livekit_plugins_openai-1.6.6-py3-none-any.whl", hash = "sha256:37a5db03d4875c4ea3a68acdcc001b8b4900d59746b7feb955d2e8530fc43d46", size = 54994, upload-time = "2026-07-18T04:18:32.428Z" },
 ]
 
 [[package]]
 name = "livekit-plugins-silero"
-version = "1.5.6"
+version = "1.6.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "livekit-agents" },
     { name = "numpy" },
     { name = "onnxruntime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/3f/74222ff7d53bae89bb77a7df38bfba988f390901dc8e5fd5a5cecb431c76/livekit_plugins_silero-1.5.6.tar.gz", hash = "sha256:5e4c1624d471f69f520ca4cc2c73779551d61f59e8c40ad7b5ee100e9824e8fc", size = 1955612, upload-time = "2026-04-22T20:23:21.395Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/8c/cd7f556d01b5009ba71eb59cf7d19000a5331f67ffdbb5f45ba7f09b400f/livekit_plugins_silero-1.6.6.tar.gz", hash = "sha256:80b415d1edbef731fedc66e9b0dff2627c2b76e084f2433b25ed94e9843ceeb5", size = 1955917, upload-time = "2026-07-18T04:18:49.34Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/f8/eb350e7713030d691a76ac8ac4a48355dc21ed407f5d6fb00febbecd5628/livekit_plugins_silero-1.5.6-py3-none-any.whl", hash = "sha256:052c68dfd6687e20bf47c9a08d2e4f21b7597b68be1b5b3ba0ab69304dbe3bd8", size = 3903689, upload-time = "2026-04-22T20:23:19.607Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/7c/64d24bd15e1cca6edc0a48c9044e9414743264ddf6349ea308e94ee80188/livekit_plugins_silero-1.6.6-py3-none-any.whl", hash = "sha256:f2edd621d6ebf44d007d942203487f735d070c991f569bf9d975c5763108e48f", size = 3903913, upload-time = "2026-07-18T04:18:47.552Z" },
 ]
 
 [[package]]
 name = "livekit-plugins-turn-detector"
-version = "1.5.6"
+version = "1.6.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -1806,22 +1845,22 @@ dependencies = [
     { name = "onnxruntime" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/3d/4e0d79a851fb80e911ce921b1f5e8005442e6d9f5bf8eecf768ce351e3e5/livekit_plugins_turn_detector-1.5.6.tar.gz", hash = "sha256:97c31b87b050ab03b307d619705745b1b719a7d8627db4d740cb878ae60de920", size = 8718, upload-time = "2026-04-22T20:23:45.19Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/54/a08fda137247baba443ed3afadd4f0d35cbb09eedb7b3db5cd447d183ba9/livekit_plugins_turn_detector-1.6.6.tar.gz", hash = "sha256:60a3ff4d828d2862e6ec90266e61357c8c75e33aca8fabcb2b80acaa63676987", size = 7408, upload-time = "2026-07-18T04:19:14.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ed/e1003b8e4192fd266f0869ba2adbb743c80f2071993fa67ec666435f6466/livekit_plugins_turn_detector-1.5.6-py3-none-any.whl", hash = "sha256:7a2039735ca868d2d10fb60dbdf74d8d9043ecd0959d803915ffa0eae95c4930", size = 10332, upload-time = "2026-04-22T20:23:43.967Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/97/49c0bcaf5578ad70f11a3f8bf40d99fd2b014fe170f6771afa8188f3bfbe/livekit_plugins_turn_detector-1.6.6-py3-none-any.whl", hash = "sha256:091395e3f3122cf7cb9db3119e19e69129c09969facb197fc15c5aa75a14edde", size = 10468, upload-time = "2026-07-18T04:19:13.564Z" },
 ]
 
 [[package]]
 name = "livekit-protocol"
-version = "1.1.6"
+version = "1.1.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
     { name = "types-protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/28/8a7ee5a4126476a0ce770a482274d51fc81ae0d9f578c07f07d6655acfc4/livekit_protocol-1.1.6.tar.gz", hash = "sha256:43648863440a6ce064f7f8b8b287dda8f5ac82b8da64738b20f42cad51e70f9b", size = 93925, upload-time = "2026-04-20T15:48:43.032Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/e7/912a7d303e4c1ff79c23b5b4425a7abefe161329cda78a5ba3571a7533bf/livekit_protocol-1.1.20.tar.gz", hash = "sha256:cf379e99ddf5890c145053ba340c4b0e92d492591a757e34f741eea9694af6af", size = 122448, upload-time = "2026-07-20T14:08:11.569Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/36/525cd9364036617aa97c597c93d7bddb6be311b86288cd54de77e4892544/livekit_protocol-1.1.6-py3-none-any.whl", hash = "sha256:286ac0bd555b6b75cd8a0c5d417572d7dab524129fcea43080202d170f957710", size = 115012, upload-time = "2026-04-20T15:48:41.312Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/dc5559169397e36f9e3bf1f67bb75312dfcdc3d6666dbd7c1cd61c6b50c6/livekit_protocol-1.1.20-py3-none-any.whl", hash = "sha256:8685a8c014afb83113b5d784f816cb3c54e1d9d3da6c142bbac30c0773c9c760", size = 149257, upload-time = "2026-07-20T14:08:10.132Z" },
 ]
 
 [[package]]
@@ -2259,7 +2298,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.32.0"
+version = "2.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2271,9 +2310,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/59/bdcc6b759b8c42dd73afaf5bf8f902c04b37987a5514dbc1c64dba390fef/openai-2.32.0.tar.gz", hash = "sha256:c54b27a9e4cb8d51f0dd94972ffd1a04437efeb259a9e60d8922b8bd26fe55e0", size = 693286, upload-time = "2026-04-15T22:28:19.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/ac/f725c4efbda8657d02be684607e5a2e5ce362e4790fdbcbdfb7c15018647/openai-2.46.0.tar.gz", hash = "sha256:0421e0735ac41451cad894af4cddf0435bfbf8cbc538ac0e15b3c062f2ddc06a", size = 1114628, upload-time = "2026-07-17T02:48:06.05Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/c1/d6e64ccd0536bf616556f0cad2b6d94a8125f508d25cfd814b1d2db4e2f1/openai-2.32.0-py3-none-any.whl", hash = "sha256:4dcc9badeb4bf54ad0d187453742f290226d30150890b7890711bda4f32f192f", size = 1162570, upload-time = "2026-04-15T22:28:17.714Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/206238ebcb50b235942b1c66dba4974776f2057402a8d91c399be587d66a/openai-2.46.0-py3-none-any.whl", hash = "sha256:672381db55efb3a1e2610f29304c130cccdd0b319bace4d492b2443cb64c1e7c", size = 1637556, upload-time = "2026-07-17T02:48:03.695Z" },
 ]
 
 [package.optional-dependencies]

--- a/voicebot/hailhq/voicebot/agent.py
+++ b/voicebot/hailhq/voicebot/agent.py
@@ -34,6 +34,7 @@ from sqlalchemy import select, update
 from sqlalchemy.exc import SQLAlchemyError
 
 from hailhq.core.agent_tools.client import AgentApiClient
+from hailhq.core.agent_tools.send_dtmf import DTMF_CODES
 from hailhq.core.call_end_reasons import CallEndReason
 from hailhq.core.config import settings
 from hailhq.core.db import session_scope
@@ -43,6 +44,7 @@ from hailhq.core.pool import release_pool_reservation
 from hailhq.core.models import Call, CallEvent, UsageEvent
 from hailhq.core.schemas import TERMINAL_CALL_STATUSES
 from hailhq.core.url_guard import assert_public_https_url
+from hailhq.voicebot.amd import MACHINE_HANGUP_CATEGORIES, amd_end_reason, run_amd
 from hailhq.voicebot.pipeline import (
     ProviderKeyError,
     build_session,
@@ -178,10 +180,28 @@ def make_agent_hangup(
     return _hangup
 
 
+def make_agent_send_dtmf(ctx: JobContext) -> Callable[[str], Awaitable[None]]:
+    """Build the DTMF handle wired into the ``send_dtmf`` agent tool.
+
+    One already-validated digit per call — ``core``'s tool owns the vocabulary
+    (:data:`hailhq.core.agent_tools.send_dtmf.DTMF_CODES`) and the inter-digit
+    pacing; this side owns only the transport, which is what keeps ``core``
+    free of ``livekit`` imports.
+    """
+
+    async def _send_dtmf(digit: str) -> None:
+        await ctx.room.local_participant.publish_dtmf(
+            code=DTMF_CODES[digit], digit=digit
+        )
+
+    return _send_dtmf
+
+
 async def build_tools_safely(
     metadata: dict[str, Any],
     call_id: UUID,
     hangup: Callable[[], Awaitable[None]],
+    send_dtmf: Callable[[str], Awaitable[None]],
 ) -> tuple[list, AgentApiClient | None]:
     """Build this call's agent tools, degrading to none on any failure.
 
@@ -191,7 +211,9 @@ async def build_tools_safely(
     the session.
     """
     try:
-        return await build_agent_tools(metadata, call_id=call_id, hangup=hangup)
+        return await build_agent_tools(
+            metadata, call_id=call_id, hangup=hangup, send_dtmf=send_dtmf
+        )
     except Exception:
         logger.exception(
             "call_id=%s build_agent_tools failed; continuing without agent tools",
@@ -566,11 +588,22 @@ async def on_call_end(
         # backstop can retry. No-op for non-pool calls.
         await release_pool_reservation(session, call_id=call_id)
         usage_event_id: str | None = None
-        # Only bill for calls that *this call* actually completed a conversation
-        # on. A no-answer / busy / failed call has a non-zero ring delta but
-        # isn't billable; an already-terminal row (transitioned is False) was
-        # billed — or deliberately not — by whoever closed it first.
-        if transitioned and final_status == "completed" and duration_ms > 0:
+        # Bill when the call actually consumed minutes. Two sufficient
+        # conditions, deliberately OR'd:
+        #   - `answered_at` set: the SIP leg went active, so someone (or
+        #     something) picked up. This is what lets a voicemail box
+        #     (status=no_answer) or a call that died mid-conversation
+        #     (status=failed) still bill for the minutes it burned.
+        #   - status='completed': the historical test, kept so a completed
+        #     call whose answer signal never landed — a DB blip inside
+        #     `mark_call_answered`, a missed `sip.callStatus` event, a legacy
+        #     row predating `answered_at`, or the `recording_duration_ms`
+        #     fallback above — is still billed rather than silently free.
+        # A genuine no-answer satisfies neither and stays unbilled. An
+        # already-terminal row (transitioned is False) was billed — or
+        # deliberately not — by whoever closed it first.
+        billable = answered_at is not None or final_status == "completed"
+        if transitioned and billable and duration_ms > 0:
             usage = UsageEvent(
                 organization_id=organization_id,
                 channel="voice",
@@ -782,7 +815,10 @@ async def entrypoint(ctx: JobContext) -> None:
             captured["status"] = "failed"
 
     agent_tools, agent_api = await build_tools_safely(
-        metadata, call_id, make_agent_hangup(ctx, captured)
+        metadata,
+        call_id,
+        make_agent_hangup(ctx, captured),
+        make_agent_send_dtmf(ctx),
     )
     if agent_tools:
         logger.info(
@@ -797,16 +833,20 @@ async def entrypoint(ctx: JobContext) -> None:
     )
     await session.start(agent=agent, room=ctx.room)
 
-    await speak_greeting(session, metadata)
-
     room_name = ctx.room.name
 
     soft_cap_seconds = settings.hail_voice_max_duration_seconds
     soft_cap_task: asyncio.Task[None] | None = None
     if soft_cap_seconds > 0:
-        # When the cap actually fires (vs being cancelled by a natural hangup)
-        # stamp end_reason='soft_cap_reached' before ctx.shutdown so the
-        # shutdown callback writes it.
+        # Armed here, before AMD and before the greeting, so the cap bounds
+        # the whole call from pickup. Starting it after those would let a
+        # 20s detection window plus greeting playout (`session.say` awaits
+        # full playout) push the real ceiling ~30s past what the operator
+        # configured. Cancelled in `_shutdown` on every other exit path.
+        #
+        # When the cap actually fires (vs being cancelled by a natural
+        # hangup) stamp end_reason='soft_cap_reached' before ctx.shutdown so
+        # the shutdown callback writes it.
         def _on_soft_cap_fired() -> None:
             captured["end_reason"] = CallEndReason.SOFT_CAP_REACHED.value
             # Status stays None → on_call_end falls back to "completed".
@@ -840,6 +880,54 @@ async def entrypoint(ctx: JobContext) -> None:
 
     ctx.add_shutdown_callback(_shutdown)
 
+    # Answering machine detection: classify the greeting before we say
+    # anything. The event is written on every call, machine or not, so
+    # classification quality is observable per call. A detection failure
+    # returns None and the call proceeds exactly as it did before AMD.
+    amd_result = await run_amd(session, call_id)
+    await write_call_event(
+        call_id,
+        "amd_result",
+        {
+            "category": amd_result.category.value if amd_result else None,
+            # Truncated like the `error` payload above: an IVR menu or a
+            # rambling voicemail greeting can run to multiple KB, and this
+            # row is written on every single call.
+            "transcript": (amd_result.transcript or "")[:500] if amd_result else None,
+        },
+    )
+    if amd_result is not None and amd_result.category in MACHINE_HANGUP_CATEGORIES:
+        # Voicemail or a dead mailbox — hang up without speaking. We never
+        # leave a message: a partial line on someone's voicemail is worse
+        # than silence. Mirrors `make_agent_hangup`: delete_room disconnects
+        # the phone leg, ctx.shutdown releases the job and drives `_shutdown`.
+        end_reason = amd_end_reason(amd_result.category)
+        captured["status"] = "no_answer"
+        captured["end_reason"] = end_reason
+        logger.info(
+            "call_id=%s answered by a machine (%s) — hanging up",
+            call_id,
+            amd_result.category.value,
+        )
+        try:
+            await ctx.delete_room()
+        except Exception:
+            logger.exception("delete_room failed after machine detection")
+        ctx.shutdown(reason=end_reason)
+        return
+
+    # AMD holds the greeting for up to its detection window, and the callee
+    # can hang up inside it. `AgentSession.say` raises RuntimeError once the
+    # activity is torn down, so a greeting that arrives after the session
+    # died must not escape entrypoint — the shutdown callback registered
+    # above already finalizes the row.
+    try:
+        await speak_greeting(session, metadata)
+    except Exception:
+        logger.exception(
+            "call_id=%s greeting failed; session closed during detection", call_id
+        )
+
 
 __all__ = [
     "AI_DISCLOSURE_LINE",
@@ -856,6 +944,7 @@ __all__ = [
     "entrypoint",
     "is_sip_answer_signal",
     "make_agent_hangup",
+    "make_agent_send_dtmf",
     "mark_call_answered",
     "on_call_end",
     "parse_metadata",

--- a/voicebot/hailhq/voicebot/amd.py
+++ b/voicebot/hailhq/voicebot/amd.py
@@ -1,0 +1,122 @@
+"""Answering machine detection for outbound calls.
+
+Classifies who picked up — person, phone tree, voicemail, dead mailbox — so
+the agent never talks to a machine. Lives outside :mod:`hailhq.voicebot.agent`
+purely to keep that module's size in check; the only caller is ``entrypoint``.
+
+Verified 2026-07-21 against livekit-agents 1.6.6
+(``livekit/agents/voice/amd/detector.py``, ``.../classifier.py``): the ``AMD``
+constructor kwargs used below, ``AMDCategory`` values, and ``execute()``
+returning an :class:`AMDPredictionEvent`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from uuid import UUID
+
+from livekit.agents.llm import LLM
+from livekit.agents.voice import AgentSession
+from livekit.agents.voice.amd import AMD, AMDPredictionEvent
+
+from hailhq.core.call_end_reasons import CallEndReason
+
+logger = logging.getLogger("hailhq.voicebot")
+
+# Categories we hang up on rather than speak to. `machine-ivr` is deliberately
+# absent — AMD starts LiveKit's IVR navigation for it and the tree may still
+# route to a person. `uncertain` is absent too: when in doubt, talk.
+MACHINE_HANGUP_CATEGORIES: frozenset[str] = frozenset(
+    {"machine-vm", "machine-unavailable"}
+)
+
+_END_REASON_BY_CATEGORY: dict[str, CallEndReason] = {
+    "machine-vm": CallEndReason.VOICEMAIL_REACHED,
+    "machine-unavailable": CallEndReason.MACHINE_UNAVAILABLE,
+}
+
+# Ceiling on how long a live-but-silent callee waits before hearing the
+# disclosure. LiveKit's default is 10.0s; ten seconds of dead air is a worse
+# regression than a slightly less certain verdict.
+NO_SPEECH_THRESHOLD_SECONDS = 6.0
+
+# Backstop on the whole detection. AMD's own 20s budget is armed only once
+# the SIP audio track publishes (``AMD._setup`` awaits
+# ``wait_for_track_publication``, which takes no timeout), so a leg that
+# never publishes — trunk failure, no early media — would otherwise leave
+# ``execute()`` waiting on its verdict forever, with entrypoint blocked
+# behind it. Comfortably above AMD's internal budget so this fires only when
+# that budget never started.
+DETECTION_TIMEOUT_SECONDS = 30.0
+
+
+def amd_end_reason(category: str) -> str:
+    """The ``call_end_reason`` for a machine category we hang up on."""
+    return _END_REASON_BY_CATEGORY[category].value
+
+
+async def run_amd(session: AgentSession, call_id: UUID) -> AMDPredictionEvent | None:
+    """Classify the greeting on ``session``'s SIP leg. ``None`` if AMD failed.
+
+    ``llm`` and ``stt`` are passed explicitly on purpose. Left unset on 1.6.6,
+    AMD auto-selects LiveKit Inference (``google/gemini-3.1-flash-lite`` +
+    ``cartesia/ink-whisper``) whenever ``LIVEKIT_URL`` is Cloud and the API key
+    and secret are set — which is Hail's deployed config. That would send the
+    greeting transcript to a vendor we do not otherwise use, bill it outside
+    the ``usage_events`` model, and override the BYO provider precedence that
+    :mod:`hailhq.voicebot.pipeline` exists to enforce. Passing the session's
+    own layers keeps classification on the brain the org chose — and since that
+    LLM is not on LiveKit's evaluated list, the compatibility warning would
+    otherwise fire on every call.
+
+    ``participant_identity`` matches the identity the API service gives the SIP
+    participant it creates (``caller-{call_id}``). Without it AMD attaches to
+    the first remote audio track, which is non-deterministic if the room ever
+    holds another participant.
+
+    A detection failure must never kill a call — same posture as
+    ``build_tools_safely``. The caller treats ``None`` as "proceed normally".
+    """
+    try:
+        # session.llm is typed LLM | RealtimeModel | None; Hail never uses a
+        # RealtimeModel, so narrow rather than widen AMD's parameter type.
+        session_llm = session.llm
+        if not isinstance(session_llm, LLM):
+            logger.warning("call_id=%s session has no plain LLM; skipping AMD", call_id)
+            return None
+        session_stt = session.stt
+        if session_stt is None:
+            logger.warning("call_id=%s session has no STT; skipping AMD", call_id)
+            return None
+        async with AMD(
+            session,
+            llm=session_llm,
+            stt=session_stt,
+            participant_identity=f"caller-{call_id}",
+            detection_options={"no_speech_threshold": NO_SPEECH_THRESHOLD_SECONDS},
+            suppress_compatibility_warning=True,
+        ) as detector:
+            return await asyncio.wait_for(
+                detector.execute(), timeout=DETECTION_TIMEOUT_SECONDS
+            )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "call_id=%s answering machine detection timed out after %ss; "
+            "proceeding as if a human answered",
+            call_id,
+            DETECTION_TIMEOUT_SECONDS,
+        )
+        return None
+    except Exception:
+        logger.exception("call_id=%s answering machine detection failed", call_id)
+        return None
+
+
+__all__ = [
+    "DETECTION_TIMEOUT_SECONDS",
+    "MACHINE_HANGUP_CATEGORIES",
+    "NO_SPEECH_THRESHOLD_SECONDS",
+    "amd_end_reason",
+    "run_amd",
+]

--- a/voicebot/hailhq/voicebot/tools.py
+++ b/voicebot/hailhq/voicebot/tools.py
@@ -58,7 +58,7 @@ def _wrap(spec: ToolSpec, tctx: ToolContext):
 
 
 async def build_agent_tools(
-    metadata: dict[str, Any], *, call_id: UUID, hangup
+    metadata: dict[str, Any], *, call_id: UUID, hangup, send_dtmf
 ) -> tuple[list, AgentApiClient | None]:
     """Build this call's LiveKit tools. Returns (tools, api_client).
 
@@ -98,7 +98,11 @@ async def build_agent_tools(
         api = AgentApiClient(settings.hail_api_url, settings.hail_internal_secret)
 
     tctx = ToolContext(
-        call_id=call_id, organization_id=organization_id, api=api, hangup=hangup
+        call_id=call_id,
+        organization_id=organization_id,
+        api=api,
+        hangup=hangup,
+        send_dtmf=send_dtmf,
     )
 
     available: list[ToolSpec] = []

--- a/voicebot/tests/_fakes.py
+++ b/voicebot/tests/_fakes.py
@@ -143,18 +143,42 @@ class FakeAnnouncingSession:
         return handle
 
 
+class FakeLocalParticipant:
+    """Records ``publish_dtmf`` calls made by the DTMF handle.
+
+    Verified shape against livekit/rtc/participant.py:
+    ``publish_dtmf(*, code: int, digit: str)``.
+    """
+
+    def __init__(self) -> None:
+        self.dtmf: list[tuple[int, str]] = []
+
+    async def publish_dtmf(self, *, code: int, digit: str) -> None:
+        self.dtmf.append((code, digit))
+
+
+class FakeRoom:
+    """Minimal ``ctx.room``: the local participant plus a name."""
+
+    def __init__(self, name: str = "hail-test") -> None:
+        self.name = name
+        self.local_participant = FakeLocalParticipant()
+
+
 class FakeJobContext:
     """Stand-in for livekit.agents.JobContext.
 
     Verified shape against livekit/agents/job.py: we need
-    ``ctx.shutdown(reason=…)`` and ``ctx.delete_room()`` (returns an
-    awaitable resolving to the DeleteRoomResponse; a completed Future here).
+    ``ctx.shutdown(reason=…)``, ``ctx.delete_room()`` (returns an
+    awaitable resolving to the DeleteRoomResponse; a completed Future here),
+    and ``ctx.room.local_participant`` for the DTMF handle.
     """
 
     def __init__(self) -> None:
         self.shutdown_calls: list[str] = []
         self.delete_room_calls: int = 0
         self.delete_room_error: Exception | None = None
+        self.room = FakeRoom()
 
     def shutdown(self, reason: str = "") -> None:
         self.shutdown_calls.append(reason)
@@ -173,5 +197,7 @@ __all__ = [
     "FakeAnnouncingSession",
     "FakeJobContext",
     "FakeLLM",
+    "FakeLocalParticipant",
+    "FakeRoom",
     "FakeSpeechHandle",
 ]

--- a/voicebot/tests/test_agent.py
+++ b/voicebot/tests/test_agent.py
@@ -41,6 +41,7 @@ from hailhq.voicebot.agent import (
     entrypoint,
     is_sip_answer_signal,
     make_agent_hangup,
+    make_agent_send_dtmf,
     mark_call_answered,
     on_call_end,
     parse_metadata,
@@ -345,11 +346,13 @@ async def test_on_call_end_inserts_usage_event(async_session: AsyncSession) -> N
     The website's private rater turns that into a dollar debit later.
     """
     call_id = await _make_call_row(async_session)
-    # Backdate started_at so the (now - started_at) delta is roughly 60s.
+    # Backdate the pickup so the (now - answered_at) delta is roughly 60s.
+    # `answered_at` is what gates billing: it means the SIP leg went active.
+    answered = datetime.now(timezone.utc) - timedelta(seconds=60)
     await async_session.execute(
         update(Call)
         .where(Call.id == call_id)
-        .values(started_at=datetime.now(timezone.utc) - timedelta(seconds=60))
+        .values(started_at=answered, answered_at=answered)
     )
     await async_session.commit()
 
@@ -1097,6 +1100,158 @@ async def test_agent_hangup_still_shuts_down_when_delete_room_fails() -> None:
     assert ctx.shutdown_calls == ["agent_end_call"]
 
 
+async def test_agent_send_dtmf_publishes_rfc4733_code() -> None:
+    """The DTMF handle owns only transport; core owns the digit vocabulary."""
+    ctx = FakeJobContext()
+    send_dtmf = make_agent_send_dtmf(ctx)  # type: ignore[arg-type]
+
+    await send_dtmf("#")
+    await send_dtmf("7")
+
+    assert ctx.room.local_participant.dtmf == [(11, "#"), (7, "7")]
+
+
+async def test_on_call_end_bills_a_machine_answered_call(
+    async_session: AsyncSession,
+) -> None:
+    """A voicemail box that picked up burned real minutes — bill them.
+
+    Billing keys off `answered_at` (the SIP leg went active), not the final
+    status, so an AMD hangup recorded as `no_answer` is still billed.
+    """
+    call_id = await _make_call_row(async_session)
+    answered = datetime.now(timezone.utc) - timedelta(seconds=12)
+    await async_session.execute(
+        update(Call)
+        .where(Call.id == call_id)
+        .values(started_at=answered, answered_at=answered)
+    )
+    await async_session.commit()
+
+    await on_call_end(
+        call_id,
+        room_name=f"hail-{call_id}",
+        status_override="no_answer",
+        end_reason_override=CallEndReason.VOICEMAIL_REACHED.value,
+    )
+
+    refreshed = (
+        await async_session.execute(select(Call).where(Call.id == call_id))
+    ).scalar_one()
+    await async_session.refresh(refreshed)
+    assert refreshed.status == "no_answer"
+    assert refreshed.end_reason == CallEndReason.VOICEMAIL_REACHED.value
+
+    rows = (
+        (
+            await async_session.execute(
+                select(UsageEvent).where(UsageEvent.ref == str(call_id))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert 10_000 <= rows[0].units <= 20_000
+
+
+async def test_on_call_end_bills_a_completed_call_with_no_answered_at(
+    async_session: AsyncSession,
+) -> None:
+    """A completed call whose answer signal never landed must still bill.
+
+    `mark_call_answered` can miss (DB blip, dropped `sip.callStatus` event),
+    and legacy rows predate `answered_at` entirely. Billing falls back to
+    `started_at` for those, so `status='completed'` remains a sufficient
+    condition alongside `answered_at`.
+    """
+    call_id = await _make_call_row(async_session)
+    await async_session.execute(
+        update(Call)
+        .where(Call.id == call_id)
+        .values(started_at=datetime.now(timezone.utc) - timedelta(seconds=45))
+    )
+    await async_session.commit()
+
+    await on_call_end(call_id, room_name=f"hail-{call_id}")
+
+    rows = (
+        (
+            await async_session.execute(
+                select(UsageEvent).where(UsageEvent.ref == str(call_id))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert 40_000 <= rows[0].units <= 55_000
+
+
+async def test_on_call_end_does_not_bill_a_call_that_never_answered(
+    async_session: AsyncSession,
+) -> None:
+    """A genuine no-answer rang but never picked up — nothing to bill."""
+    call_id = await _make_call_row(async_session)
+    # started_at (dial time) is set, answered_at is not: pure ring time.
+    await async_session.execute(
+        update(Call)
+        .where(Call.id == call_id)
+        .values(started_at=datetime.now(timezone.utc) - timedelta(seconds=30))
+    )
+    await async_session.commit()
+
+    await on_call_end(
+        call_id,
+        room_name=f"hail-{call_id}",
+        status_override="no_answer",
+        end_reason_override=CallEndReason.USER_UNAVAILABLE.value,
+    )
+
+    rows = (
+        (
+            await async_session.execute(
+                select(UsageEvent).where(UsageEvent.ref == str(call_id))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+async def test_on_call_end_bills_a_call_that_failed_mid_conversation(
+    async_session: AsyncSession,
+) -> None:
+    """Deliberate widening: answered-then-failed minutes were consumed too."""
+    call_id = await _make_call_row(async_session)
+    answered = datetime.now(timezone.utc) - timedelta(seconds=20)
+    await async_session.execute(
+        update(Call)
+        .where(Call.id == call_id)
+        .values(status="in_progress", started_at=answered, answered_at=answered)
+    )
+    await async_session.commit()
+
+    await on_call_end(
+        call_id,
+        room_name=f"hail-{call_id}",
+        status_override="failed",
+        end_reason_override=CallEndReason.AGENT_ERROR.value,
+    )
+
+    rows = (
+        (
+            await async_session.execute(
+                select(UsageEvent).where(UsageEvent.ref == str(call_id))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+
+
 async def test_build_tools_safely_degrades_on_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1108,7 +1263,9 @@ async def test_build_tools_safely_degrades_on_failure(
     """
     from hailhq.voicebot import agent as agent_mod
 
-    async def _boom(_metadata: dict, *, call_id: UUID, hangup: object) -> tuple:
+    async def _boom(
+        _metadata: dict, *, call_id: UUID, hangup: object, send_dtmf: object
+    ) -> tuple:
         raise RuntimeError("dead connection during availability checks")
 
     monkeypatch.setattr(agent_mod, "build_agent_tools", _boom)
@@ -1116,9 +1273,12 @@ async def test_build_tools_safely_degrades_on_failure(
     async def _hangup() -> None:
         return None
 
+    async def _send_dtmf(_digit: str) -> None:
+        return None
+
     call_id = UUID("11111111-2222-3333-4444-555555555557")
     # Must not raise.
-    tools, api = await build_tools_safely({}, call_id, _hangup)
+    tools, api = await build_tools_safely({}, call_id, _hangup, _send_dtmf)
 
     assert tools == []
     assert api is None
@@ -1133,7 +1293,9 @@ async def test_build_tools_safely_passes_through_on_success(
     sentinel_tools = [object()]
     sentinel_api = object()
 
-    async def _ok(_metadata: dict, *, call_id: UUID, hangup: object) -> tuple:
+    async def _ok(
+        _metadata: dict, *, call_id: UUID, hangup: object, send_dtmf: object
+    ) -> tuple:
         return sentinel_tools, sentinel_api
 
     monkeypatch.setattr(agent_mod, "build_agent_tools", _ok)
@@ -1141,8 +1303,11 @@ async def test_build_tools_safely_passes_through_on_success(
     async def _hangup() -> None:
         return None
 
+    async def _send_dtmf(_digit: str) -> None:
+        return None
+
     call_id = UUID("11111111-2222-3333-4444-555555555558")
-    tools, api = await build_tools_safely({}, call_id, _hangup)
+    tools, api = await build_tools_safely({}, call_id, _hangup, _send_dtmf)
 
     assert tools is sentinel_tools
     assert api is sentinel_api

--- a/voicebot/tests/test_amd.py
+++ b/voicebot/tests/test_amd.py
@@ -1,0 +1,396 @@
+"""Answering machine detection: construction, verdict handling, observability.
+
+The per-category tests drive the real ``entrypoint`` with ``run_amd``
+monkeypatched, so they assert the wiring (hang up vs. speak, what lands in
+``captured``, what reaches ``call_events``) rather than LiveKit's classifier.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any
+from uuid import UUID
+
+import pytest
+from livekit.agents.voice.amd import AMDCategory, AMDPredictionEvent
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from hailhq.core.call_end_reasons import CallEndReason
+from hailhq.core.models import Call, CallEvent
+from hailhq.voicebot import amd as amd_mod
+from hailhq.voicebot.amd import (
+    MACHINE_HANGUP_CATEGORIES,
+    NO_SPEECH_THRESHOLD_SECONDS,
+    amd_end_reason,
+    run_amd,
+)
+
+from ._fakes import FakeLLM
+from .test_agent import _make_call_row
+
+# --------------------------------------------------------------------------- #
+# run_amd construction
+# --------------------------------------------------------------------------- #
+
+
+class _RecordingAMD:
+    """Stand-in for livekit.agents.voice.amd.AMD recording its kwargs."""
+
+    last_kwargs: dict[str, Any] = {}
+    result: AMDPredictionEvent | None = None
+
+    def __init__(self, session: Any, **kwargs: Any) -> None:
+        type(self).last_kwargs = {"session": session, **kwargs}
+
+    async def __aenter__(self) -> "_RecordingAMD":
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+    async def execute(self) -> AMDPredictionEvent:
+        assert type(self).result is not None
+        return type(self).result
+
+
+def _prediction(category: str) -> AMDPredictionEvent:
+    return AMDPredictionEvent(
+        speech_duration=1.0,
+        category=AMDCategory(category),
+        reason="test",
+        transcript="hello you have reached",
+        delay=0.1,
+    )
+
+
+def _session_with_layers() -> SimpleNamespace:
+    return SimpleNamespace(llm=FakeLLM(), stt=object())
+
+
+async def test_run_amd_passes_session_layers_and_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AMD must classify on the session's own brain, not LiveKit Inference."""
+    _RecordingAMD.result = _prediction("human")
+    monkeypatch.setattr(amd_mod, "AMD", _RecordingAMD)
+
+    session = _session_with_layers()
+    call_id = UUID("11111111-2222-3333-4444-5555555555aa")
+
+    result = await run_amd(session, call_id)  # type: ignore[arg-type]
+
+    assert result is not None and result.category == AMDCategory.HUMAN
+    kwargs = _RecordingAMD.last_kwargs
+    assert kwargs["session"] is session
+    assert kwargs["llm"] is session.llm
+    assert kwargs["stt"] is session.stt
+    assert kwargs["participant_identity"] == f"caller-{call_id}"
+    assert kwargs["detection_options"] == {
+        "no_speech_threshold": NO_SPEECH_THRESHOLD_SECONDS
+    }
+    assert kwargs["suppress_compatibility_warning"] is True
+    # ivr_detection is left at LiveKit's default (True) on purpose.
+    assert "ivr_detection" not in kwargs
+
+
+async def test_run_amd_returns_none_when_detection_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A detection failure must never kill the call."""
+
+    class _Boom:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            raise RuntimeError("classifier exploded")
+
+    monkeypatch.setattr(amd_mod, "AMD", _Boom)
+
+    assert await run_amd(_session_with_layers(), UUID(int=1)) is None  # type: ignore[arg-type]
+
+
+async def test_run_amd_gives_up_when_detection_never_settles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AMD's own budget arms only once the SIP track publishes; a leg that
+    never publishes would otherwise block entrypoint forever."""
+
+    class _NeverSettles(_RecordingAMD):
+        async def execute(self) -> AMDPredictionEvent:
+            await asyncio.Event().wait()  # pragma: no cover — never returns
+            raise AssertionError("unreachable")
+
+    monkeypatch.setattr(amd_mod, "AMD", _NeverSettles)
+    monkeypatch.setattr(amd_mod, "DETECTION_TIMEOUT_SECONDS", 0.01)
+
+    assert await run_amd(_session_with_layers(), UUID(int=4)) is None  # type: ignore[arg-type]
+
+
+async def test_run_amd_skips_when_session_has_no_llm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(amd_mod, "AMD", _RecordingAMD)
+    session = SimpleNamespace(llm=None, stt=object())
+    assert await run_amd(session, UUID(int=2)) is None  # type: ignore[arg-type]
+
+
+async def test_run_amd_skips_when_session_has_no_stt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(amd_mod, "AMD", _RecordingAMD)
+    session = SimpleNamespace(llm=FakeLLM(), stt=None)
+    assert await run_amd(session, UUID(int=3)) is None  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# category → outcome mapping
+# --------------------------------------------------------------------------- #
+
+
+def test_only_the_two_unreachable_machine_categories_hang_up() -> None:
+    assert MACHINE_HANGUP_CATEGORIES == {"machine-vm", "machine-unavailable"}
+    # machine-ivr proceeds: AMD has already started IVR navigation and the
+    # tree may still route to a person.
+    assert AMDCategory.MACHINE_IVR not in MACHINE_HANGUP_CATEGORIES
+    assert AMDCategory.UNCERTAIN not in MACHINE_HANGUP_CATEGORIES
+    assert AMDCategory.HUMAN not in MACHINE_HANGUP_CATEGORIES
+
+
+def test_amd_end_reason_maps_to_call_end_reason_values() -> None:
+    assert amd_end_reason("machine-vm") == CallEndReason.VOICEMAIL_REACHED.value
+    assert (
+        amd_end_reason("machine-unavailable") == CallEndReason.MACHINE_UNAVAILABLE.value
+    )
+
+
+# --------------------------------------------------------------------------- #
+# entrypoint wiring
+# --------------------------------------------------------------------------- #
+
+
+class _FakeAmdSession:
+    """AgentSession stand-in: event registration, start(), and say()."""
+
+    def __init__(self) -> None:
+        self.say_calls: list[str] = []
+        self.started = False
+
+    def on(self, _event: str):
+        def _register(fn):
+            return fn
+
+        return _register
+
+    async def start(self, **_kwargs: object) -> None:
+        self.started = True
+
+    def say(self, text: str, *, allow_interruptions: bool = True) -> Any:
+        self.say_calls.append(text)
+
+        async def _resolve() -> None:
+            return None
+
+        return _resolve()
+
+
+class _FakeLocalParticipant:
+    def __init__(self) -> None:
+        self.dtmf: list[tuple[int, str]] = []
+
+    async def publish_dtmf(self, *, code: int, digit: str) -> None:
+        self.dtmf.append((code, digit))
+
+
+class _FakeAmdRoom:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.remote_participants: dict[str, object] = {}
+        self.local_participant = _FakeLocalParticipant()
+
+    def on(self, _event: str):
+        def _register(fn):
+            return fn
+
+        return _register
+
+
+class _FakeAmdCtx:
+    def __init__(self, metadata: str, room_name: str) -> None:
+        self.job = SimpleNamespace(metadata=metadata)
+        self.room = _FakeAmdRoom(room_name)
+        self.proc = SimpleNamespace(userdata={"vad": object()})
+        self.shutdown_calls: list[str] = []
+        self.delete_room_calls = 0
+        self.shutdown_callbacks: list[Any] = []
+
+    async def connect(self) -> None:
+        return None
+
+    def shutdown(self, reason: str = "") -> None:
+        self.shutdown_calls.append(reason)
+
+    async def delete_room(self) -> None:
+        self.delete_room_calls += 1
+
+    def add_shutdown_callback(self, cb: Any) -> None:
+        self.shutdown_callbacks.append(cb)
+
+
+async def _drive_entrypoint(
+    async_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    amd_result: AMDPredictionEvent | None,
+) -> tuple[UUID, _FakeAmdCtx, _FakeAmdSession]:
+    """Run ``entrypoint`` with AMD stubbed, then fire the shutdown callback."""
+    from hailhq.voicebot import agent as agent_mod
+
+    org_id = UUID("11111111-2222-3333-4444-555555555555")
+    call_id = await _make_call_row(async_session)
+    session = _FakeAmdSession()
+
+    async def _no_org_cfgs(_org_id: UUID | None, *, skip_llm: bool = False) -> dict:
+        return {}
+
+    async def _fake_run_amd(_session: object, _call_id: UUID):
+        return amd_result
+
+    monkeypatch.setattr(agent_mod, "resolve_org_configs", _no_org_cfgs)
+    monkeypatch.setattr(agent_mod, "build_session", lambda *a, **k: session)
+    monkeypatch.setattr(agent_mod, "run_amd", _fake_run_amd)
+    monkeypatch.setattr(
+        agent_mod.settings, "hail_voice_max_duration_seconds", 0, raising=False
+    )
+
+    ctx = _FakeAmdCtx(
+        metadata=json.dumps(
+            {
+                "call_id": str(call_id),
+                "organization_id": str(org_id),
+                "tools": [],
+                "first_message": "Is this a good time?",
+            }
+        ),
+        room_name=f"hail-{call_id}",
+    )
+
+    await entrypoint_under_test(ctx)
+
+    # The job releases after entrypoint returns; run the callback the same
+    # way the SDK would so on_call_end lands.
+    for cb in ctx.shutdown_callbacks:
+        await cb()
+    await asyncio.sleep(0)
+    return call_id, ctx, session
+
+
+def entrypoint_under_test(ctx: Any):
+    from hailhq.voicebot.agent import entrypoint
+
+    return entrypoint(ctx)
+
+
+async def _amd_events(async_session: AsyncSession, call_id: UUID) -> list[CallEvent]:
+    return list(
+        (
+            await async_session.execute(
+                select(CallEvent).where(
+                    CallEvent.call_id == call_id, CallEvent.kind == "amd_result"
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+@pytest.mark.parametrize(
+    "category,end_reason",
+    [
+        ("machine-vm", CallEndReason.VOICEMAIL_REACHED.value),
+        ("machine-unavailable", CallEndReason.MACHINE_UNAVAILABLE.value),
+    ],
+)
+async def test_machine_categories_hang_up_without_speaking(
+    async_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    category: str,
+    end_reason: str,
+) -> None:
+    call_id, ctx, session = await _drive_entrypoint(
+        async_session, monkeypatch, amd_result=_prediction(category)
+    )
+
+    # Nothing was said — no disclosure, no first_message, no voicemail left.
+    assert session.say_calls == []
+    assert ctx.delete_room_calls == 1
+    assert ctx.shutdown_calls == [end_reason]
+
+    refreshed = (
+        await async_session.execute(select(Call).where(Call.id == call_id))
+    ).scalar_one()
+    await async_session.refresh(refreshed)
+    assert refreshed.status == "no_answer"
+    assert refreshed.end_reason == end_reason
+
+
+@pytest.mark.parametrize("category", ["human", "uncertain", "machine-ivr"])
+async def test_non_hangup_categories_speak_the_disclosure(
+    async_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    category: str,
+) -> None:
+    from hailhq.voicebot.agent import AI_DISCLOSURE_LINE
+
+    _call_id, ctx, session = await _drive_entrypoint(
+        async_session, monkeypatch, amd_result=_prediction(category)
+    )
+
+    assert session.say_calls == [AI_DISCLOSURE_LINE, "Is this a good time?"]
+    assert ctx.delete_room_calls == 0
+    assert ctx.shutdown_calls == []
+
+
+async def test_detection_failure_proceeds_like_a_human_answer(
+    async_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hailhq.voicebot.agent import AI_DISCLOSURE_LINE
+
+    _call_id, ctx, session = await _drive_entrypoint(
+        async_session, monkeypatch, amd_result=None
+    )
+
+    assert session.say_calls[0] == AI_DISCLOSURE_LINE
+    assert ctx.delete_room_calls == 0
+
+
+@pytest.mark.parametrize(
+    "category",
+    ["human", "uncertain", "machine-ivr", "machine-vm", "machine-unavailable"],
+)
+async def test_amd_result_event_written_on_every_path(
+    async_session: AsyncSession, monkeypatch: pytest.MonkeyPatch, category: str
+) -> None:
+    call_id, _ctx, _session = await _drive_entrypoint(
+        async_session, monkeypatch, amd_result=_prediction(category)
+    )
+
+    events = await _amd_events(async_session, call_id)
+    assert len(events) == 1
+    assert events[0].payload == {
+        "category": category,
+        "transcript": "hello you have reached",
+    }
+
+
+async def test_amd_result_event_written_when_detection_failed(
+    async_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    call_id, _ctx, _session = await _drive_entrypoint(
+        async_session, monkeypatch, amd_result=None
+    )
+
+    events = await _amd_events(async_session, call_id)
+    assert len(events) == 1
+    assert events[0].payload == {"category": None, "transcript": None}

--- a/voicebot/tests/test_tools.py
+++ b/voicebot/tests/test_tools.py
@@ -47,6 +47,7 @@ def _tctx():
         organization_id=uuid.uuid4(),
         api=None,
         hangup=None,
+        send_dtmf=None,
     )
 
 
@@ -55,20 +56,26 @@ async def test_empty_opt_out_disables_all_tools():
         {"organization_id": str(uuid.uuid4()), "tools": []},
         call_id=uuid.uuid4(),
         hangup=None,
+        send_dtmf=None,
     )
     assert tools == []
     assert api is None
 
 
 async def test_missing_organization_id_disables_tools():
-    tools, api = await build_agent_tools({}, call_id=uuid.uuid4(), hangup=None)
+    tools, api = await build_agent_tools(
+        {}, call_id=uuid.uuid4(), hangup=None, send_dtmf=None
+    )
     assert tools == []
     assert api is None
 
 
 async def test_malformed_organization_id_disables_tools():
     tools, api = await build_agent_tools(
-        {"organization_id": "not-a-uuid"}, call_id=uuid.uuid4(), hangup=None
+        {"organization_id": "not-a-uuid"},
+        call_id=uuid.uuid4(),
+        hangup=None,
+        send_dtmf=None,
     )
     assert tools == []
     assert api is None
@@ -79,6 +86,7 @@ async def test_malformed_tools_field_disables_tools():
         {"organization_id": str(uuid.uuid4()), "tools": "send_sms"},
         call_id=uuid.uuid4(),
         hangup=None,
+        send_dtmf=None,
     )
     assert tools == []
     assert api is None
@@ -144,6 +152,7 @@ async def test_availability_failure_does_not_poison_session(db, monkeypatch):
         {"organization_id": str(uuid.uuid4())},
         call_id=uuid.uuid4(),
         hangup=None,
+        send_dtmf=None,
     )
     try:
         assert [get_raw_function_info(t).name for t in tools] == ["healthy_tool"]


### PR DESCRIPTION
  Classify who answers an outbound call and hang up on voicemail or a dead
  mailbox instead of talking to a machine. AMD runs on every call with the
  session's own LLM and STT, so classification stays on the org's chosen
  provider rather than silently auto-selecting LiveKit Inference.

  Add a send_dtmf agent tool so the agent can press keypad digits at any
  point. AMD force-disables session-level ivr_detection, so LiveKit's own
  DTMF tool only exists after a machine-ivr verdict; a Hail-registered tool
  is always available and inherits the registry's allowlist and failure
  handling.

  Machine-answered calls record status=no_answer with new voicemail_reached
  and machine_unavailable end reasons, and are billed: the usage_events
  guard now keys off answered_at rather than a completed status, since a
  connected leg consumed real minutes.

  Bumps livekit-agents and plugins 1.5.6 -> 1.6.6 for the AMD detection
  fixes (#5918), the DTMF room-routing fix (#6360), and the
  participant_identity and detection_options parameters.