### PR TITLE
feat(cli): humane call tails — hail/human/machine labels, silence dot…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Hail are documented here. The format is based on [Keep a 
 
 ## [Unreleased]
 
+- `hail tail` call-transcript display overhaul: turns render as `[hail]` /
+  `[human]` (was `[agent]` / `[user]`); pickup speech that AMD attributes
+  to a machine renders as `[machine]` with a plain-language `[amd]`
+  verdict line ("answered by a machine (phone menu)") instead of payload
+  JSON; silent seconds render as dim `.`
+  lines (gaps beyond 10s compress to three dots plus a duration); and
+  `--id` now accepts a bare call UUID or a 4+ char hex prefix (`hail tail
+df10f471`), resolved like git short hashes.
+
 ## [0.17.0] — 2026-07-23
 
 Optional AI disclosure and a voice agent that opens the call itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,19 @@ All notable changes to Hail are documented here. The format is based on [Keep a 
 
 ## [Unreleased]
 
+## [0.18.0] — 2026-07-23
+
+Readable call tails in the CLI. `cli-v0.17.0` cut alongside; the SDK is
+unchanged and stays at `hail-sdk==0.13.0`.
+
 - `hail tail` call-transcript display overhaul: turns render as `[hail]` /
   `[human]` (was `[agent]` / `[user]`); pickup speech that AMD attributes
   to a machine renders as `[machine]` with a plain-language `[amd]`
   verdict line ("answered by a machine (phone menu)") instead of payload
-  JSON; silent seconds render as dim `.`
-  lines (gaps beyond 10s compress to three dots plus a duration); and
-  `--id` now accepts a bare call UUID or a 4+ char hex prefix (`hail tail
-df10f471`), resolved like git short hashes.
+  JSON; silent seconds render as timestamped dim `[wait] .` lines (gaps
+  beyond 10s compress to three dots plus a duration); and `--id` now
+  accepts a bare call UUID or a 4+ char hex prefix (`hail tail df10f471`),
+  resolved like git short hashes.
 
 ## [0.17.0] — 2026-07-23
 

--- a/cli/internal/cmd/call_tail.go
+++ b/cli/internal/cmd/call_tail.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 )
@@ -29,14 +28,8 @@ for stream flags (--from-start, --no-follow, --interval, --kind).`,
 }
 
 func runCallTail(ctx context.Context, opts *Options, f *tailFlags, input string) error {
-	apiClient, err := opts.newClient()
-	if err != nil {
-		return err
-	}
-	id, _, err := resolveCallID(ctx, apiClient, input)
-	if err != nil {
-		return err
-	}
-	f.id = fmt.Sprintf("call:%s", id.String())
+	// runTail owns prefix resolution (resolveTailID); this alias only pins
+	// the resource type.
+	f.id = "call:" + input
 	return runTail(ctx, opts, f)
 }

--- a/cli/internal/cmd/email_tail.go
+++ b/cli/internal/cmd/email_tail.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 )
@@ -26,14 +25,8 @@ for stream flags (--from-start, --no-follow, --interval, --kind).`,
 }
 
 func runEmailTail(ctx context.Context, opts *Options, f *tailFlags, input string) error {
-	apiClient, err := opts.newClient()
-	if err != nil {
-		return err
-	}
-	id, err := resolveEmailID(ctx, apiClient, input)
-	if err != nil {
-		return err
-	}
-	f.id = fmt.Sprintf("email:%s", id.String())
+	// runTail owns prefix resolution (resolveTailID); this alias only pins
+	// the resource type.
+	f.id = "email:" + input
 	return runTail(ctx, opts, f)
 }

--- a/cli/internal/cmd/tail.go
+++ b/cli/internal/cmd/tail.go
@@ -60,40 +60,54 @@ var terminalCallStatuses = map[client.EventStreamResponseCallStatus]bool{
 	client.EventStreamResponseCallStatusCanceled:  true,
 }
 
