### PR TITLE
feat(calls): optional AI disclosure and self-opening voice agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Hail are documented here. The format is based on [Keep a 
 
 ## [Unreleased]
 
+- `first_message` is now truly optional: without one the agent opens the
+  conversation itself with a generated first turn — reacting to how the
+  call was answered (the AMD pickup transcript) or introducing itself
+  after silence — instead of waiting mute for the callee to speak.
+- `POST /calls` gains `ai_disclosure` (default `true`): set `false` to skip
+  the spoken "this is an AI assistant" line at the start of the call. The
+  line stays non-customizable, the agent still identifies as an AI when
+  asked, and the opt-out is recorded in the audit log — disabling is the
+  caller's responsibility (47 CFR 64.1200(b)(1) and state AI bot-disclosure
+  laws may require it). Exposed via SDK `calls.create(ai_disclosure=...)`,
+  CLI `hail call --ai-disclosure=false`, MCP `place_call(ai_disclosure=...)`.
+
 ## [0.16.0] — 2026-07-23
 
 Multi-language calls and a more natural-sounding voice agent.

--- a/api/hailhq/api/routes/calls.py
+++ b/api/hailhq/api/routes/calls.py
@@ -319,6 +319,9 @@ async def create_call(
             "consent_source": body.consent_source,
             "consent_obtained_at": isoformat_or_none(body.consent_obtained_at),
             "message_type": body.message_type,
+            # Compliance-relevant: record when a caller opted out of the
+            # spoken AI disclosure, so the decision is attributable later.
+            "ai_disclosure": body.ai_disclosure,
             "compliance": gate.checks,
         },
     )
@@ -368,6 +371,7 @@ async def create_call(
                 "system_prompt": body.system_prompt,
                 "llm": llm_meta,
                 "first_message": body.first_message,
+                "ai_disclosure": body.ai_disclosure,
                 "tools": body.tools,
                 "org_name": await org_name_task,
             },

