### PR TITLE
fix(numbers): return 422 (not 500) when a number can't be provisioned

### DIFF
--- a/api/hailhq/api/routes/numbers.py
+++ b/api/hailhq/api/routes/numbers.py
@@ -10,6 +10,7 @@ stays with the rest of the `/numbers` router rather than splitting onto
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated
 from uuid import UUID
 
@@ -32,12 +33,14 @@ from hailhq.core import telephony_catalog
 from hailhq.core.db import get_session
 from hailhq.core.models import PhoneNumber
 from hailhq.core.providers.sms import SmsProvider
-from hailhq.core.providers.voice import VoiceProvider
+from hailhq.core.providers.voice import NumberNotProvisionable, VoiceProvider
 from hailhq.core.schemas import (
     NumberAcquireRequest,
     PhoneNumberListResponse,
     PhoneNumberResponse,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/numbers", tags=["numbers"])
 
@@ -136,6 +139,26 @@ async def acquire_number(
         raise HTTPException(
             status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=str(exc),
+        ) from exc
+    except NumberNotProvisionable as exc:
+        # Deterministic: this country/number-type can't be provisioned without
+        # regulatory setup (a bundle/address) we don't have — a retry fails
+        # identically, so cache the 422 rather than releasing the key. The raw
+        # carrier reason is logged, not leaked to the caller.
+        logger.warning(
+            "number not provisionable (%s %s): %s",
+            body.country_code,
+            body.number_type,
+            exc.detail,
+        )
+        raise await cache_failure(
+            idem,
+            unprocessable(
+                f"we can't provision a {body.number_type} number in "
+                f"{body.country_code} yet — it needs regulatory verification "
+                "we don't support",
+                loc=["body", "number_type"],
+            ),
         ) from exc
 
     number = PhoneNumber(

--- a/api/tests/test_numbers_api.py
+++ b/api/tests/test_numbers_api.py
@@ -93,6 +93,28 @@ async def test_acquire_number_idempotent_replay(
     voice_provider_mock.acquire_number.assert_awaited_once()
 
 
+async def test_acquire_not_provisionable_returns_422_not_500(
+    client, org_and_key, voice_provider_mock
+):
+    """A carrier 'bundle required' rejection (NumberNotProvisionable) surfaces
+    as a clean 422 — not an opaque 500 — and the provider IS reached (unlike
+    the pre-provider allow-list 422). The raw carrier reason is not leaked."""
+    from hailhq.core.providers.voice import NumberNotProvisionable
+
+    voice_provider_mock.acquire_number.side_effect = NumberNotProvisionable(
+        "Bundle required and not provided for country: [GB] and numberType: [MOBILE]"
+    )
+    _, _, plaintext = org_and_key
+    resp = await client.post(
+        "/numbers",
+        json={"country_code": "US", "number_type": "local"},
+        headers={"Authorization": f"Bearer {plaintext}"},
+    )
+    assert resp.status_code == 422, resp.text
+    voice_provider_mock.acquire_number.assert_awaited_once()
+    assert "Bundle" not in resp.text  # raw carrier reason stays server-side
+
+
 async def test_acquire_rejects_unlisted_country_type(
     client, org_and_key, voice_provider_mock
 ):

--- a/core/hailhq/core/providers/voice/__init__.py
+++ b/core/hailhq/core/providers/voice/__init__.py
@@ -1,4 +1,5 @@
 from hailhq.core.providers.voice.base import (
+    NumberNotProvisionable,
     NumberType,
     ProviderCallStatus,
     ProviderNumber,
@@ -7,6 +8,7 @@ from hailhq.core.providers.voice.base import (
 from hailhq.core.providers.voice.twilio import TwilioVoiceProvider
 
 __all__ = [
+    "NumberNotProvisionable",
     "NumberType",
     "ProviderCallStatus",
     "ProviderNumber",

--- a/core/hailhq/core/providers/voice/base.py
+++ b/core/hailhq/core/providers/voice/base.py
@@ -23,11 +23,26 @@ from pydantic import BaseModel
 from hailhq.core.schemas import NumberType
 
 __all__ = [
+    "NumberNotProvisionable",
     "NumberType",
     "ProviderCallStatus",
     "ProviderNumber",
     "VoiceProvider",
 ]
+
+
+class NumberNotProvisionable(Exception):
+    """The carrier refused to provision the requested number for a reason a
+    retry won't fix — most often a country/number-type that needs regulatory
+    verification (a bundle or address) the platform hasn't set up (e.g. GB
+    mobile). Distinct from a transient inventory miss (``LookupError``, a 503)
+    and from transport/auth failures (which propagate). Carries a
+    human-readable ``detail`` for the caller-facing 422.
+    """
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
 
 
 class ProviderNumber(BaseModel):

--- a/core/hailhq/core/providers/voice/twilio.py
+++ b/core/hailhq/core/providers/voice/twilio.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 
 import asyncio
 
+from twilio.base.exceptions import TwilioRestException
 from twilio.rest import Client as TwilioClient
 
 from hailhq.core.config import settings
 from hailhq.core.providers.voice.base import (
+    NumberNotProvisionable,
     NumberType,
     ProviderCallStatus,
     ProviderNumber,
@@ -87,10 +89,22 @@ class TwilioVoiceProvider(VoiceProvider):
             )
         chosen = available[0]
 
-        purchased = await asyncio.to_thread(
-            self._client.incoming_phone_numbers.create,
-            phone_number=chosen.phone_number,
-        )
+        try:
+            purchased = await asyncio.to_thread(
+                self._client.incoming_phone_numbers.create,
+                phone_number=chosen.phone_number,
+            )
+        except TwilioRestException as exc:
+            # A 400 at purchase means the number can't be provisioned as
+            # requested — most often a country/number-type that needs a
+            # regulatory bundle or address we haven't set up (e.g. GB mobile:
+            # "Bundle required and not provided"). Surface it as a typed,
+            # non-retryable error the route maps to a 422, not an opaque 500.
+            # Auth (401/403), rate-limit (429), and 5xx transport failures
+            # propagate unchanged.
+            if exc.status == 400:
+                raise NumberNotProvisionable(exc.msg) from exc
+            raise
 
         return ProviderNumber(
             provider_resource_id=purchased.sid,

--- a/core/tests/providers/test_twilio_voice.py
+++ b/core/tests/providers/test_twilio_voice.py
@@ -14,8 +14,10 @@ from urllib.parse import parse_qs, urlsplit
 
 import pytest
 import responses
+from twilio.base.exceptions import TwilioRestException
 
 from hailhq.core.providers.voice import (
+    NumberNotProvisionable,
     ProviderCallStatus,
     ProviderNumber,
     TwilioVoiceProvider,
@@ -164,6 +166,98 @@ async def test_acquire_raises_when_no_numbers_available(
             country_code="US",
             number_type="local",
             capabilities=["voice"],
+        )
+
+
+@responses.activate
+async def test_acquire_raises_not_provisionable_on_bundle_required(
+    provider: TwilioVoiceProvider,
+) -> None:
+    """A 400 at purchase (e.g. GB mobile 'Bundle required') is translated into
+    a typed NumberNotProvisionable — not a raw TwilioRestException that would
+    surface as a 500."""
+    responses.add(
+        responses.GET,
+        f"{API_BASE}/AvailablePhoneNumbers/GB/Mobile.json",
+        json={
+            "available_phone_numbers": [
+                {
+                    "phone_number": "+447700900123",
+                    "iso_country": "GB",
+                    "capabilities": {
+                        "voice": True,
+                        "SMS": True,
+                        "MMS": False,
+                        "fax": False,
+                    },
+                }
+            ],
+            "uri": "/x",
+        },
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        f"{API_BASE}/IncomingPhoneNumbers.json",
+        json={
+            "code": 21649,
+            "message": (
+                "Unable to create record: Bundle required and not provided "
+                "for country: [GB] and numberType: [MOBILE]"
+            ),
+            "status": 400,
+        },
+        status=400,
+    )
+
+    with pytest.raises(NumberNotProvisionable) as excinfo:
+        await provider.acquire_number(
+            country_code="GB",
+            number_type="mobile",
+            capabilities=["voice", "sms"],
+        )
+    assert "Bundle required" in excinfo.value.detail
+
+
+@responses.activate
+async def test_acquire_propagates_non_400_purchase_error(
+    provider: TwilioVoiceProvider,
+) -> None:
+    """A 5xx at purchase is a transport failure and propagates unchanged — it
+    must NOT be swallowed as NumberNotProvisionable (which would wrongly tell
+    the caller the number is unavailable)."""
+    responses.add(
+        responses.GET,
+        f"{API_BASE}/AvailablePhoneNumbers/US/Local.json",
+        json={
+            "available_phone_numbers": [
+                {
+                    "phone_number": "+14155551234",
+                    "iso_country": "US",
+                    "capabilities": {
+                        "voice": True,
+                        "SMS": True,
+                        "MMS": True,
+                        "fax": False,
+                    },
+                }
+            ],
+            "uri": "/x",
+        },
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        f"{API_BASE}/IncomingPhoneNumbers.json",
+        json={"code": 20500, "message": "Internal server error", "status": 500},
+        status=500,
+    )
+
+    with pytest.raises(TwilioRestException):
+        await provider.acquire_number(
+            country_code="US",
+            number_type="local",
+            capabilities=["voice", "sms"],
         )
 
 


### PR DESCRIPTION
Acquiring a number whose country/type needs a Twilio regulatory bundle we don't have (e.g. GB mobile: "Bundle required and not provided") raised an unhandled TwilioRestException from the purchase call, surfacing as an opaque
500. The voice provider now catches a 400 at purchase and raises a typed NumberNotProvisionable; the route maps it to a clear 422 and logs the raw carrier reason. Transient (LookupError) and transport/auth failures are unchanged.