-// parseResourceID mirrors core.schemas.parse_resource_id: validate and split
-// a "<type>:<uuid>" value before any HTTP. Errors carry the same shape as
-// the API helper but without brackets (matches the CLI error contract).
-func parseResourceID(value string) (resType string, resID uuid.UUID, err error) {
+// splitResourceArg splits a CLI-supplied --id value into (type, idPart).
+// A bare value with no "<type>:" prefix is treated as a call — `hail tail
+// --id df10f471` mirrors `hail call tail df10f471`. Validation of the id
+// part (full UUID vs 4+ char hex prefix) happens in resolveTailID.
+func splitResourceArg(value string) (resType, idPart string, err error) {
 	idx := strings.Index(value, ":")
 	if idx < 0 {
-		return "", uuid.Nil, fmt.Errorf("must be '<type>:<uuid>' (e.g. 'call:abc-...'); missing ':'")
+		return "call", value, nil
 	}
 	resType = value[:idx]
-	idStr := value[idx+1:]
+	idPart = value[idx+1:]
 	if resType == "" {
-		return "", uuid.Nil, fmt.Errorf("missing resource type before ':'")
+		return "", "", fmt.Errorf("missing resource type before ':'")
 	}
-	if idStr == "" {
-		return "", uuid.Nil, fmt.Errorf("missing resource id after ':'")
+	if idPart == "" {
+		return "", "", fmt.Errorf("missing resource id after ':'")
 	}
-	supported := false
 	for _, t := range supportedResourceTypes {
 		if t == resType {
-			supported = true
-			break
+			return resType, idPart, nil
 		}
 	}
-	if !supported {
-		return "", uuid.Nil, fmt.Errorf(
-			"unsupported resource type %q; supported: %s",
-			resType, strings.Join(supportedResourceTypes, ", "),
+	return "", "", fmt.Errorf(
+		"unsupported resource type %q; supported: %s",
+		resType, strings.Join(supportedResourceTypes, ", "),
+	)
+}
+
+// resolveTailID turns the id part into a full UUID. A full UUID passes
+// through with no HTTP; anything else is treated as a hex prefix and
+// resolved against the recent list for the resource type (calls and
+// emails have list endpoints; sms rows don't yet).
+func resolveTailID(ctx context.Context, apiClient *client.ClientWithResponses, resType, idPart string) (uuid.UUID, error) {
+	if parsed, err := uuid.Parse(idPart); err == nil {
+		return parsed, nil
+	}
+	switch resType {
+	case "call":
+		id, _, err := resolveCallID(ctx, apiClient, idPart)
+		return id, err
+	case "email":
+		return resolveEmailID(ctx, apiClient, idPart)
+	default:
+		return uuid.Nil, fmt.Errorf(
+			"invalid %s id %q: prefixes are not resolvable for %s, pass the full UUID",
+			resType, idPart, resType,
 		)
 	}
-	parsed, perr := uuid.Parse(idStr)
-	if perr != nil {
-		return "", uuid.Nil, fmt.Errorf("invalid uuid %q: %w", idStr, perr)
-	}
-	return resType, parsed, nil
 }
 
 // ANSI color codes used when stdout is a TTY and NO_COLOR is unset.
@@ -107,6 +121,17 @@ const (
 	colorRed     = "\x1b[31m"
 	colorDim     = "\x1b[2m"
 )
+
+// amdSentences maps AMD verdict categories (voicebot/hailhq/voicebot/amd.py)
+// to human-readable [amd] lines. Unknown categories render verbatim so a
+// new verdict doesn't need a CLI release to show up legibly.
+var amdSentences = map[string]string{
+	"human":               "answered by a human",
+	"machine-ivr":         "answered by a machine (phone menu)",
+	"machine-vm":          "answered by a machine (voicemail)",
+	"machine-unavailable": "answered by a machine (mailbox unavailable)",
+	"uncertain":           "unclear who answered — treating as human",
+}
 
 // perCallPalette is the small set of stable colors assigned to short call
 // ids in org-wide tail mode. Hashed lookup lives in shortIDColor.
@@ -134,8 +159,12 @@ Narrow to one resource either way:
 
   hail tail --id call:<uuid>
   hail tail call:<uuid>
+  hail tail df10f471            # bare id — treated as a call
+  hail tail --id call:df10f471  # 4+ char prefix, resolved like git short hashes
 
-Both forms accept '<type>:<uuid>' where <type> is one of: ` + strings.Join(supportedResourceTypes, ", ") + `.
+Both forms accept '<type>:<id>' where <type> is one of: ` + strings.Join(supportedResourceTypes, ", ") + `,
+and <id> is a full UUID or a 4+ char hex prefix (calls and emails). A bare
+<id> with no type defaults to call.
 
 When narrowed to a call, tail auto-exits when the call reaches a terminal
 status (completed/failed/busy/no_answer/canceled). Email tails currently
@@ -151,7 +180,7 @@ run until SIGINT.`,
 			return runTail(cmd.Context(), opts, f)
 		},
 	}
-	cmd.Flags().StringVar(&f.id, "id", "", "Narrow to one resource as '<type>:<uuid>' (e.g. 'call:abc-...'); supported: "+strings.Join(supportedResourceTypes, ", "))
+	cmd.Flags().StringVar(&f.id, "id", "", "Narrow to one resource: '<type>:<uuid>', '<type>:<prefix>', or a bare call id/prefix; supported types: "+strings.Join(supportedResourceTypes, ", "))
 	registerTailFlags(cmd, f)
 	return cmd
 }
@@ -172,21 +201,6 @@ func runTail(ctx context.Context, opts *Options, f *tailFlags) error {
 		return fmt.Errorf("--interval must be in [100, 10000] ms, got %d", f.intervalMS)
 	}
 
-	// Parse --id early so malformed / unsupported values fail before any
-	// network IO. The CLI knows the supported set in v1; it does not have to
-	// round-trip the API to validate.
-	var (
-		idWire       string // exact "<type>:<uuid>" string put on the wire
-		resourceType string
-	)
-	if f.id != "" {
-		rtype, rid, err := parseResourceID(f.id)
-		if err != nil {
-			return err
-		}
-		resourceType = rtype
-		idWire = fmt.Sprintf("%s:%s", rtype, rid.String())
-	}
 	// SIGINT cancels the poll loop. Exit 130 happens at Execute() — we just
 	// return errInterrupted from here.
 	tailCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
@@ -195,6 +209,26 @@ func runTail(ctx context.Context, opts *Options, f *tailFlags) error {
 	apiClient, err := opts.newClient()
 	if err != nil {
 		return err
+	}
+
+	// Resolve --id: split fails fast on malformed / unsupported values with
+	// no network IO, and a short prefix costs one list roundtrip (a full
+	// UUID none) before polling starts.
+	var (
+		idWire       string // exact "<type>:<uuid>" string put on the wire
+		resourceType string
+	)
+	if f.id != "" {
+		rtype, idPart, err := splitResourceArg(f.id)
+		if err != nil {
+			return err
+		}
+		rid, err := resolveTailID(tailCtx, apiClient, rtype, idPart)
+		if err != nil {
+			return err
+		}
+		resourceType = rtype
+		idWire = fmt.Sprintf("%s:%s", rtype, rid.String())
 	}
 
 	colorize := shouldColorize(opts.Stdout)
@@ -236,6 +270,12 @@ func runTail(ctx context.Context, opts *Options, f *tailFlags) error {
 		return resp.JSON200, nil
 	}
 
+	renderer := newTailRenderer(opts, resourceType != "", colorize, f.kind != "")
+	// Buffered pickup transcripts must survive every exit path — fetch
+	// errors, --no-follow, SIGINT. flushAll is idempotent, so the explicit
+	// call before the terminal-status line below is safe to keep.
+	defer renderer.flushAll()
+
 	for {
 		page, err := fetch(cursor)
 		if err != nil {
@@ -250,7 +290,7 @@ func runTail(ctx context.Context, opts *Options, f *tailFlags) error {
 		var lastEvent *client.EventResponse
 		for {
 			for i := range page.Items {
-				if err := renderEvent(opts, page.Items[i], resourceType != "", colorize); err != nil {
+				if err := renderer.renderEvent(page.Items[i]); err != nil {
 					return err
 				}
 				lastEvent = &page.Items[i]
@@ -281,11 +321,13 @@ func runTail(ctx context.Context, opts *Options, f *tailFlags) error {
 		// EmailStatus field on the generated client. Email tails run until SIGINT.
 		if resourceType == "call" &&
 			firstPage.CallStatus != nil && terminalCallStatuses[*firstPage.CallStatus] {
+			renderer.flushAll()
 			finalLine := fmt.Sprintf("call %s", string(*firstPage.CallStatus))
 			renderSystemLine(opts, time.Now().UTC(), finalLine, colorize)
 			return nil
 		}
 
+		renderer.markQuiet()
 		select {
 		case <-tailCtx.Done():
 			return errInterrupted
@@ -294,38 +336,190 @@ func runTail(ctx context.Context, opts *Options, f *tailFlags) error {
 	}
 }
 
-// renderEvent dispatches on event.Kind and writes one line to opts.Stdout.
-// In --json mode each event is emitted as a single JSON object per line.
+// tailRenderer owns cross-event display state: AMD-aware labeling of
+// pickup transcripts, and silence dots between displayed lines. One
+// instance lives for the whole tail loop.
 //
 // `singleResource` is true when --id <type>:<uuid> narrowed the stream; the
 // short-id prefix is omitted in that mode (every event belongs to the same
 // resource, the prefix would be redundant noise).
-func renderEvent(opts *Options, ev client.EventResponse, singleResource, colorize bool) error {
-	if opts.JSON {
+type tailRenderer struct {
+	opts           *Options
+	singleResource bool
+	colorize       bool
+	// kindFiltered is true when --kind narrows the stream server-side. A
+	// partial stream disables both AMD buffering (the amd_result row may be
+	// filtered out, so buffered turns would starve until call end) and
+	// silence dots (gaps between filtered lines are not dead air).
+	kindFiltered bool
+	// pending buffers user_turn events per call until that call's AMD
+	// verdict arrives, so a phone tree's menu prompt renders as [machine]
+	// instead of [human]. The transcript events land in the stream before
+	// the amd_result row, so the right label is unknowable on arrival.
+	pending     map[openapi_types.UUID][]client.EventResponse
+	amdResolved map[openapi_types.UUID]bool
+	// lastShownAt is the event-timestamp of the last printed line; silence
+	// dots derive from gaps between them. quietAnchor is its wall-clock
+	// twin for live-mode waiting dots.
+	lastShownAt time.Time
+	quietAnchor time.Time
+	hasShown    bool
+}
+
+func newTailRenderer(opts *Options, singleResource, colorize, kindFiltered bool) *tailRenderer {
+	return &tailRenderer{
+		opts:           opts,
+		singleResource: singleResource,
+		colorize:       colorize,
+		kindFiltered:   kindFiltered,
+		pending:        map[openapi_types.UUID][]client.EventResponse{},
+		amdResolved:    map[openapi_types.UUID]bool{},
+	}
+}
+
+// renderEvent dispatches on event.Kind and writes one line to opts.Stdout.
+// In --json mode each event is emitted as a single JSON object per line,
+// verbatim and unbuffered — the NDJSON stream must not be reordered.
+func (r *tailRenderer) renderEvent(ev client.EventResponse) error {
+	if r.opts.JSON {
 		out, err := json.Marshal(ev)
 		if err != nil {
 			return fmt.Errorf("encode event JSON: %w", err)
 		}
-		fmt.Fprintln(opts.Stdout, string(out))
+		fmt.Fprintln(r.opts.Stdout, string(out))
 		return nil
 	}
 
-	ts := ev.OccurredAt.UTC().Format("15:04:05")
-	label, body := renderEventBody(ev)
-	if colorize {
-		label = colorFor(ev.Kind) + label + colorReset
-	}
-	if singleResource {
-		fmt.Fprintf(opts.Stdout, "[%s] %-9s %s\n", ts, label, body)
+	res := eventResourceID(ev)
+	if ev.Kind == "user_turn" && !r.kindFiltered && !r.amdResolved[res] {
+		r.pending[res] = append(r.pending[res], ev)
 		return nil
 	}
-	short := shortCallID(eventResourceID(ev))
-	prefix := fmt.Sprintf("[%s]", short)
-	if colorize {
-		prefix = shortIDColor(short) + prefix + colorReset
+	if ev.Kind == "amd_result" {
+		r.amdResolved[res] = true
+		category, _ := ev.Payload["category"].(string)
+		r.flushPending(res, strings.HasPrefix(category, "machine"))
+	} else if ev.Kind != "state_change" || len(r.pending[res]) > 0 {
+		// The voicebot writes amd_result before any agent_turn, so any
+		// post-pickup event kind means the verdict is not coming (AMD
+		// skipped or failed, or the tail joined mid-call) — whoever speaks
+		// from here is presumed a person, with no buffering delay.
+		// state_change alone doesn't resolve: queued/ringing transitions
+		// precede pickup in --from-start replays.
+		r.amdResolved[res] = true
+		r.flushPending(res, false)
 	}
-	fmt.Fprintf(opts.Stdout, "[%s] %s %-9s %s\n", ts, prefix, label, body)
+	label, body := renderEventBody(ev)
+	r.printLine(ev, label, colorFor(ev.Kind), body)
 	return nil
+}
+
+// flushPending prints a call's buffered pickup transcripts, labeled per
+// the AMD verdict, preserving their original timestamps and order.
+func (r *tailRenderer) flushPending(res openapi_types.UUID, machine bool) {
+	for _, ev := range r.pending[res] {
+		label, color := "[human]", colorYellow
+		if machine {
+			label, color = "[machine]", colorDim
+		}
+		text, _ := ev.Payload["text"].(string)
+		if text == "" {
+			text = payloadJSON(ev.Payload)
+		}
+		r.printLine(ev, label, color, text)
+	}
+	delete(r.pending, res)
+}
+
+// flushAll drains every buffer as [human] — the stream is ending, so no
+// verdict is coming.
+func (r *tailRenderer) flushAll() {
+	for res := range r.pending {
+		r.flushPending(res, false)
+	}
+}
+
+// printLine writes one formatted line, preceded by silence dots when the
+// event-timestamp gap since the previous line warrants them.
+func (r *tailRenderer) printLine(ev client.EventResponse, label, color, body string) {
+	r.renderSilence(ev.OccurredAt)
+	ts := ev.OccurredAt.UTC().Format("15:04:05")
+	if r.colorize && color != "" {
+		label = color + label + colorReset
+	}
+	if r.singleResource {
+		fmt.Fprintf(r.opts.Stdout, "[%s] %-9s %s\n", ts, label, body)
+	} else {
+		short := shortCallID(eventResourceID(ev))
+		prefix := fmt.Sprintf("[%s]", short)
+		if r.colorize {
+			prefix = shortIDColor(short) + prefix + colorReset
+		}
+		fmt.Fprintf(r.opts.Stdout, "[%s] %s %-9s %s\n", ts, prefix, label, body)
+	}
+	r.lastShownAt = ev.OccurredAt
+	r.quietAnchor = time.Now()
+	r.hasShown = true
+}
+
+// renderSilence prints one dim "." line per second of gap between displayed
+// lines, so dead air is visible instead of implied. Gaps beyond 10s
+// compress to three dots plus a duration — a four-hour hold must not
+// scroll fourteen thousand lines. Single-resource mode only: org-wide
+// streams interleave calls, so gaps between lines mean nothing there.
+func (r *tailRenderer) renderSilence(ts time.Time) {
+	if !r.singleResource || r.kindFiltered || !r.hasShown {
+		return
+	}
+	secs := int(ts.Sub(r.lastShownAt).Seconds())
+	if secs < 2 {
+		return
+	}
+	if secs > 10 {
+		for i := 0; i < 3; i++ {
+			r.dotLine(".")
+		}
+		r.dotLine(fmt.Sprintf("(%s silent)", (time.Duration(secs) * time.Second).String()))
+		return
+	}
+	for i := 0; i < secs; i++ {
+		r.dotLine(".")
+	}
+}
+
+// markQuiet prints live-mode waiting dots: one per full wall-clock second
+// since the last printed line. It advances both anchors so the next
+// event's timestamp gap doesn't re-print the same silence.
+func (r *tailRenderer) markQuiet() {
+	if !r.singleResource || r.kindFiltered || r.opts.JSON || !r.hasShown {
+		return
+	}
+	now := time.Now()
+	if secs := int(now.Sub(r.quietAnchor).Seconds()); secs > 10 {
+		// Wall-clock jump — machine suspend, a blocked terminal — not a
+		// live second-by-second wait. Compress like renderSilence instead
+		// of flooding one dot line per elapsed second.
+		for i := 0; i < 3; i++ {
+			r.dotLine(".")
+		}
+		r.dotLine(fmt.Sprintf("(%s silent)", (time.Duration(secs) * time.Second).String()))
+		advance := time.Duration(secs) * time.Second
+		r.quietAnchor = r.quietAnchor.Add(advance)
+		r.lastShownAt = r.lastShownAt.Add(advance)
+		return
+	}
+	for now.Sub(r.quietAnchor) >= time.Second {
+		r.dotLine(".")
+		r.quietAnchor = r.quietAnchor.Add(time.Second)
+		r.lastShownAt = r.lastShownAt.Add(time.Second)
+	}
+}
+
+func (r *tailRenderer) dotLine(s string) {
+	if r.colorize {
+		s = colorDim + s + colorReset
+	}
+	fmt.Fprintln(r.opts.Stdout, s)
 }
 
 // eventResourceID picks the id (call, email, or sms) that owns this event,
@@ -380,15 +574,25 @@ func renderEventBody(ev client.EventResponse) (label, body string) {
 	case "agent_turn":
 		text, _ := ev.Payload["text"].(string)
 		if text == "" {
-			return "[agent]", payloadJSON(ev.Payload)
+			return "[hail]", payloadJSON(ev.Payload)
 		}
-		return "[agent]", text
+		return "[hail]", text
 	case "user_turn":
 		text, _ := ev.Payload["text"].(string)
 		if text == "" {
-			return "[user]", payloadJSON(ev.Payload)
+			return "[human]", payloadJSON(ev.Payload)
 		}
-		return "[user]", text
+		return "[human]", text
+	case "amd_result":
+		// The pickup transcript lines above already show what was heard —
+		// render only the verdict, as a sentence, not the payload JSON.
+		if category, ok := ev.Payload["category"].(string); ok && category != "" {
+			if sentence, ok := amdSentences[category]; ok {
+				return "[amd]", sentence
+			}
+			return "[amd]", category
+		}
+		return "[amd]", payloadJSON(ev.Payload)
 	case "tool_call":
 		// Verified shape (voicebot/.../agent.py): {"tools": [<name>, ...]}.
 		// Spec mentions {"name", "args"} too — handle both defensively.
@@ -451,7 +655,7 @@ func colorFor(kind string) string {
 		return colorCyan
 	case "user_turn":
 		return colorYellow
-	case "state_change":
+	case "state_change", "amd_result":
 		return colorDim
 	case "error":
 		return colorRed

--- a/cli/internal/cmd/tail.go
+++ b/cli/internal/cmd/tail.go
@@ -476,14 +476,14 @@ func (r *tailRenderer) renderSilence(ts time.Time) {
 		return
 	}
 	if secs > 10 {
-		for i := 0; i < 3; i++ {
-			r.dotLine(".")
+		for i := 1; i <= 3; i++ {
+			r.dotLine(r.lastShownAt.Add(time.Duration(i)*time.Second), ".")
 		}
-		r.dotLine(fmt.Sprintf("(%s silent)", (time.Duration(secs) * time.Second).String()))
+		r.dotLine(ts, fmt.Sprintf("(%s silent)", (time.Duration(secs)*time.Second).String()))
 		return
 	}
-	for i := 0; i < secs; i++ {
-		r.dotLine(".")
+	for i := 1; i <= secs; i++ {
+		r.dotLine(r.lastShownAt.Add(time.Duration(i)*time.Second), ".")
 	}
 }
 
@@ -499,27 +499,30 @@ func (r *tailRenderer) markQuiet() {
 		// Wall-clock jump — machine suspend, a blocked terminal — not a
 		// live second-by-second wait. Compress like renderSilence instead
 		// of flooding one dot line per elapsed second.
-		for i := 0; i < 3; i++ {
-			r.dotLine(".")
+		for i := 1; i <= 3; i++ {
+			r.dotLine(r.lastShownAt.Add(time.Duration(i)*time.Second), ".")
 		}
-		r.dotLine(fmt.Sprintf("(%s silent)", (time.Duration(secs) * time.Second).String()))
 		advance := time.Duration(secs) * time.Second
+		r.dotLine(r.lastShownAt.Add(advance), fmt.Sprintf("(%s silent)", advance.String()))
 		r.quietAnchor = r.quietAnchor.Add(advance)
 		r.lastShownAt = r.lastShownAt.Add(advance)
 		return
 	}
 	for now.Sub(r.quietAnchor) >= time.Second {
-		r.dotLine(".")
+		r.dotLine(r.lastShownAt.Add(time.Second), ".")
 		r.quietAnchor = r.quietAnchor.Add(time.Second)
 		r.lastShownAt = r.lastShownAt.Add(time.Second)
 	}
 }
 
-func (r *tailRenderer) dotLine(s string) {
+// dotLine writes one waiting line — "[13:50:57] [wait]    ." — timestamped
+// like every other line so silence reads in sequence with the transcript.
+func (r *tailRenderer) dotLine(ts time.Time, s string) {
+	line := fmt.Sprintf("[%s] %-9s %s", ts.UTC().Format("15:04:05"), "[wait]", s)
 	if r.colorize {
-		s = colorDim + s + colorReset
+		line = colorDim + line + colorReset
 	}
-	fmt.Fprintln(r.opts.Stdout, s)
+	fmt.Fprintln(r.opts.Stdout, line)
 }
 
 // eventResourceID picks the id (call, email, or sms) that owns this event,

--- a/cli/internal/cmd/tail_test.go
+++ b/cli/internal/cmd/tail_test.go
@@ -172,8 +172,10 @@ func TestTail_RejectsMalformedId(t *testing.T) {
 		id        string
 		mustMatch string
 	}{
-		{"missing colon", "badvalue", "missing ':'"},
-		{"bad uuid", "call:notuuid", "invalid uuid"},
+		// A bare value defaults to a call id; non-hex garbage fails the
+		// local shape check before any HTTP.
+		{"bare non-id", "badvalue", "invalid call id"},
+		{"bad uuid", "call:notuuid", "invalid call id"},
 		{"bare colon", ":", "missing resource type"},
 		{"empty id", "call:", "missing resource id"},
 	}
@@ -324,8 +326,8 @@ func TestTail_DefensiveOnUnknownKind(t *testing.T) {
 	if !strings.Contains(stdout, "\"a\":1") && !strings.Contains(stdout, "\"a\": 1") {
 		t.Errorf("missing payload JSON for unknown kind:\n%s", stdout)
 	}
-	if !strings.Contains(stdout, "[agent]") {
-		t.Errorf("missing [agent] label for fallback:\n%s", stdout)
+	if !strings.Contains(stdout, "[hail]") {
+		t.Errorf("missing [hail] label for fallback:\n%s", stdout)
 	}
 }
 
@@ -580,5 +582,173 @@ func TestTail_UnsupportedType(t *testing.T) {
 	)
 	if err == nil || !strings.Contains(err.Error(), "unsupported resource type") {
 		t.Fatalf("want unsupported-type rejection, got %v", err)
+	}
+}
+
+// TestTail_MachineTranscriptsRelabeled: pickup transcripts that precede a
+// machine AMD verdict render as [machine], never [human]; the amd_result
+// row renders as a compact [amd] verdict, not payload JSON.
+func TestTail_MachineTranscriptsRelabeled(t *testing.T) {
+	tFuture := time.Now().Add(time.Hour)
+	srv := newSequenceServer(t, []sequenceResponse{
+		{http.StatusOK, client.EventStreamResponse{
+			Items: []client.EventResponse{
+				sampleEventInCall("11111111-1111-1111-1111-111111111111", callA, "user_turn",
+					map[string]interface{}{"text": "press one."}, tFuture),
+				sampleEventInCall("22222222-2222-2222-2222-222222222221", callA, "amd_result",
+					map[string]interface{}{"category": "machine-ivr", "transcript": "press one."}, tFuture.Add(time.Second)),
+				sampleEventInCall("33333333-3333-3333-3333-333333333331", callA, "agent_turn",
+					map[string]interface{}{"text": "Hi, this is an AI assistant."}, tFuture.Add(2*time.Second)),
+			},
+			CallStatus: completedStatus(),
+		}},
+	})
+
+	stdout, _, err := runRoot(t,
+		map[string]string{"HAIL_API_KEY": "sk_test", "HAIL_API_URL": srv.URL, "NO_COLOR": "1"},
+		"tail", "--id", "call:"+uuid.UUID(callA).String(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout, "[machine]") || !strings.Contains(stdout, "press one.") {
+		t.Errorf("machine transcript not relabeled:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "[human]") || strings.Contains(stdout, "[user]") {
+		t.Errorf("machine speech leaked a human/user label:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "[amd]") || !strings.Contains(stdout, "answered by a machine (phone menu)") {
+		t.Errorf("missing [amd] verdict sentence:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "transcript") {
+		t.Errorf("amd_result should not dump payload JSON:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "[hail]") {
+		t.Errorf("agent line should render as [hail]:\n%s", stdout)
+	}
+}
+
+// TestTail_HumanPickupFlushesAsHuman: transcripts buffered during AMD
+// flush as [human] when the verdict is human, preserving order before the
+// verdict line.
+func TestTail_HumanPickupFlushesAsHuman(t *testing.T) {
+	tFuture := time.Now().Add(time.Hour)
+	srv := newSequenceServer(t, []sequenceResponse{
+		{http.StatusOK, client.EventStreamResponse{
+			Items: []client.EventResponse{
+				sampleEventInCall("11111111-1111-1111-1111-111111111111", callA, "user_turn",
+					map[string]interface{}{"text": "Hello?"}, tFuture),
+				sampleEventInCall("22222222-2222-2222-2222-222222222221", callA, "amd_result",
+					map[string]interface{}{"category": "human"}, tFuture.Add(time.Second)),
+			},
+			CallStatus: completedStatus(),
+		}},
+	})
+
+	stdout, _, err := runRoot(t,
+		map[string]string{"HAIL_API_KEY": "sk_test", "HAIL_API_URL": srv.URL, "NO_COLOR": "1"},
+		"tail", "--id", "call:"+uuid.UUID(callA).String(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout, "[human]") || !strings.Contains(stdout, "Hello?") {
+		t.Errorf("human pickup transcript missing:\n%s", stdout)
+	}
+	if strings.Index(stdout, "Hello?") > strings.Index(stdout, "[amd]") {
+		t.Errorf("buffered transcript must print before the verdict line:\n%s", stdout)
+	}
+}
+
+// TestTail_SilenceDotsBetweenEvents: a short gap prints one dim "." line
+// per second; a long gap compresses to three dots plus a duration.
+func TestTail_SilenceDotsBetweenEvents(t *testing.T) {
+	tFuture := time.Now().Add(time.Hour)
+	srv := newSequenceServer(t, []sequenceResponse{
+		{http.StatusOK, client.EventStreamResponse{
+			Items: []client.EventResponse{
+				sampleEventInCall("11111111-1111-1111-1111-111111111111", callA, "agent_turn",
+					map[string]interface{}{"text": "One moment."}, tFuture),
+				sampleEventInCall("22222222-2222-2222-2222-222222222221", callA, "agent_turn",
+					map[string]interface{}{"text": "Still here."}, tFuture.Add(5*time.Second)),
+				sampleEventInCall("33333333-3333-3333-3333-333333333331", callA, "agent_turn",
+					map[string]interface{}{"text": "Back again."}, tFuture.Add(3605*time.Second)),
+			},
+			CallStatus: completedStatus(),
+		}},
+	})
+
+	stdout, _, err := runRoot(t,
+		map[string]string{"HAIL_API_KEY": "sk_test", "HAIL_API_URL": srv.URL, "NO_COLOR": "1"},
+		"tail", "--id", "call:"+uuid.UUID(callA).String(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dotLines := 0
+	for _, line := range strings.Split(stdout, "\n") {
+		if line == "." {
+			dotLines++
+		}
+	}
+	// 5 for the 5s gap + 3 for the compressed hour-long gap.
+	if dotLines != 8 {
+		t.Errorf("dot lines = %d, want 8:\n%s", dotLines, stdout)
+	}
+	if !strings.Contains(stdout, "1h0m0s silent") {
+		t.Errorf("missing compressed silence duration:\n%s", stdout)
+	}
+}
+
+// TestTail_BareUUIDDefaultsToCall: --id with a bare UUID (no "call:"
+// prefix) narrows to that call.
+func TestTail_BareUUIDDefaultsToCall(t *testing.T) {
+	srv := newSequenceServer(t, []sequenceResponse{
+		{http.StatusOK, client.EventStreamResponse{CallStatus: completedStatus()}},
+	})
+
+	_, _, err := runRoot(t,
+		map[string]string{"HAIL_API_KEY": "sk_test", "HAIL_API_URL": srv.URL, "NO_COLOR": "1"},
+		"tail", "--id", uuid.UUID(callA).String(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := srv.lastReq.URL.Query().Get("id")
+	want := "call:" + uuid.UUID(callA).String()
+	if got != want {
+		t.Errorf("wire id = %q, want %q", got, want)
+	}
+}
+
+// TestTail_ShortPrefixResolvesViaCallsList: --id call:<prefix> resolves the
+// full UUID through GET /calls before polling events.
+func TestTail_ShortPrefixResolvesViaCallsList(t *testing.T) {
+	var eventsQuery atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/calls"):
+			_ = json.NewEncoder(w).Encode(client.CallListResponse{
+				Items: []client.CallResponse{sampleCall(uuid.UUID(callA).String(), "+15551234567", client.CallResponseStatusCompleted)},
+			})
+		default:
+			eventsQuery.Store(r.URL.Query().Get("id"))
+			_ = json.NewEncoder(w).Encode(client.EventStreamResponse{CallStatus: completedStatus()})
+		}
+	}))
+	defer srv.Close()
+
+	_, _, err := runRoot(t,
+		map[string]string{"HAIL_API_KEY": "sk_test", "HAIL_API_URL": srv.URL, "NO_COLOR": "1"},
+		"tail", "--id", "call:c2a8f1d3",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "call:" + uuid.UUID(callA).String()
+	if got, _ := eventsQuery.Load().(string); got != want {
+		t.Errorf("events wire id = %q, want %q", got, want)
 	}
 }

--- a/cli/internal/cmd/tail_test.go
+++ b/cli/internal/cmd/tail_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -687,7 +688,7 @@ func TestTail_SilenceDotsBetweenEvents(t *testing.T) {
 	}
 	dotLines := 0
 	for _, line := range strings.Split(stdout, "\n") {
-		if line == "." {
+		if strings.Contains(line, "[wait]") && strings.HasSuffix(line, " .") {
 			dotLines++
 		}
 	}
@@ -695,7 +696,11 @@ func TestTail_SilenceDotsBetweenEvents(t *testing.T) {
 	if dotLines != 8 {
 		t.Errorf("dot lines = %d, want 8:\n%s", dotLines, stdout)
 	}
-	if !strings.Contains(stdout, "1h0m0s silent") {
+	// Dot lines carry the standard timestamp prefix: "[HH:MM:SS] [wait]    ."
+	if !regexp.MustCompile(`(?m)^\[\d{2}:\d{2}:\d{2}\] \[wait\]\s+\.$`).MatchString(stdout) {
+		t.Errorf("dot lines missing timestamped [wait] prefix:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "[wait]") || !strings.Contains(stdout, "1h0m0s silent") {
 		t.Errorf("missing compressed silence duration:\n%s", stdout)
 	}
 }


### PR DESCRIPTION
…s, short ids

hail tail renders agent/user turns as [hail]/[human]; pickup speech that AMD attributes to a machine is buffered and relabeled [machine], with the amd_result row rendered as a plain-language verdict sentence instead of payload JSON. Silent seconds print as dim dot lines (long gaps compress to three dots plus a duration), and --id accepts a bare call UUID or a 4+ char hex prefix resolved like git short hashes. Buffering, dots, and verdicts disable under --kind filters and flush on every exit path.