--- a/api/tests/test_calls_api.py
+++ b/api/tests/test_calls_api.py
@@ -248,6 +248,8 @@ async def test_post_calls_happy_path_201(
     assert dispatch_kwargs["agent_name"] == "hail-voicebot"
     assert dispatch_kwargs["metadata"]["call_id"] == body["id"]
     assert dispatch_kwargs["metadata"]["system_prompt"] == "Be brief."
+    # Disclosure defaults on and always reaches the voicebot explicitly.
+    assert dispatch_kwargs["metadata"]["ai_disclosure"] is True
 
     livekit_mock.create_sip_participant.assert_awaited_once()
     sip_kwargs = livekit_mock.create_sip_participant.await_args.kwargs
@@ -273,6 +275,41 @@ async def test_post_calls_happy_path_201(
     assert len(events) == 1
     assert events[0].kind == "state_change"
     assert events[0].payload == {"from": "queued", "to": "dialing"}
+
+
+async def test_post_calls_ai_disclosure_opt_out_reaches_dispatch_and_audit(
+    client: httpx.AsyncClient,
+    async_session: AsyncSession,
+    org_and_key: tuple[str, ApiKey, str],
+    livekit_mock: AsyncMock,
+    add_phone_number,
+) -> None:
+    """``ai_disclosure: false`` flows to the voicebot dispatch metadata and
+    is recorded in the audit log (the opt-out must be attributable)."""
+    org_id, _api_key, plain = org_and_key
+    await add_phone_number(async_session, org_id, e164="+14155551234")
+
+    resp = await client.post(
+        "/calls",
+        json={
+            "to": "+14155559999",
+            "system_prompt": "Be brief.",
+            "recipient_consent": True,
+            "ai_disclosure": False,
+        },
+        headers={"Authorization": f"Bearer {plain}"},
+    )
+
+    assert resp.status_code == 201
+    metadata = livekit_mock.dispatch_agent.await_args.kwargs["metadata"]
+    assert metadata["ai_disclosure"] is False
+
+    audit = (
+        await async_session.execute(
+            select(AuditLog).where(AuditLog.action == "call.create")
+        )
+    ).scalar_one()
+    assert audit.payload["ai_disclosure"] is False
 
 
 async def test_post_calls_livekit_failure_marks_call_failed(

--- a/cli/internal/client/client.gen.go
+++ b/cli/internal/client/client.gen.go
@@ -850,6 +850,9 @@ type BodyUploadEmailAttachment struct {
 
 // CallCreate defines model for CallCreate.
 type CallCreate struct {
+	// AiDisclosure Speak the AI self-disclosure line ('Hi, this is an AI assistant calling on behalf of ...') as the first thing on the call. Enabled by default. Disable only if you have verified the disclosure is not required for this call — 47 CFR 64.1200(b)(1) requires identifying the initiating business at the start of artificial-voice calls in the US, and several jurisdictions have AI bot-disclosure laws. Hail does not verify this for you. The agent still identifies itself as an AI if asked.
+	AiDisclosure *bool `json:"ai_disclosure,omitempty"`
+
 	// ConsentObtainedAt When consent was obtained, if known.
 	ConsentObtainedAt *time.Time `json:"consent_obtained_at,omitempty"`
 

--- a/cli/internal/cmd/call.go
+++ b/cli/internal/cmd/call.go
@@ -23,6 +23,7 @@ type callFlags struct {
 	from           string
 	firstMessage   string
 	language       string
+	aiDisclosure   bool
 	tools          []string
 	idempotencyKey string
 }
@@ -74,6 +75,7 @@ Example (minimal):
 	cmd.Flags().StringVar(&f.from, "from", "", "Override the from-number (default: first active number on the org)")
 	cmd.Flags().StringVar(&f.firstMessage, "first-message", "", "Spoken on pickup before listening")
 	cmd.Flags().StringVar(&f.language, "language", "", "Spoken language for the call, lowercase ISO 639-1 (e.g. fr); default English")
+	cmd.Flags().BoolVar(&f.aiDisclosure, "ai-disclosure", true, "Speak the AI self-disclosure line first on the call; --ai-disclosure=false skips it (your responsibility — disclosure laws may require it)")
 	cmd.Flags().StringSliceVar(&f.tools, "tools", nil, "Agent tools to allow (comma-separated or repeated); omit for all available, 'none' to disable all")
 	cmd.Flags().StringVar(&f.idempotencyKey, "idempotency-key", "", "Defaults to a fresh UUID")
 	f.registerConsentFlags(cmd, "call")
@@ -104,6 +106,9 @@ func runCall(cmd *cobra.Command, opts *Options, f *callFlags, toNumber string) e
 	}
 	if f.language != "" {
 		body.VoiceConfig = &client.VoiceConfig{Language: strPtr(f.language)}
+	}
+	if cmd.Flags().Changed("ai-disclosure") {
+		body.AiDisclosure = &f.aiDisclosure
 	}
 	if cmd.Flags().Changed("tools") {
 		// [] disables all agent tools; the sentinel word "none" maps to []

--- a/cli/internal/cmd/call_test.go
+++ b/cli/internal/cmd/call_test.go
@@ -249,6 +249,44 @@ func TestCallSubcommand_LanguageFlag(t *testing.T) {
 	}
 }
 
+func TestCallSubcommand_AiDisclosureFlag(t *testing.T) {
+	t.Run("explicit false sent", func(t *testing.T) {
+		srv := newFakeServer(t, http.StatusCreated, sampleResponse())
+		_, _, err := runRoot(t,
+			map[string]string{"HAIL_API_KEY": "sk_test", "HAIL_API_URL": srv.URL},
+			"call", "+15551234567", "--prompt", "hi", "--recipient-consent",
+			"--ai-disclosure=false",
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var body client.CallCreate
+		if err := json.Unmarshal(srv.lastBody, &body); err != nil {
+			t.Fatalf("body parse: %v", err)
+		}
+		if body.AiDisclosure == nil || *body.AiDisclosure != false {
+			t.Errorf("AiDisclosure = %v, want false", body.AiDisclosure)
+		}
+	})
+	t.Run("omitted stays server-default", func(t *testing.T) {
+		srv := newFakeServer(t, http.StatusCreated, sampleResponse())
+		_, _, err := runRoot(t,
+			map[string]string{"HAIL_API_KEY": "sk_test", "HAIL_API_URL": srv.URL},
+			"call", "+15551234567", "--prompt", "hi", "--recipient-consent",
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var body client.CallCreate
+		if err := json.Unmarshal(srv.lastBody, &body); err != nil {
+			t.Fatalf("body parse: %v", err)
+		}
+		if body.AiDisclosure != nil {
+			t.Errorf("AiDisclosure = %v, want omitted", *body.AiDisclosure)
+		}
+	})
+}
+
 func TestCallSubcommand_ToolsFlag(t *testing.T) {
 	t.Run("explicit list", func(t *testing.T) {
 		srv := newFakeServer(t, http.StatusCreated, sampleResponse())

--- a/core/hailhq/core/schemas.py
+++ b/core/hailhq/core/schemas.py
@@ -190,6 +190,20 @@ class CallCreate(ConsentAttestationMixin):
     system_prompt: str | None = None
     llm: LLMConfig | None = None
     first_message: str | None = None
+    ai_disclosure: bool = Field(
+        default=True,
+        description=(
+            "Speak the AI self-disclosure line ('Hi, this is an AI "
+            "assistant calling on behalf of ...') as the first thing on "
+            "the call. Enabled by default. Disable only if you have "
+            "verified the disclosure is not required for this call — 47 "
+            "CFR 64.1200(b)(1) requires identifying the initiating "
+            "business at the start of artificial-voice calls in the US, "
+            "and several jurisdictions have AI bot-disclosure laws. Hail "
+            "does not verify this for you. The agent still identifies "
+            "itself as an AI if asked."
+        ),
+    )
     voice_config: VoiceConfig = Field(default_factory=VoiceConfig)
     conversation_id: UUID | None = None
     metadata: dict = Field(default_factory=dict)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,7 +31,7 @@ LiveKit Cloud is external. The `hail` Go CLI is a human-facing scriptable tool, 
 1. Caller (agent via MCP, or CLI, or direct HTTP) → `POST /calls` with `{to, from, first_message?, …llm}`.
 2. Hail API creates a LiveKit room and dispatches the voicebot into it.
 3. Voicebot joins; LiveKit places a SIP outbound via the Twilio trunk to `to`.
-4. On pickup, voicebot classifies who answered before saying anything (see below), then speaks the AI disclosure and `first_message` (if set) and runs the STT → LLM → TTS loop.
+4. On pickup, voicebot classifies who answered before saying anything (see below), then speaks the AI disclosure (unless the call set `ai_disclosure: false` — the opt-out is audit-logged and the caller's responsibility) and `first_message` (if set) and runs the STT → LLM → TTS loop.
 5. On hangup, voicebot writes the call record to Postgres and uploads the recording to S3.
 
 ### Answering machine detection and DTMF

--- a/mcp/hailhq/mcp/hail_client.py
+++ b/mcp/hailhq/mcp/hail_client.py
@@ -103,6 +103,7 @@ class HailClient:
         from_: str | None = None,
         first_message: str | None = None,
         language: str | None = None,
+        ai_disclosure: bool = True,
         metadata: dict[str, Any] | None = None,
         tools: list[str] | None = None,
         idempotency_key: str | None = None,
@@ -132,6 +133,8 @@ class HailClient:
             fields["first_message"] = first_message
         if language is not None:
             fields["voice_config"] = {"language": language}
+        if not ai_disclosure:
+            fields["ai_disclosure"] = False
         if metadata is not None:
             fields["metadata"] = metadata
         if tools is not None:

--- a/mcp/hailhq/mcp/tools.py
+++ b/mcp/hailhq/mcp/tools.py
@@ -114,6 +114,7 @@ async def place_call(
     from_: str | None = None,
     first_message: str | None = None,
     language: str | None = None,
+    ai_disclosure: bool = True,
     metadata: dict[str, Any] | None = None,
     tools: list[str] | None = None,
     idempotency_key: str | None = None,
@@ -132,6 +133,7 @@ async def place_call(
             from_=from_,
             first_message=first_message,
             language=language,
+            ai_disclosure=ai_disclosure,
             metadata=metadata,
             tools=tools,
             idempotency_key=idempotency_key,
@@ -536,6 +538,7 @@ def register_tools(
         from_: str | None = None,
         first_message: str | None = None,
         language: str | None = None,
+        ai_disclosure: bool = True,
         metadata: dict[str, Any] | None = None,
         tools: list[str] | None = None,
         idempotency_key: str | None = None,
@@ -553,10 +556,18 @@ def register_tools(
 
         ``to`` must be E.164 (e.g. ``+14155551234``). ``from_`` is
         optional and defaults to the first active number on your org.
-        ``first_message`` is spoken on pickup before listening.
+        ``first_message`` is spoken verbatim on pickup; omit it to let
+        the agent open the conversation itself — it reacts to how the
+        call was answered, or introduces itself after silence.
         ``language`` sets the call's spoken language for both
         speech-to-text and text-to-speech, as a lowercase ISO 639-1 code
         (e.g. ``"fr"``); omit for English.
+        ``ai_disclosure=False`` skips the spoken "this is an AI
+        assistant" line at the start of the call. Leave enabled unless
+        the user has verified it is not required for this call — US
+        artificial-voice calls (47 CFR 64.1200(b)(1)) and several AI
+        bot-disclosure laws require it, and Hail does not verify this.
+        The agent still identifies itself as an AI if asked.
         ``metadata`` is free-form JSON attached to the call record.
         ``tools`` are the agent tools to allow on this call. Omit for all
         available; pass ``[]`` to disable.
@@ -597,6 +608,7 @@ def register_tools(
                     from_=from_,
                     first_message=first_message,
                     language=language,
+                    ai_disclosure=ai_disclosure,
                     metadata=metadata,
                     tools=tools,
                     idempotency_key=idempotency_key,

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -119,6 +119,29 @@ async def test_place_call_language_lands_in_voice_config(client: HailClient) -> 
     assert body["voice_config"] == {"language": "fr"}
 
 
+@respx.mock
+async def test_place_call_ai_disclosure_opt_out(client: HailClient) -> None:
+    captured: dict = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = request.read().decode("utf-8")
+        return httpx.Response(201, json=_call_response())
+
+    respx.post(f"{_BASE_URL}/calls").mock(side_effect=_handler)
+
+    result = await tools.place_call(
+        client=client,
+        recipient_consent=True,
+        to="+14155559999",
+        system_prompt="be polite",
+        ai_disclosure=False,
+    )
+    assert "error" not in result, result
+
+    body = httpx.Response(200, content=captured["body"]).json()
+    assert body["ai_disclosure"] is False
+
+
 async def test_place_call_rejects_bad_language(client: HailClient) -> None:
     """A non-ISO-639-1 code fails CallCreate validation before any HTTP."""
     result = await tools.place_call(

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1969,6 +1969,18 @@ components:
             - type: string
             - type: "null"
           title: First Message
+        ai_disclosure:
+          type: boolean
+          title: Ai Disclosure
+          description:
+            "Speak the AI self-disclosure line ('Hi, this is an AI assistant\
+            \ calling on behalf of ...') as the first thing on the call. Enabled by\
+            \ default. Disable only if you have verified the disclosure is not required\
+            \ for this call \u2014 47 CFR 64.1200(b)(1) requires identifying the initiating\
+            \ business at the start of artificial-voice calls in the US, and several\
+            \ jurisdictions have AI bot-disclosure laws. Hail does not verify this\
+            \ for you. The agent still identifies itself as an AI if asked."
+          default: true
         voice_config:
           $ref: "#/components/schemas/VoiceConfig"
         conversation_id:

--- a/sdk/hail/client.py
+++ b/sdk/hail/client.py
@@ -87,6 +87,7 @@ class _CallsResource:
         from_: str | None = None,
         first_message: str | None = None,
         language: str | None = None,
+        ai_disclosure: bool = True,
         metadata: dict[str, Any] | None = None,
         consent_source: str | None = None,
         consent_obtained_at: datetime | None = None,
@@ -102,6 +103,9 @@ class _CallsResource:
         rule. ``recipient_consent`` is required — the server 422s without
         it. ``language`` is the call's spoken language for both STT and TTS
         as a lowercase ISO 639-1 code (e.g. ``"fr"``); omit for English.
+        ``ai_disclosure=False`` skips the spoken AI self-disclosure line —
+        disabling is your responsibility (US artificial-voice calls and
+        several AI bot-disclosure laws require it).
         ``idempotency_key`` defaults to a fresh UUIDv4.
         """
         body: dict[str, Any] = {"to": to, "recipient_consent": recipient_consent}
@@ -111,6 +115,8 @@ class _CallsResource:
             body["system_prompt"] = system_prompt
         if first_message is not None:
             body["first_message"] = first_message
+        if not ai_disclosure:
+            body["ai_disclosure"] = False
         if language is not None:
             body["voice_config"] = {"language": language}
         if metadata is not None:

--- a/sdk/hail/models.py
+++ b/sdk/hail/models.py
@@ -95,6 +95,10 @@ class CallCreate(BaseModel):
     system_prompt: str | None = None
     llm: LLMConfig | None = None
     first_message: str | None = None
+    # Speak the AI self-disclosure line first on the call (default True).
+    # Disabling is the caller's responsibility — see the API schema notes
+    # on 47 CFR 64.1200(b)(1) and state AI bot-disclosure laws.
+    ai_disclosure: bool = True
     voice_config: VoiceConfig = Field(default_factory=VoiceConfig)
     conversation_id: UUID | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)

--- a/sdk/tests/test_client.py
+++ b/sdk/tests/test_client.py
@@ -127,6 +127,29 @@ async def test_calls_create_language_lands_in_voice_config(
 
 
 @respx.mock
+async def test_calls_create_ai_disclosure_opt_out(base_url: str, api_key: str) -> None:
+    """ai_disclosure=False lands in the body; default -> key omitted."""
+    route = respx.post(f"{base_url}/calls").mock(
+        return_value=httpx.Response(201, json=make_call_response())
+    )
+    async with Client(api_key=api_key, base_url=base_url) as c:
+        await c.calls.create(
+            to="+15555550123",
+            system_prompt="be polite",
+            recipient_consent=True,
+            ai_disclosure=False,
+        )
+        await c.calls.create(
+            to="+15555550123",
+            system_prompt="be polite",
+            recipient_consent=True,
+        )
+    bodies = [json.loads(call.request.content) for call in route.calls]
+    assert bodies[0]["ai_disclosure"] is False
+    assert "ai_disclosure" not in bodies[1]
+
+
+@respx.mock
 async def test_calls_create_sends_consent_fields(base_url: str, api_key: str) -> None:
     route = respx.post(f"{base_url}/calls").mock(
         return_value=httpx.Response(201, json=make_call_response())

--- a/voicebot/hailhq/voicebot/agent.py
+++ b/voicebot/hailhq/voicebot/agent.py
@@ -166,8 +166,8 @@ def build_instructions(system_prompt: str | None) -> str:
     return f"{VOICE_PREAMBLE}\n\n# Caller instructions\n\n{caller}"
 
 
-# Proactive AI disclosure — spoken unconditionally as the first thing on
-# every call, immediately after session.start(). Unlike VOICE_PREAMBLE (LLM
+# Proactive AI disclosure — spoken by default as the first thing on every
+# call, immediately after session.start(). Unlike VOICE_PREAMBLE (LLM
 # instructions the model could ignore), this is a literal session.say() so
 # it is a real, enforced disclosure, not a prompt hope. When the API
 # resolved the requesting organization's display name, the line names it —
@@ -176,7 +176,11 @@ def build_instructions(system_prompt: str | None) -> str:
 # wording. Only the name is interpolated; the template is hardcoded and
 # not reachable/overridable via the public API: org_name arrives in the
 # server-built dispatch metadata (resolved from the org record), never
-# from body.system_prompt, body.first_message, or body.metadata.
+# from body.system_prompt, body.first_message, or body.metadata. Callers
+# can opt out per call via ``ai_disclosure: false`` (the API records the
+# opt-out in the audit log; the responsibility for it is theirs) — but the
+# line itself stays non-customizable, and the preamble still makes the
+# agent identify as an AI when asked.
 _DISCLOSURE_PREFIX = "Hi, this is an AI assistant calling on behalf of "
 
 AI_DISCLOSURE_LINE = _DISCLOSURE_PREFIX + "whoever requested this call."
@@ -273,20 +277,70 @@ async def build_tools_safely(
         return [], None
 
 
-async def speak_greeting(session: AgentSession, metadata: dict[str, Any]) -> None:
-    """Speak the mandatory AI disclosure, then the caller's ``first_message`` if set.
+# Spoken opening when the caller supplied no ``first_message``. A real LLM
+# turn, mirroring the IVR branch's reasoning: ``session.say`` is TTS-only,
+# so without this a call with no ``first_message`` opened in dead air —
+# nothing spoken beyond the disclosure and no LLM turn until the callee
+# spoke first. The AMD pickup transcript, when there is one, lets the model
+# react to how the call was answered ("Joe's Pizza, good evening") instead
+# of talking past it; after 6s of pickup silence (AMD's no-speech
+# threshold) the transcript is empty and the model introduces itself cold.
+_OPENING_BASE = (
+    "The call was just answered. Open the conversation: briefly greet the "
+    "person and say why you are calling, following your instructions, then "
+    "give them room to respond."
+)
 
-    The disclosure is unconditional and always first. Its template is not
-    reachable via caller-controlled fields (``body.system_prompt`` /
+
+def opening_instructions(pickup_transcript: str | None) -> str:
+    """The prompt for the generated opening turn (no caller ``first_message``)."""
+    heard = (pickup_transcript or "").strip()
+    if heard:
+        return (
+            f'{_OPENING_BASE} They answered the phone saying: "{heard}" — '
+            "respond to that naturally."
+        )
+    return f"{_OPENING_BASE} They have not said anything yet."
+
+
+async def speak_greeting(
+    session: AgentSession,
+    metadata: dict[str, Any],
+    pickup_transcript: str | None = None,
+    *,
+    generate_opening: bool = True,
+) -> None:
+    """Open the call: disclosure (unless opted out), then the first message.
+
+    The disclosure leads by default and can only be skipped, never
+    customized or reordered: its template is not reachable via
+    caller-controlled fields (``body.system_prompt`` /
     ``body.first_message``); only ``org_name`` — resolved server-side by
-    the API from the organization record — is interpolated into it. Call
-    this right after ``session.start()``.
+    the API from the organization record — is interpolated into it, and a
+    caller-supplied ``first_message`` can never precede it. The
+    ``ai_disclosure`` default is ``True`` so a dispatch that predates the
+    field (rolling deploy) keeps the disclosure.
+
+    A caller ``first_message`` is spoken verbatim. Without one, the LLM
+    generates the opening (see :func:`opening_instructions`) so the call
+    never opens in dead air — including with ``ai_disclosure: false``.
+    Call this right after ``session.start()``.
+
+    ``generate_opening=False`` skips that generated turn. It exists for
+    the deferred IVR path (:func:`arm_deferred_greeting`), where the
+    greeting fires *because* a person just spoke: there the session's
+    normal turn loop already answers that utterance, so an injected
+    opening would race it and its "they have not said anything yet"
+    premise would be false.
     """
-    await session.say(
-        disclosure_line(metadata.get("org_name")), allow_interruptions=True
-    )
+    if metadata.get("ai_disclosure", True):
+        await session.say(
+            disclosure_line(metadata.get("org_name")), allow_interruptions=True
+        )
     if metadata.get("first_message"):
         await session.say(metadata["first_message"], allow_interruptions=True)
+    elif generate_opening:
+        session.generate_reply(instructions=opening_instructions(pickup_transcript))
 
 
 DTMF_TOOL_NAME = "send_dtmf"
@@ -332,7 +386,10 @@ def arm_deferred_greeting(
 
         async def _run() -> None:
             try:
-                await speak_greeting(session, metadata)
+                # No generated opening here: this fires because a person
+                # just spoke, and the normal turn loop answers them. The
+                # injected opening turn is for cold-open pickups only.
+                await speak_greeting(session, metadata, generate_opening=False)
             except Exception:
                 logger.exception(
                     "call_id=%s deferred greeting failed after IVR", call_id
@@ -478,8 +535,9 @@ def parse_metadata(raw: str | None) -> dict[str, Any]:
 
     Required: ``call_id`` (returned as a parsed :class:`UUID`). Optional:
     ``voice_config``, ``system_prompt``, ``llm`` (None → mode A fallback
-    chain), ``first_message``, ``org_name`` (server-resolved display name
-    spoken in the AI disclosure; absent/None → generic wording).
+    chain), ``first_message``, ``ai_disclosure`` (absent → ``True``),
+    ``org_name`` (server-resolved display name spoken in the AI
+    disclosure; absent/None → generic wording).
     """
     payload = json.loads(raw) if raw else {}
     if "call_id" not in payload:
@@ -1116,7 +1174,11 @@ async def entrypoint(ctx: JobContext) -> None:
         # arrives after the session died must not escape entrypoint — the
         # shutdown callback registered above already finalizes the row.
         try:
-            await speak_greeting(session, metadata)
+            await speak_greeting(
+                session,
+                metadata,
+                pickup_transcript=amd_result.transcript if amd_result else None,
+            )
         except Exception:
             logger.exception(
                 "call_id=%s greeting failed; session closed during detection", call_id
@@ -1143,6 +1205,7 @@ __all__ = [
     "make_agent_send_dtmf",
     "mark_call_answered",
     "on_call_end",
+    "opening_instructions",
     "parse_metadata",
     "prewarm",
     "soft_cap_announce_and_hangup",

--- a/voicebot/tests/_fakes.py
+++ b/voicebot/tests/_fakes.py
@@ -134,6 +134,7 @@ class FakeAnnouncingSession:
 
     def __init__(self) -> None:
         self.say_calls: list[tuple[str, bool]] = []
+        self.generate_reply_calls: list[str | None] = []
         self.last_handle: FakeSpeechHandle | None = None
 
     def say(self, text: str, *, allow_interruptions: bool) -> FakeSpeechHandle:
@@ -141,6 +142,10 @@ class FakeAnnouncingSession:
         handle = FakeSpeechHandle()
         self.last_handle = handle
         return handle
+
+    def generate_reply(self, *, instructions: str | None = None) -> FakeSpeechHandle:
+        self.generate_reply_calls.append(instructions)
+        return FakeSpeechHandle()
 
 
 class FakeLocalParticipant:

--- a/voicebot/tests/test_agent.py
+++ b/voicebot/tests/test_agent.py
@@ -44,6 +44,7 @@ from hailhq.voicebot.agent import (
     make_agent_send_dtmf,
     mark_call_answered,
     on_call_end,
+    opening_instructions,
     parse_metadata,
     soft_cap_announce_and_hangup,
     speak_greeting,
@@ -969,13 +970,64 @@ async def test_speak_greeting_speaks_disclosure_before_first_message() -> None:
     assert second_text == "Hi, calling about your order."
 
 
+async def test_speak_greeting_skips_disclosure_when_opted_out() -> None:
+    """``ai_disclosure: False`` skips the disclosure; ``first_message`` still
+    plays. With neither, the LLM opening still fires — never dead air."""
+    session = FakeAnnouncingSession()
+    await speak_greeting(
+        session, {"ai_disclosure": False, "first_message": "Hi, about your order."}
+    )
+    assert session.say_calls == [("Hi, about your order.", True)]
+    assert session.generate_reply_calls == []
+
+    session = FakeAnnouncingSession()
+    await speak_greeting(session, {"ai_disclosure": False})
+    assert session.say_calls == []
+    assert session.generate_reply_calls == [opening_instructions(None)]
+
+
 async def test_speak_greeting_speaks_disclosure_when_no_first_message() -> None:
-    """No ``first_message`` in metadata → the disclosure is still spoken."""
+    """No ``first_message`` → disclosure still spoken, then a generated
+    opening turn instead of silence."""
     session = FakeAnnouncingSession()
 
     await speak_greeting(session, {})
 
     assert session.say_calls == [(AI_DISCLOSURE_LINE, True)]
+    assert session.generate_reply_calls == [opening_instructions(None)]
+
+
+async def test_speak_greeting_first_message_suppresses_generated_opening() -> None:
+    """A caller ``first_message`` is the opening — no LLM turn on top of it."""
+    session = FakeAnnouncingSession()
+
+    await speak_greeting(session, {"first_message": "Hi, about your order."})
+
+    assert session.generate_reply_calls == []
+
+
+async def test_generated_opening_reacts_to_pickup_transcript() -> None:
+    """The AMD pickup transcript flows into the opening instructions; silence
+    (None/blank) gets the not-said-anything variant."""
+    session = FakeAnnouncingSession()
+    await speak_greeting(session, {}, pickup_transcript="Joe's Pizza, good evening?")
+    assert len(session.generate_reply_calls) == 1
+    assert "Joe's Pizza, good evening?" in session.generate_reply_calls[0]
+
+    assert "not said anything" in opening_instructions("   ")
+    assert "not said anything" in opening_instructions(None)
+
+
+async def test_speak_greeting_deferred_path_skips_generated_opening() -> None:
+    """``generate_opening=False`` (the deferred IVR path) fires no opening
+    turn: the greeting runs because a person just spoke, and the session's
+    normal turn loop answers them. Disclosure still plays."""
+    session = FakeAnnouncingSession()
+
+    await speak_greeting(session, {}, generate_opening=False)
+
+    assert session.say_calls == [(AI_DISCLOSURE_LINE, True)]
+    assert session.generate_reply_calls == []
 
 
 async def test_speak_greeting_first_message_cannot_precede_disclosure() -> None:


### PR DESCRIPTION
POST /calls gains ai_disclosure (default true); false skips the spoken AI self-disclosure line. The line stays non-customizable, the agent still identifies as an AI when asked, and the opt-out is audit-logged — disabling is the caller responsibility under 47 CFR 64.1200(b)(1) and state AI bot-disclosure laws. Exposed via SDK calls.create, CLI --ai-disclosure=false, and MCP place_call.

first_message is now truly optional: without one the agent opens the call itself with a generated LLM turn — reacting to the AMD pickup transcript or introducing itself after silence — instead of waiting mute for the callee to speak.