### PR TITLE
docs: rewrite README and docs in ASD-STE100, fix stale claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,41 @@
 # Hail
 
-> Universal communication platform for AI agents.
-> Phone calls, SMS, email — outbound first, inbound next. Self-hostable. Open source (AGPLv3).
+> Hail is a communication platform for AI agents.
+> Agents can make telephone calls. Agents can send and receive SMS messages and email. Inbound telephone calls will follow. You can host Hail on your own servers. The source code is open (AGPLv3).
 
-Your agent wants to place a call: _"Call +1… and ask if they want to reschedule."_ Hail does the carrier glue, runs the voice pipeline, and lets the agent plug in its own brain (or fall back to OpenAI → Gemini → Claude).
+An example: your agent must call a person to change an appointment. Hail connects to the telephone carrier and operates the voice pipeline. The agent can supply its own LLM. If the agent does not supply an LLM, Hail uses a fallback sequence: OpenAI, then Gemini, then Claude.
 
-## Quickstart
+## Quick start
 
-```bash
-git clone https://github.com/hail-hq/hail
-cd hail
-cp .env.example .env
-# fill in Twilio, LiveKit Cloud, Deepgram, Cartesia, and one of OpenAI / Gemini / Anthropic
-docker compose up
-```
+Do these steps:
 
-Authenticate:
+1. Get the source code and go into the directory:
 
-- **Hail Cloud** (managed at hail.so): `hail login` runs the device-flow and saves an API key to `~/.hail/credentials.json`.
-- **Self-host**: seed an API key directly into your local stack — see [docs/operations.md](docs/operations.md) "First-run DB seed". Then export `HAIL_API_KEY` (or pass `--api-key`).
+   ```bash
+   git clone https://github.com/hail-hq/hail
+   cd hail
+   ```
 
-Use it — CLI (for humans scripting Hail):
+2. Copy the example configuration file:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+3. Add your credentials to `.env` for Twilio, LiveKit Cloud, Deepgram, and Cartesia. Add credentials for one of OpenAI, Gemini, or Anthropic.
+
+4. Start the stack:
+
+   ```bash
+   docker compose up
+   ```
+
+Then get an API key. There are two procedures:
+
+- **Hail Cloud** (managed at hail.so): Run `hail login`. The command starts the device flow. It writes an API key to `~/.hail/credentials.json`.
+- **Self-host**: Put an API key into your local database. Refer to [docs/operations.md](docs/operations.md), section "First-run DB seed". Then set the environment variable `HAIL_API_KEY`, or give the `--api-key` option.
+
+Use the CLI (for persons who write scripts for Hail):
 
 ```bash
 hail login                        # authenticate (device flow)
@@ -30,6 +45,16 @@ hail auth token                   # print bare API key for scripting
 hail call +14155550100 --prompt "be brief"
 hail call list
 hail call tail <id>               # follow events for one call
+
+hail sms +15551234567 --body "Hello!" --recipient-consent
+hail sms list
+hail sms status <id>
+hail sms suppressions list        # opt-out list
+hail sms sender-id get            # custom sender ID
+
+hail numbers acquire              # dedicated phone number (voice + SMS)
+hail numbers list
+hail contacts list                # org contact directory
 
 hail email send --to a@b.com --subject hi --body "hello"
 hail email list
@@ -49,13 +74,17 @@ hail completion zsh               # source <(hail completion zsh)
 hail version
 ```
 
-Or over HTTP / MCP:
+Or use HTTP or MCP:
 
 ```bash
 # HTTP
 curl -X POST http://localhost:8080/calls \
   -H "Authorization: Bearer $HAIL_API_KEY" \
   -d '{"to":"+15551234567","system_prompt":"..."}'
+
+curl -X POST http://localhost:8080/sms \
+  -H "Authorization: Bearer $HAIL_API_KEY" \
+  -d '{"to":"+15551234567","body":"hello","recipient_consent":true}'
 
 curl -X POST http://localhost:8080/emails \
   -H "Authorization: Bearer $HAIL_API_KEY" \
@@ -67,24 +96,24 @@ curl -X POST http://localhost:8080/emails \
 #   https://mcp.hail.so        (Hail Cloud, later)
 ```
 
-`hail tail` in action:
+This is `hail tail` in operation:
 
 ![Animated terminal demo of hail tail streaming live call events](docs/assets/gifs/hail-tail-live-stream.gif)
 
-Full setup: [docs/setup/twilio.md](docs/setup/twilio.md), [docs/setup/livekit-cloud.md](docs/setup/livekit-cloud.md), [docs/setup/aws-ses.md](docs/setup/aws-ses.md), [docs/setup/mcp.md](docs/setup/mcp.md).
+For the full setup, refer to [docs/setup/twilio.md](docs/setup/twilio.md), [docs/setup/livekit-cloud.md](docs/setup/livekit-cloud.md), [docs/setup/aws-ses.md](docs/setup/aws-ses.md), and [docs/setup/mcp.md](docs/setup/mcp.md).
 
 ## Tenets
 
-1. **Clear comms.** Explicit OpenAPI contracts. No magic.
-2. **Simple code.** Boring is best. No abstractions without two uses.
-3. **Brief docs.** One screen per page. Setup ≤ 10 minutes from a fresh clone.
-4. **Self-hostable.** `docker compose up` runs everything except LiveKit Cloud.
-5. **Pluggable brain.** BYO endpoint compatible with OpenAI's completions API, or use Hail's bundled fallback (OpenAI → Gemini → Anthropic). Voice pipeline + transport are always Hail's.
-6. **Agent-first docs.** AI agents are first-class readers. Lead with concrete, runnable examples; link to canonical sources (OpenAPI spec, MCP tool schemas, code paths) rather than paraphrase them. Every page should let a reader — human or agent — take the next action.
+1. **Clear communication.** The API has explicit OpenAPI contracts. There is no hidden behavior.
+2. **Simple code.** Simple solutions are best. We do not add an abstraction before it has two uses.
+3. **Short documents.** Each page is one screen. Setup from a new clone takes 10 minutes or less.
+4. **Self-hostable.** The command `docker compose up` starts all the services. Only LiveKit Cloud is external.
+5. **Pluggable brain.** Connect your own LLM endpoint that is compatible with the OpenAI completions API. As an alternative, use the fallback sequence from Hail: OpenAI, then Gemini, then Anthropic. Hail always supplies the voice pipeline and the transport.
+6. **Agent-first documents.** AI agents are primary readers. Each page starts with an example that you can run. Pages give links to canonical sources (OpenAPI spec, MCP tool schemas, code paths). They do not give the same data again in different words. Each page lets a reader — a person or an agent — do the subsequent action.
 
 ## Milestones
 
-Checked = shipped. Per-artifact changelogs (GitHub Releases for the CLI, PyPI release notes for the SDK) own the "shipped in which version" question.
+A checked box shows a feature that we released. The changelog for each artifact (GitHub Releases for the CLI, PyPI release notes for the SDK) shows the version that contains each feature.
 
 ### Phone calls
 
@@ -105,7 +134,7 @@ Checked = shipped. Per-artifact changelogs (GitHub Releases for the CLI, PyPI re
 
 - Outbound
   - [x] AWS SES
-  - [x] Custom sender domains (own DNS, auto DKIM + MAIL FROM)
+  - [x] Custom sender domains (own DNS, automatic DKIM + MAIL FROM)
 - Inbound
   - [x] AWS SES
   - [x] Custom domains (receive on verified domains)
@@ -139,8 +168,8 @@ Checked = shipped. Per-artifact changelogs (GitHub Releases for the CLI, PyPI re
 - CLI
   - [x] `hail` binary via GitHub Releases
 - MCP server
-  - [x] Remote Streamable HTTP endpoint bundled with every Hail deploy
-  - ~~PyPI stdio package~~ — intentionally not shipped; see [docs/setup/mcp.md](docs/setup/mcp.md)
+  - [x] Remote Streamable HTTP endpoint included with each Hail deployment
+  - ~~PyPI stdio package~~ — we do not supply this package; refer to [docs/setup/mcp.md](docs/setup/mcp.md)
 - Python SDK
   - [x] `hail-sdk` on PyPI, imports as `hail`
 
@@ -152,17 +181,19 @@ Checked = shipped. Per-artifact changelogs (GitHub Releases for the CLI, PyPI re
 
 ## Architecture
 
+This diagram shows the path of an outbound call:
+
 ```
 AI agent ──► Hail API ──dispatch──► Voicebot ──► LiveKit Cloud ──SIP──► Twilio ──► 📞
 ```
 
-Full diagram: [docs/architecture.md](docs/architecture.md).
+For the full diagram, refer to [docs/architecture.md](docs/architecture.md).
 
 ## Contributing
 
-See [docs/contributing.md](docs/contributing.md). TL;DR: fork, branch, conventional-commit, PR. Provider adapters go in `core/hailhq/core/providers/`. Update `.env.example` for any new env var.
+Refer to [docs/contributing.md](docs/contributing.md). The procedure is short: make a fork, make a branch, write conventional commits, and open a pull request. Put provider adapters in `core/hailhq/core/providers/`. If you add a new environment variable, update `.env.example` in the same commit.
 
 ## License
 
-Source code: [AGPL-3.0-or-later](./LICENSE) — if you run a modified Hail as a service, you must release your source.
-Pricing dataset (`costs/`): [CC-BY-4.0](./costs/LICENSE) — reuse the pricing JSON freely with attribution.
+The source code has the [AGPL-3.0-or-later](./LICENSE) license. If you operate a modified Hail as a service, you must release your source code.
+The pricing dataset (`costs/`) has the [CC-BY-4.0](./costs/LICENSE) license. You can use the pricing JSON if you give attribution.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Hail v1 is three Python services + a Go CLI, wrapped around LiveKit Cloud.
+Hail v1 is three Python services plus a Go CLI, built around LiveKit Cloud.
 
 ```
  AI agent                                     Hail                                LiveKit Cloud         PSTN
@@ -18,54 +18,64 @@ Hail v1 is three Python services + a Go CLI, wrapped around LiveKit Cloud.
 
 ## Services
 
-- **api** (`:8080`, FastAPI) — REST surface; accepts `POST /calls` etc. Source of truth for OpenAPI.
-- **mcp** (`:8081`, Streamable HTTP; legacy SSE during transition) — MCP server wrapping the API; what agent clients (Claude.ai, ChatGPT, Claude Code, Cursor) connect to. See [MCP setup](./setup/mcp.md).
-- **voicebot** (LiveKit Agents worker) — registers with LiveKit Cloud; dispatched into a room per call.
+- **api** (`:8080`, FastAPI) — the REST surface; it accepts `POST /calls` and the other routes. It is the source of truth for OpenAPI.
+- **mcp** (`:8081`, Streamable HTTP; legacy SSE during the transition) — the MCP server that wraps the API. Agent clients (Claude.ai, ChatGPT, Claude Code, Cursor) connect to it. Refer to [MCP setup](./setup/mcp.md).
+- **voicebot** (LiveKit Agents worker) — registers with LiveKit Cloud. Hail dispatches it into a room for each call.
 - **postgres** — call records, phone numbers, API keys.
-- **minio** (dev only) — S3-compatible local object storage. Swap for real S3 in prod.
+- **minio** (dev only) — S3-compatible local object storage. Use real S3 in production.
 
-LiveKit Cloud is external. The `hail` Go CLI is a human-facing scriptable tool, not a service.
+LiveKit Cloud is external. The `hail` Go CLI is a scriptable tool for humans, not a service.
 
 ## Outbound call flow
 
-1. Caller (agent via MCP, or CLI, or direct HTTP) → `POST /calls` with `{to, from, first_message?, …llm}`.
-2. Hail API creates a LiveKit room and dispatches the voicebot into it.
-3. Voicebot joins; LiveKit places a SIP outbound via the Twilio trunk to `to`.
-4. On pickup, voicebot classifies who answered before saying anything (see below), then speaks the AI disclosure (unless the call set `ai_disclosure: false` — the opt-out is audit-logged and the caller's responsibility) and `first_message` (if set) and runs the STT → LLM → TTS loop.
-5. On hangup, voicebot writes the call record to Postgres and uploads the recording to S3.
+1. The caller (an agent via MCP, the CLI, or direct HTTP) sends `POST /calls` with `{to, from, first_message?, …llm}`.
+2. The Hail API creates a LiveKit room and dispatches the voicebot into it.
+3. The voicebot joins the room. LiveKit places an outbound SIP call through the Twilio trunk to `to`.
+4. On pickup, the voicebot classifies who answered before it speaks (refer to the section below). Then it speaks the AI disclosure and the `first_message` (if set), and runs the STT → LLM → TTS loop. If the call set `ai_disclosure: false`, the voicebot skips the disclosure; Hail audit-logs the opt-out, and the opt-out is the caller's responsibility.
+5. On hangup, the voicebot writes the call record to Postgres and uploads the recording to S3.
 
 ### Answering machine detection and DTMF
 
-Every outbound call runs LiveKit's AMD ([`voicebot/hailhq/voicebot/amd.py`](../voicebot/hailhq/voicebot/amd.py)) against the greeting, classifying on the session's own LLM and STT rather than LiveKit Inference. `machine-vm` and `machine-unavailable` hang up without speaking — no message is ever left — and record `status=no_answer` with `end_reason=voicemail_reached` / `machine_unavailable`. `human` and `uncertain` proceed normally. `machine-ivr` does **not** speak the greeting — a menu cannot hear it, and `session.say` is TTS-only so it would give the LLM no turn in which to press a key. Instead the agent takes a real LLM turn (`generate_reply`) carrying the captured menu text and the `send_dtmf` tool, and the disclosure is deferred until the first person speaks. The verdict lands in `call_events` as an `amd_result` row on every call. A detection failure is non-fatal: the call proceeds as if a human answered.
+Every outbound call runs LiveKit's AMD ([`voicebot/hailhq/voicebot/amd.py`](../voicebot/hailhq/voicebot/amd.py)) against the greeting. Classification runs on the session's own LLM and STT, not on LiveKit Inference. On `machine-vm` and `machine-unavailable`, the voicebot hangs up without a word — it never leaves a message. It records `status=no_answer` with `end_reason=voicemail_reached` / `machine_unavailable`. On `human` and `uncertain`, the call proceeds normally.
 
-Billing no longer requires a `completed` status: a call is billed when `answered_at` is set (the SIP leg went active) **or** the call completed normally. The first clause bills a machine-answered call and one that failed mid-conversation; the second keeps billing a completed call whose answer signal never landed.
+On `machine-ivr`, the voicebot does **not** speak the greeting. A menu cannot hear it, and `session.say` is TTS-only, so the LLM would get no turn in which to press a key. Instead, the agent takes a real LLM turn (`generate_reply`) with the captured menu text and the `send_dtmf` tool. Hail defers the disclosure until the first person speaks. Hail writes the verdict to `call_events` as an `amd_result` row on every call. A detection failure is non-fatal: the call proceeds as if a human answered.
 
-The agent can press keypad digits at any point via the `send_dtmf` tool ([`core/hailhq/core/agent_tools/send_dtmf.py`](../core/hailhq/core/agent_tools/send_dtmf.py)) — not just after an IVR verdict — so phone trees reached mid-call are navigable.
+Billing no longer requires a `completed` status. Hail bills a call when `answered_at` is set (the SIP leg went active) **or** when the call completed normally. The first clause bills a machine-answered call and a call that failed mid-conversation. The second clause keeps billing for a completed call whose answer signal never arrived.
+
+The agent can press keypad digits at any point with the `send_dtmf` tool ([`core/hailhq/core/agent_tools/send_dtmf.py`](../core/hailhq/core/agent_tools/send_dtmf.py)) — not only after an IVR verdict. Thus the agent can navigate phone trees that it reaches mid-call.
 
 ## LLM modes
 
-**A — system prompt (default).** Caller supplies `system_prompt`. Voicebot uses LiveKit's `FallbackAdapter` chaining `openai.LLM` → `google.LLM` → `anthropic.LLM` (fast models each). Falls through on error.
+**A — system prompt (default).** The caller supplies `system_prompt`. The voicebot uses LiveKit's `FallbackAdapter`, which chains `openai.LLM` → `google.LLM` → `anthropic.LLM` (a fast model for each). It falls through on error.
 
-**B — BYO endpoint.** Caller supplies `llm: { base_url, api_key, model }`. Voicebot points `openai.LLM` at that endpoint. No fallback.
+**B — BYO endpoint.** The caller supplies `llm: { base_url, api_key, model }`. The voicebot points `openai.LLM` at that endpoint. There is no fallback.
 
-One mode per call.
+Each call uses one mode.
 
 ## Data
 
-- **Postgres** — call records, phone numbers, API keys.
+- **Postgres** — call, SMS, and email records; phone numbers; email domains; contacts; webhook subscriptions; API keys.
 - **S3** — call recordings.
 - **LiveKit Cloud** — transient media (ephemeral).
 
+## SMS
+
+The `SmsProvider` adapter in [`core/hailhq/core/providers/sms/`](../core/hailhq/core/providers/sms/) sends SMS through Twilio.
+
+**Outbound.** `POST /sms` sends from the org's dedicated SMS-capable number. There is no pool fallback — refer to `hail numbers` for number acquisition. Twilio posts delivery-status callbacks. These callbacks move `Sms.status` and fan out the `sms.delivered` / `sms.undelivered` / `sms.failed` webhook events.
+
+**Inbound.** Twilio posts each incoming message to `POST /sms/inbound`. Hail verifies the `X-Twilio-Signature` header. It matches the destination number to an org, stores the message, and fires the `sms.received` webhook event. Messages to unknown or pool numbers are dropped. An opt-out reply (`STOP`) adds the sender to the org's suppression list; `START` removes it.
+
 ## Outbound email
 
-Outbound mail goes through AWS SES via the `EmailProvider` adapter in `core/hailhq/core/providers/email/`. Two flavors of sender identity, stored in `email_domains`:
+The `EmailProvider` adapter in `core/hailhq/core/providers/email/` sends outbound mail through AWS SES. Hail stores two kinds of sender identity in `email_domains`:
 
-- **`kind='custom'`** — tenant-controlled DNS (e.g. `acme.com`). `POST /email-domains` registers the identity with SES and auto-configures a custom MAIL FROM on `send.<domain>`; the response surfaces three DKIM CNAMEs **plus** the MAIL FROM MX/SPF records (each carrying an optional `priority`). The tenant publishes them, then `POST /email-domains/{id}/verify` re-polls SES for both DKIM and MAIL FROM status. Verified custom domains can also **receive** — inbound matches by identity, one row + webhook per matched domain.
-- **`kind='hail_mail'`** — per-org address under an operator-managed parent domain. The full sender is `<user>+<org>@<HAIL_MAIL_BASE_DOMAIN>` (e.g. `alice+acme@mail.hail.so`); the parent domain is pre-verified once by the operator out of band, so per-org rows land already-verified without ever calling SES.
+- **`kind='custom'`** — tenant-controlled DNS (for example `acme.com`). `POST /email-domains` registers the identity with SES and auto-configures a custom MAIL FROM on `send.<domain>`. The response surfaces three DKIM CNAMEs **plus** the MAIL FROM MX/SPF records (each with an optional `priority`). The tenant publishes them, then calls `POST /email-domains/{id}/verify` to re-poll SES for the DKIM and MAIL FROM status. Verified custom domains can also **receive** — inbound matches by identity, with one row and one webhook per matched domain.
+- **`kind='hail_mail'`** — a per-org address under an operator-managed parent domain. The full sender is `<user>+<org>@<HAIL_MAIL_BASE_DOMAIN>` (for example `alice+acme@mail.hail.so`). The operator pre-verifies the parent domain once, out of band. Thus Hail creates per-org rows as already verified, without a call to SES.
 
 ### Self-hosted vs managed
 
-The two surfaces differ in where the prefixes come from and where they're edited:
+The two surfaces differ in the source of the prefixes and in the place where you edit them:
 
 |                       | Self-hosted Hail                                                                                                         | Managed Hail (hail.so)                                                                              |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
@@ -77,30 +87,30 @@ The two surfaces differ in where the prefixes come from and where they're edited
 | SES production access | Operator's AWS account                                                                                                   | Operator's AWS account                                                                              |
 | Billing               | Off — `usage_events` accumulates as raw analytics                                                                        | Cloud rater applies cents/unit, debits `account_credits`                                            |
 
-Both prefixes are validated against `^[a-z0-9]([a-z0-9-]{0,18}[a-z0-9])?$` (1–20 chars, lowercase alphanumeric + hyphen, no leading/trailing hyphen), so the full local part fits well under the RFC-5321 64-char budget.
+Hail validates both prefixes against `^[a-z0-9]([a-z0-9-]{0,18}[a-z0-9])?$` (1–20 chars, lowercase alphanumeric + hyphen, no leading or trailing hyphen). Thus the full local part stays well under the RFC-5321 64-char budget.
 
 ### Send-time resolution
 
 `POST /emails` picks a sender in this order:
 
-1. Explicit `from` — must match a `verified` row owned by the caller's org.
-2. First verified org-owned domain (ordered by `created_at`, so a tenant's "default sender" stays stable).
-3. Auto-mint a hail-mail row using the configured prefixes, if `HAIL_MAIL_BASE_DOMAIN` is set.
+1. An explicit `from` — it must match a `verified` row that the caller's org owns.
+2. The first verified org-owned domain (ordered by `created_at`, so a tenant's "default sender" stays stable).
+3. An auto-minted hail-mail row with the configured prefixes, if `HAIL_MAIL_BASE_DOMAIN` is set.
 
-If none of those resolve, the request returns `503` pointing at how to register a domain.
+If none of those resolve, the request returns `503` with instructions on how to register a domain.
 
-See [`docs/setup/aws-ses.md`](./setup/aws-ses.md) for the operator-side setup, and [`docs/superpowers/plans/2026-05-17-hail-mail-addressing.md`](./superpowers/plans/2026-05-17-hail-mail-addressing.md) for the addressing/configurability plan.
+Refer to [`docs/setup/aws-ses.md`](./setup/aws-ses.md) for the operator-side setup. Refer to [`docs/superpowers/plans/2026-05-17-hail-mail-addressing.md`](./superpowers/plans/2026-05-17-hail-mail-addressing.md) for the addressing/configurability plan.
 
 ## Inbound email
 
-Operators on AWS enable inbound by applying `infra/terraform/`, which
-provisions an S3 bucket, an SES Receipt Rule + Rule Set, and a small
-Lambda that signs and forwards SES events into Hail's
-`POST /internal/ses-events` endpoint. The API parses raw MIME from S3,
-routes the message to the owning org by parsing the hail-mail
-local-part (`<user>+<org>@mail.hail.so`), persists an `Email` row with
-`direction='inbound'`, and fans out events to per-domain webhooks and
-org-wide subscriptions via the background delivery worker.
+Operators on AWS enable inbound email when they apply `infra/terraform/`.
+The Terraform provisions an S3 bucket, an SES Receipt Rule + Rule Set,
+and a small Lambda. The Lambda signs SES events and forwards them to
+Hail's `POST /internal/ses-events` endpoint. The API parses the raw MIME
+from S3 and routes the message to the owning org by the hail-mail
+local-part (`<user>+<org>@mail.hail.so`). It persists an `Email` row
+with `direction='inbound'`. The background delivery worker fans out
+events to per-domain webhooks and org-wide subscriptions.
 
 ```
 inbound SMTP ──► SES Receipt Rule
@@ -118,21 +128,21 @@ inbound SMTP ──► SES Receipt Rule
                                       • enqueue forwarding sends (header rewrite)
 ```
 
-The cloud-agnostic SMTP path is stubbed
-([`SmtpInboundProvider`](../core/hailhq/core/providers/email/inbound/smtp.py))
-and tracked in [`docs/setup/smtp-inbound.md`](setup/smtp-inbound.md).
+The cloud-agnostic SMTP path is a stub
+([`SmtpInboundProvider`](../core/hailhq/core/providers/email/inbound/smtp.py)).
+[`docs/setup/smtp-inbound.md`](setup/smtp-inbound.md) tracks it.
 
 ### Per-domain routing — forward and/or webhook
 
 Each `email_domains` row carries `inbound_enabled`, `forward_to`, and `webhook_url`. When `inbound_enabled` is true:
 
-- `forward_to` (list of addresses) triggers one outbound `Email` row per target through the existing send loop, with header rewrite (envelope `From:` = `forwarder+<org>@mail.hail.so`, `Reply-To:` = original sender, `References:` preserved for threading, `X-Hail-Forward-Hops` and `Auto-Submitted: auto-forwarded` for loop suppression).
+- `forward_to` (a list of addresses) triggers one outbound `Email` row per target through the existing send loop. The forward rewrites headers: envelope `From:` = `forwarder+<org>@mail.hail.so`, `Reply-To:` = the original sender, `References:` preserved for threading, and `X-Hail-Forward-Hops` plus `Auto-Submitted: auto-forwarded` for loop suppression.
 - `webhook_url` triggers a signed POST through the webhook delivery worker.
 
-A separate `inbound_routes` table for per-mailbox routing within custom domains is deferred to a future milestone (when tenants point their own MX at SES).
+A separate `inbound_routes` table, for per-mailbox routing in custom domains, is deferred to a future milestone (when tenants point their own MX at SES).
 
 ### Org-wide subscriptions
 
-The `/webhooks` CRUD surface is the firehose pattern — one subscription covers multiple event types (`email.received`, `email.bounced`, `email.complained`). Stripe-style signing: `X-Hail-Signature: t=<unix>,v1=<hex>`. Retries on a fixed `0/30s/2m/10m/1h/6h/24h` ladder; after the last retry the delivery is marked `dead` and after 50 consecutive dead deliveries the subscription auto-disables.
+The `/webhooks` CRUD surface is the firehose pattern — one subscription covers multiple event types (`email.received`, `email.bounced`, `email.complained`). Signatures are Stripe-style: `X-Hail-Signature: t=<unix>,v1=<hex>`. Hail retries deliveries on a fixed `0/30s/2m/10m/1h/6h/24h` ladder. After the last retry, Hail marks the delivery `dead`. After 50 consecutive dead deliveries, the subscription auto-disables.
 
-See [`docs/setup/aws-ses.md`](./setup/aws-ses.md) §10 for the operator runbook and [`docs/superpowers/specs/2026-06-06-inbound-email-design.md`](./superpowers/specs/2026-06-06-inbound-email-design.md) for the full spec.
+Refer to [`docs/setup/aws-ses.md`](./setup/aws-ses.md) §10 for the operator runbook. Refer to [`docs/superpowers/specs/2026-06-06-inbound-email-design.md`](./superpowers/specs/2026-06-06-inbound-email-design.md) for the full spec.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,8 +1,51 @@
-# CLI reference: email & webhooks
+# CLI reference
 
-`hail` is the Go CLI. It codegens its client from [`openapi/openapi.yaml`](../openapi/openapi.yaml) — that spec is the canonical contract; this page covers only the email and webhooks surface. Run `hail <cmd> --help` for the full, authoritative flag list.
+`hail` is the Go CLI. It codegens its client from [`openapi/openapi.yaml`](../openapi/openapi.yaml) — that spec is the canonical contract. This page is a brief summary of each command group. Run `hail <cmd> --help` for the full, authoritative flag list.
 
 Global flags (any command): `--api-url`, `--api-key`, `--json`. Auth resolves `--api-key > $HAIL_API_KEY > ~/.hail/credentials.json` (run `hail login`).
+
+## Calls
+
+Outbound phone calls only.
+
+```bash
+# Place an outbound call (consent attestation required)
+hail call +15551234567 --prompt "You are a scheduling assistant." --recipient-consent
+
+hail call status <id>     # one call (full UUID or 4+ char prefix)
+hail call list
+hail call tail <id>       # follow the event stream for one call
+```
+
+`hail call` flags: `--prompt` (mode A) or `--llm-url`/`--llm-key`/`--llm-model` (mode B), `--from`, `--first-message`, `--language`, `--ai-disclosure`, `--tools`, `--idempotency-key`, plus the consent flags.
+
+## SMS
+
+```bash
+# Send an outbound SMS (consent attestation required)
+hail sms +15551234567 --body "Hello" --recipient-consent
+
+hail sms status <id>
+hail sms list --status delivered
+
+hail sms suppressions list     # the opt-out list
+hail sms sender-id get         # the org's custom sender ID
+```
+
+`hail sms` flags: `--body` (required), `--from`, `--idempotency-key`, plus the consent flags. `list` takes `--status` (`queued|sent|delivered|failed|undelivered|received`), `--to`, `--limit`, `--cursor`.
+
+## Numbers
+
+Dedicated phone numbers for voice and SMS.
+
+```bash
+hail numbers acquire --country US --type local
+hail numbers list
+hail numbers get <id>
+hail numbers enable-sms <id>   # attach a Messaging Service so the number can send SMS
+```
+
+`acquire` flags: `--country`, `--type` (`local|mobile|toll_free|national`), `--idempotency-key`.
 
 ## Email
 
@@ -26,9 +69,11 @@ hail email send --to alice@example.com --subject "Hi" --body "Hello"
 
 `hail email send` flags: `--to` (repeatable / comma-separated), `--cc`, `--bcc`, `--from`, `--reply-to`, `--subject` (required), `--body`, `--body-html`, `--body-file`, `--body-html-file` (`-` reads stdin), `--idempotency-key`.
 
+More email subcommands: `tail <id>`, `raw <id>`, `events <id>`, `stats`, `attachment`, `attachment-upload`. Run `hail email --help` for the list.
+
 ### Email domains
 
-Identities email is sent from and received on. Two kinds: `hail_mail` (operator-managed parent, verified immediately) and `custom` (your DNS; returns DKIM CNAMEs to publish, then run `verify`).
+The identities that send and receive email. There are two kinds: `hail_mail` (operator-managed parent domain, verified immediately) and `custom` (your DNS). For `custom`, the register call returns DKIM CNAMEs. Publish them, then run `verify`.
 
 ```bash
 # Register a hail-mail identity (uses server prefix defaults)
@@ -47,23 +92,62 @@ hail email domain delete <id>   # also drops the SES identity for custom rows
 
 > Renamed: `hail sender-domain ...` is now `hail email domain ...`. The old name no longer exists.
 
-## Webhooks
+## Contacts
 
-Org-wide outbound subscriptions. Each fires an HMAC-signed POST per matching event, retried on a fixed ladder. See [setup/webhooks.md](setup/webhooks.md) for the payload shape and signature verification.
+The org's contact directory (members + manual contacts).
 
 ```bash
-# Register a subscription (prints the signing secret ONCE)
-hail webhooks create \
-  --url https://example.com/hooks/hail \
-  --events email.received,email.received.suppressed
-
-hail webhooks list
-
-# Delivery attempts for a subscription (full UUID or 4+ char prefix)
-hail webhooks deliveries <subscription-id>
-
-# Replay a single delivery
-hail webhooks redeliver <subscription-id> <delivery-id>
+hail contacts list --q alice
+hail contacts create "Alice" --phone +15551234567
+hail contacts update <id> --email alice@example.com
+hail contacts delete <id>
+hail contacts set-phone me --phone +15551234567
+hail contacts clear-phone me
 ```
 
-`create` flags: `--url` (required), `--events` (comma-separated; default `email.received`). Valid event types: `email.received`, `email.received.suppressed`. The response includes the plaintext signing secret — it is shown only on create; store it then.
+`create` requires one of `--phone` / `--email`. `list` takes `--q`, `--limit`, `--cursor`, `--all`.
+
+## Events
+
+```bash
+hail tail                      # stream events from across the org
+hail tail --id call:1a2b       # narrow to one resource
+```
+
+`hail tail` flags: `--id`, `--kind`, `--interval`, `--from-start`, `--no-follow`.
+
+## Webhooks
+
+Org-wide outbound subscriptions. Each subscription fires an HMAC-signed POST for each matching event. Hail retries failed deliveries on a fixed ladder. Refer to [setup/webhooks.md](setup/webhooks.md) for the payload shape, the event-type list, and signature verification.
+
+The CLI has no `webhooks` command group. Manage subscriptions through the HTTP API:
+
+```bash
+# Register a subscription (the response shows the signing secret ONCE — store it)
+curl -X POST "$HAIL_API_URL/webhooks" \
+  -H "Authorization: Bearer $HAIL_API_KEY" \
+  -d '{"target_url":"https://example.com/hooks/hail","event_types":["email.received","sms.received"]}'
+
+# List subscriptions
+curl "$HAIL_API_URL/webhooks" -H "Authorization: Bearer $HAIL_API_KEY"
+
+# Delivery attempts for one subscription
+curl "$HAIL_API_URL/webhooks/<sub-id>/deliveries" -H "Authorization: Bearer $HAIL_API_KEY"
+
+# Replay one delivery
+curl -X POST "$HAIL_API_URL/webhooks/<sub-id>/deliveries/<delivery-id>/redeliver" \
+  -H "Authorization: Bearer $HAIL_API_KEY"
+```
+
+Other endpoints: `PATCH /webhooks/{id}` (update URL, events, or status), `DELETE /webhooks/{id}`, and `POST /webhooks/{id}/rotate-secret`. Event types cover email, SMS, and call events — the canonical list is `WebhookEventType` in [`core/hailhq/core/schemas.py`](../core/hailhq/core/schemas.py).
+
+## Auth and utilities
+
+```bash
+hail login             # browser auth; saves an API key to ~/.hail/credentials.json
+hail auth token        # print the bare API key (for scripting)
+hail auth logout       # remove the local credentials file
+hail mcp endpoint      # print the MCP server's Streamable HTTP URL
+hail completion zsh    # shell completion script
+hail version
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-For the full operational runbook (releases, deployment, DB switching, all the gotchas), see [Operations](./operations.md). This page covers the contribution flow only.
+For the full operational runbook (releases, deployment, DB switching, all the known problems), refer to [Operations](./operations.md). This page covers the contribution flow only.
 
 ## Setup
 
@@ -14,7 +14,7 @@ docker compose -f docker-compose.yml -f docker-compose.local.yml up postgres min
                                   # just the data services for host-side dev
 ```
 
-`pnpm install` wires up the git pre-commit hook that runs `ruff`/`black`/`gofmt`/`prettier` on staged files.
+`pnpm install` installs the git pre-commit hook. The hook runs `ruff`/`black`/`gofmt`/`prettier` on staged files.
 
 ## Dev loops
 
@@ -30,7 +30,7 @@ Full stack in Docker:
 
 ## Database migrations
 
-Schema lives in [`api/migrations/versions/`](https://github.com/hail-hq/hail/tree/main/api/migrations/versions). Alembic config in [`api/alembic.ini`](https://github.com/hail-hq/hail/blob/main/api/alembic.ini); `DATABASE_URL` overrides the config default.
+The schema lives in [`api/migrations/versions/`](https://github.com/hail-hq/hail/tree/main/api/migrations/versions). The Alembic config is in [`api/alembic.ini`](https://github.com/hail-hq/hail/blob/main/api/alembic.ini); `DATABASE_URL` overrides the config default.
 
 ```bash
 cd api
@@ -39,11 +39,11 @@ uv run alembic revision -m "add foo"   # create a new revision (hand-edit the SQ
 uv run alembic downgrade -1       # revert the last revision
 ```
 
-Migrations are hand-written raw SQL for v1 (no ORM models yet). When SQLAlchemy models land, switch to `--autogenerate`.
+Migrations are hand-written raw SQL for v1 (no ORM models yet). When SQLAlchemy models are released, switch to `--autogenerate`.
 
 ## Regenerating openapi.yaml
 
-After changing API routes, dump the spec:
+After you change API routes, dump the spec:
 
 ```bash
 curl -s http://localhost:8080/openapi.json \
@@ -53,12 +53,12 @@ curl -s http://localhost:8080/openapi.json \
 
 The Go CLI codegens its client from this file, so commit the update in the same PR as the route change.
 
-Do not hand-edit `openapi/openapi.yaml` — CI regenerates it from the live app
-and compares (see `.github/workflows/openapi-check.yml`), so any manual change
-that the app does not also produce fails as "stale". A status raised via
-`raise HTTPException(...)` will **not** appear in the spec unless the route
-decorator declares it (e.g. `responses={429: {...}}`); add it there, then
-regenerate.
+Do not hand-edit `openapi/openapi.yaml`. CI regenerates it from the live app
+and compares (refer to `.github/workflows/openapi-check.yml`). Any manual
+change that the app does not also produce fails as "stale". A status raised
+via `raise HTTPException(...)` does **not** appear in the spec unless the
+route decorator declares it (for example `responses={429: {...}}`). Add it
+there, then regenerate.
 
 ## Commit style
 
@@ -70,26 +70,26 @@ regenerate.
 
 ## Adding a provider
 
-New adapters live under `core/hailhq/core/providers/<channel>/<name>.py` and implement that channel's adapter interface. Add config keys to `.env.example` using the same provider-grouped format.
+Put new adapters under `core/hailhq/core/providers/<channel>/<name>.py`. Each adapter implements that channel's adapter interface. Add config keys to `.env.example` in the same provider-grouped format.
 
 ## Model costs contributions
 
-Public AI model costs live in [`costs/`](https://github.com/hail-hq/hail/tree/main/costs) under CC-BY-4.0. JSON files at the top of that directory are the source of truth and are validated against schemas in `costs/schema/` on every PR.
+Public AI model costs live in [`costs/`](https://github.com/hail-hq/hail/tree/main/costs) under CC-BY-4.0. The JSON files at the top of that directory are the source of truth. CI validates them against the schemas in `costs/schema/` on every PR.
 
 To update a price:
 
-1. Edit `costs/<category>.json` (e.g. `costs/llm.json`).
-2. Bump `last_verified` to today (`YYYY-MM-DD`) and set `verified_by` to your GitHub handle.
+1. Edit `costs/<category>.json` (for example `costs/llm.json`).
+2. Set `last_verified` to today (`YYYY-MM-DD`). Set `verified_by` to your GitHub handle.
 3. Update `source_url` if it has changed.
-4. Run `pnpm costs:validate` locally before pushing.
+4. Run `pnpm costs:validate` locally before you push.
 
-A weekly cron opens a tracking issue listing rows older than 30 days — see [`costs-stale.yml`](https://github.com/hail-hq/hail/blob/main/.github/workflows/costs-stale.yml).
+A weekly cron opens a tracking issue that lists rows older than 30 days — refer to [`costs-stale.yml`](https://github.com/hail-hq/hail/blob/main/.github/workflows/costs-stale.yml).
 
-## What we won't merge (v1)
+## What we will not merge (v1)
 
 - Code that hard-codes a provider in `api/` or `voicebot/` — route through `core/`.
 - New env vars missing from `.env.example`.
 - Features without a milestone in README.
 - Web UI code (no dashboards in v1).
-- Docs that paraphrase the OpenAPI spec or MCP tool schemas instead of linking the canonical source.
+- Docs that paraphrase the OpenAPI spec or MCP tool schemas instead of a link to the canonical source.
 - Non-GFM Markdown in docs.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,22 +1,22 @@
 # Operations runbook
 
-Single source of truth for how to develop, deploy, migrate, and release Hail. If you're an AI agent picking up the codebase, **read this first** alongside `CLAUDE.md`.
+This document is the single source of truth for how to develop, deploy, migrate, and release Hail. If you are an AI agent that starts work on this codebase, **read this document first** together with `CLAUDE.md`.
 
 ## Quick reference
 
-| task                           | command                                                                                                                         |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| Bring up stack (bundled DB)    | `docker compose -f docker-compose.yml -f docker-compose.local.yml up -d`                                                        |
-| Bring up stack (managed DB)    | `docker compose up -d`                                                                                                          |
-| Bring up stack (prod VM)       | `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d` — pulls images from GHCR; see `docs/setup/vm-deploy.md` |
-| Tail one service               | `docker compose logs -f <api\|voicebot\|mcp\|postgres>`                                                                         |
-| Run all tests                  | `cd <core\|api\|voicebot\|mcp\|sdk> && uv run pytest` (per suite, **from each dir**)                                            |
-| Lint                           | `uvx ruff check .` then `uvx black --check .` (repo root)                                                                       |
-| Apply DB migrations            | `docker compose run --rm api alembic upgrade head`                                                                              |
-| Regenerate OpenAPI + Go client | see _Development → Regenerating OpenAPI_ below                                                                                  |
-| Publish SDK                    | tag `sdk-v<X.Y.Z>` and push (fires `release-sdk.yml`)                                                                           |
-| Publish CLI                    | tag `cli-v<X.Y.Z>` and push (fires `release-cli.yml`)                                                                           |
-| Cut umbrella release           | tag `v<X.Y.Z>` and push (no workflow; just a marker)                                                                            |
+| task                           | command                                                                                                                              |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Bring up stack (bundled DB)    | `docker compose -f docker-compose.yml -f docker-compose.local.yml up -d`                                                             |
+| Bring up stack (managed DB)    | `docker compose up -d`                                                                                                               |
+| Bring up stack (prod VM)       | `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d` — pulls images from GHCR; refer to `docs/setup/vm-deploy.md` |
+| Tail one service               | `docker compose logs -f <api\|voicebot\|mcp\|postgres>`                                                                              |
+| Run all tests                  | `cd <core\|api\|voicebot\|mcp\|sdk> && uv run pytest` (per suite, **from each dir**)                                                 |
+| Lint                           | `uvx ruff check .` then `uvx black --check .` (repo root)                                                                            |
+| Apply DB migrations            | `docker compose run --rm api alembic upgrade head`                                                                                   |
+| Regenerate OpenAPI + Go client | refer to _Development → Regenerating OpenAPI_ below                                                                                  |
+| Publish SDK                    | tag `sdk-v<X.Y.Z>` and push (fires `release-sdk.yml`)                                                                                |
+| Publish CLI                    | tag `cli-v<X.Y.Z>` and push (fires `release-cli.yml`)                                                                                |
+| Cut umbrella release           | tag `v<X.Y.Z>` and push (no workflow; just a marker)                                                                                 |
 
 ## Local development
 
@@ -41,11 +41,11 @@ cd mcp      && uv run uvicorn hailhq.mcp.server:app --reload --port 8081
 cd cli      && go run . <args>
 ```
 
-Host-side dev needs `.env` exported into the shell first: `set -a; source .env; set +a` (Pydantic Settings reads `.env` into Settings attrs, but plugin SDKs read `os.environ` directly).
+Before host-side development, export `.env` into the shell: `set -a; source .env; set +a`. Pydantic Settings reads `.env` into Settings attributes, but plugin SDKs read `os.environ` directly.
 
 ### Tests
 
-CI runs each suite from its own directory — match that locally:
+CI runs each suite from its own directory. Match that locally:
 
 ```bash
 cd core     && uv run pytest -v
@@ -56,11 +56,11 @@ cd sdk      && uv run pytest -v
 cd cli      && go test ./... && go vet ./...
 ```
 
-Python tests use **testcontainers/postgres** locally (auto-spins a Postgres container) or the `DATABASE_URL` env var when set (CI's path).
+Python tests use **testcontainers/postgres** locally (this starts a Postgres container automatically). When the `DATABASE_URL` env var is set, the tests use it instead (this is the CI path).
 
 ### Lint + format
 
-Pre-commit runs `ruff check --fix`, `black`, `gofmt -w`, and `prettier --write` on staged files via husky + lint-staged. Manually:
+Pre-commit runs `ruff check --fix`, `black`, `gofmt -w`, and `prettier --write` on staged files via husky + lint-staged. To run the checks manually:
 
 ```bash
 uvx ruff check .            # at repo root
@@ -88,11 +88,11 @@ Commit `openapi/openapi.yaml` and `cli/internal/client/client.gen.go` together w
 
 1. Add the field to `core/hailhq/core/config.py` `Settings` class.
 2. Add the env line to `.env.example` under the right provider section (provider-grouped convention).
-3. If the value is consumed by code, reference `settings.<field>`. If it's consumed implicitly by a LiveKit plugin reading `os.environ`, the Settings declaration is **documentation only** — the runtime path is `docker compose env_file: .env` exporting it to the container.
+3. If code consumes the value, reference `settings.<field>`. If a LiveKit plugin consumes the value implicitly through `os.environ`, the Settings declaration is **documentation only**. In that case, the runtime path is `docker compose env_file: .env`, which exports the value to the container.
 
 ### Adding a new provider adapter
 
-New adapters live under `core/hailhq/core/providers/<channel>/<name>.py` and implement that channel's adapter interface (e.g., `VoiceProvider` in `providers/voice/base.py`). `api/` and `voicebot/` must **not** import provider SDKs directly — go through `core`.
+Put new adapters under `core/hailhq/core/providers/<channel>/<name>.py`. Each adapter implements the adapter interface of its channel (for example, `VoiceProvider` in `providers/voice/base.py`). `api/` and `voicebot/` must **not** import provider SDKs directly. Go through `core`.
 
 ## Deployment (self-host)
 
@@ -102,23 +102,23 @@ New adapters live under `core/hailhq/core/providers/<channel>/<name>.py` and imp
 - **LiveKit Cloud**: project + URL + API key + secret + an outbound SIP trunk (`LIVEKIT_SIP_OUTBOUND_TRUNK_ID`) + an inbound trunk (`LIVEKIT_SIP_INBOUND_TRUNK_ID`, reserved for v1.1).
 - **Deepgram** (STT): API key.
 - **Cartesia** (primary TTS): API key + a voice ID from the Cartesia voice library.
-- **ElevenLabs** (fallback TTS, optional): API key + a voice ID. Used automatically when Cartesia fails, if `ELEVEN_API_KEY` is set.
-- **At least one LLM provider**: OpenAI / Gemini / Anthropic API key. The voicebot's mode-A FallbackAdapter chains all three; mode-B uses a caller-provided OpenAI-compatible endpoint per call.
+- **ElevenLabs** (fallback TTS, optional): API key + a voice ID. If `ELEVEN_API_KEY` is set, the system uses it automatically when Cartesia fails.
+- **At least one LLM provider**: OpenAI / Gemini / Anthropic API key. The voicebot's mode-A FallbackAdapter chains all three. Mode-B uses a caller-provided OpenAI-compatible endpoint for each call.
 
-Detailed setup walkthroughs: `docs/setup/twilio.md`, `docs/setup/livekit-cloud.md`, `docs/setup/mcp.md`. For running the whole stack on a single Ubuntu VM with HTTPS + auto-deploy from `main`, see `docs/setup/vm-deploy.md`.
+For detailed setup walkthroughs, refer to `docs/setup/twilio.md`, `docs/setup/livekit-cloud.md`, and `docs/setup/mcp.md`. To run the whole stack on a single Ubuntu VM with HTTPS + auto-deploy from `main`, refer to `docs/setup/vm-deploy.md`.
 
 ### Authentication
 
-Self-host and managed cloud share the same FastAPI binary, but auth is decided implicitly by what's in the env:
+Self-host and managed cloud share the same FastAPI binary, but the contents of the env decide the auth mode implicitly:
 
-| Mode                    | Trigger                                                                | What hail/api checks                                                                                                                                        |
-| ----------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Self-host** (default) | Operator sets `HAIL_API_KEY` in `.env`                                 | Constant-time compare against the env var. All shared-key requests resolve to the sentinel `organization_id = "self-hosted"` — no DB row, no member lookup. |
-| **Managed cloud**       | The auth backend's `apikey` table is migrated into the shared Postgres | Hashes the bearer with `base64url(sha256())` and looks it up; resolves the org via `members.user_id = api_keys.reference_id → members.organization_id`.     |
+| Mode                    | Trigger                                                                | What hail/api checks                                                                                                                                                                              |
+| ----------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Self-host** (default) | Operator sets `HAIL_API_KEY` in `.env`                                 | Constant-time compare against the env var. All shared-key requests resolve to the sentinel `organization_id = 00000000-0000-0000-0000-000000000000` (the nil UUID) — no DB row, no member lookup. |
+| **Managed cloud**       | The auth backend's `apikey` table is migrated into the shared Postgres | Hashes the bearer with `base64url(sha256())` and looks it up; resolves the org via `members.user_id = api_keys.reference_id → members.organization_id`.                                           |
 
-Both can be active simultaneously — if `HAIL_API_KEY` is set in managed cloud, it acts as a master/admin override that always works.
+Both modes can be active at the same time. If `HAIL_API_KEY` is set in managed cloud, it operates as a master/admin override that always works.
 
-A managed-cloud user with no `member` row gets a **403 "user not provisioned"** rather than a fabricated org — provisioning is the website's responsibility (via its `user.create.after` hook).
+A managed-cloud user with no `member` row gets a **403 "user not provisioned"**, not a fabricated org. Provisioning is the responsibility of the website (through its `user.create.after` hook).
 
 #### Self-host: first-run setup
 
@@ -130,28 +130,28 @@ echo "HAIL_API_KEY=$HAIL_API_KEY" >> hail/.env
 
 # 2) Add a phone number bound to the self-host sentinel org id.
 export TWILIO_E164='+1XXXXXXXXXX' TWILIO_PN_SID='PNxxxxxxxxxxxxxxxx'
-docker compose exec postgres psql -U hail -d hail -c "INSERT INTO phone_numbers (organization_id, e164, country_code, number_type, capabilities, provider, provider_resource_id, provisioning_state, acquired_at) VALUES ('self-hosted', '${TWILIO_E164}', 'US', 'local', ARRAY['voice','sms'], 'twilio', '${TWILIO_PN_SID}', 'active', now());"
+docker compose exec postgres psql -U hail -d hail -c "INSERT INTO phone_numbers (organization_id, e164, country_code, number_type, capabilities, provider, provider_resource_id, provisioning_state, acquired_at) VALUES ('00000000-0000-0000-0000-000000000000', '${TWILIO_E164}', 'US', 'local', ARRAY['voice','sms'], 'twilio', '${TWILIO_PN_SID}', 'active', now());"
 ```
 
-Save the value of `HAIL_API_KEY` — there's no recovery path. Then `export HAIL_API_KEY=…` in the shell that runs `hail`, or pass it via `--api-key`.
+There is no recovery path for a lost key, so save the value of `HAIL_API_KEY`. Then run `export HAIL_API_KEY=…` in the shell that runs `hail`, or pass the key with `--api-key`.
 
-> **`hail login` is managed-cloud only.** It runs the auth backend's device flow against `hail-website` and writes the resulting `hl_live_*` key to `~/.hail/credentials.json`. In self-host there's no website to authorize against — set `HAIL_API_KEY` directly and you're done.
+> **`hail login` is managed-cloud only.** It runs the auth backend's device flow against `hail-website` and writes the resulting `hl_live_*` key to `~/.hail/credentials.json`. In self-host, there is no website to authorize against. Set `HAIL_API_KEY` directly, and you are done.
 
 #### `hail auth` subcommands
 
 For interactive sessions on a managed Hail deployment:
 
-- `hail login` — device-authorization flow, persists `~/.hail/credentials.json`.
-- `hail auth logout` — delete the local credentials file (idempotent).
-- `hail auth token` — print the bare API key; use in scripts as
+- `hail login` — runs the device-authorization flow and persists `~/.hail/credentials.json`.
+- `hail auth logout` — deletes the local credentials file (idempotent).
+- `hail auth token` — prints the bare API key. Use it in scripts as
   `export HAIL_API_KEY=$(hail auth token)`.
 
-Self-hosters typically skip the device flow and set `HAIL_API_KEY`
-directly per the bootstrap section above.
+Self-hosters usually skip the device flow and set `HAIL_API_KEY`
+directly, as the bootstrap section above shows.
 
 #### Phone number pool
 
-Pool numbers are unowned `phone_numbers` rows (`is_pool=TRUE`, `organization_id IS NULL`) that any org without its own active number falls back to on outbound calls. They're claimed atomically (`SELECT … FOR UPDATE SKIP LOCKED`, randomized order to spread carrier wear), bound to one call at a time via `reserved_call_id`, and released on call end. Implementation: `core/hailhq/core/pool.py`; sweeper backstop window is `HAIL_POOL_RELEASE_GRACE_SECONDS`.
+Pool numbers are unowned `phone_numbers` rows (`is_pool=TRUE`, `organization_id IS NULL`). An org without its own active number falls back to them on outbound calls. The claim is atomic (`SELECT … FOR UPDATE SKIP LOCKED`, in randomized order to spread carrier wear). Each number binds to one call at a time through `reserved_call_id`; the system releases it when the call ends. Implementation: `core/hailhq/core/pool.py`. The sweeper backstop window is `HAIL_POOL_RELEASE_GRACE_SECONDS`.
 
 Add a Twilio number to the pool with `organization_id` NULL and `is_pool=TRUE` (the CHECK constraint enforces the pairing):
 
@@ -159,13 +159,13 @@ Add a Twilio number to the pool with `organization_id` NULL and `is_pool=TRUE` (
 psql "$DATABASE_URL" -c "INSERT INTO phone_numbers (organization_id, e164, country_code, number_type, capabilities, provider, provider_resource_id, provisioning_state, is_pool, acquired_at) VALUES (NULL, '+1XXXXXXXXXX', 'US', 'local', ARRAY['voice','sms'], 'twilio', 'PNxxxxxxxxxxxxxxxx', 'active', TRUE, now());"
 ```
 
-The number must be attached to the same Twilio SIP trunk you wired in [Twilio setup](setup/twilio.md) — there's no per-number trunk routing. To grow the pool, repeat the INSERT with a different `e164` / `PN_SID`. To quarantine a misbehaving pool number without deleting it, `UPDATE phone_numbers SET provisioning_state='failed' WHERE e164=...` — the claim query skips non-`active` rows.
+Attach the number to the same Twilio SIP trunk that you wired in [Twilio setup](setup/twilio.md). There is no per-number trunk routing. To grow the pool, repeat the INSERT with a different `e164` / `PN_SID`. To quarantine a bad pool number without deletion, run `UPDATE phone_numbers SET provisioning_state='failed' WHERE e164=...`. The claim query skips non-`active` rows.
 
-Callers can't address a pool number explicitly with `POST /calls`'s `from` field; it's shared, so a caller naming one would cross tenants. The fallback only fires when an org has zero active numbers of its own.
+Callers cannot address a pool number explicitly with the `from` field of `POST /calls`. The number is shared, so a caller that names one would cross tenants. The fallback fires only when an org has zero active numbers of its own.
 
 #### Managed cloud
 
-Run `hail login`. The CLI opens `/device` on the website, you approve, and it exchanges the device-flow session for a long-lived `hl_live_*` key minted by the auth backend into the `apikey` table. `hail/api` reads the same table — keys minted in the console work everywhere (CLI, MCP, direct API calls).
+Run `hail login`. The CLI opens `/device` on the website. You approve, and the CLI exchanges the device-flow session for a long-lived `hl_live_*` key, which the auth backend mints into the `apikey` table. `hail/api` reads the same table, so keys minted in the console work everywhere (CLI, MCP, direct API calls).
 
 ### MCP modes
 
@@ -176,9 +176,9 @@ The MCP service (`hail/mcp`) picks one of two modes at boot from env:
 | **oauth-rs**   | `HAIL_AUTH_URL` + `MCP_RESOURCE_URL` set, `HAIL_API_KEY` empty | FastMCP rejects unauth requests with `401 WWW-Authenticate: Bearer resource_metadata=…`; tools forward each request's JWT to the API; `.well-known/oauth-protected-resource` is published. |
 | **static-key** | `HAIL_API_KEY` set, `HAIL_AUTH_URL` empty                      | No inbound auth; tools use the singleton `HailClient(api_key=HAIL_API_KEY)`; no protected-resource route.                                                                                  |
 
-Both set → boot fails with `ambiguous MCP auth config`. Neither set → boot fails with `MCP auth not configured`. The mode is decided once and cannot change without restart.
+If both are set, boot fails with `ambiguous MCP auth config`. If neither is set, boot fails with `MCP auth not configured`. The service decides the mode once; a restart is necessary to change it.
 
-The MCP service does not validate JWT signatures — `hail/api` is the single source of JWT-validation truth (`HAIL_AUTH_URL`, `HAIL_AUTH_AUDIENCES`). MCP forwards the bearer onto the outbound call; the API validates and resolves the org.
+The MCP service does not validate JWT signatures. `hail/api` is the single source of JWT-validation truth (`HAIL_AUTH_URL`, `HAIL_AUTH_AUDIENCES`). MCP forwards the bearer on the outbound call. The API validates the token and resolves the org.
 
 ## Database migrations
 
@@ -197,28 +197,30 @@ cd api && uv run alembic revision -m "add foo column"
 cd api && uv run alembic downgrade -1
 ```
 
-Migrations are hand-written raw SQL for v1 (no SQLAlchemy `target_metadata` wired into `env.py`). Switch to `--autogenerate` when models become the source of truth.
+For v1, write migrations as raw SQL by hand (`env.py` has no SQLAlchemy `target_metadata` wired in). Switch to `--autogenerate` when models become the source of truth.
 
 ### Migration discipline
 
-**The deploy workflow runs `alembic upgrade head` against prod on every push to `main`** — there is no human review gate between merging a migration and it executing. Three rules keep this safe; one is enforced by the workflow, two depend on you:
+**The deploy workflow runs `alembic upgrade head` against prod on every push to `main`.** There is no human review gate between the merge of a migration and its execution. Three rules keep this safe. The workflow enforces one; the other two depend on you:
 
-1. **`api/migrations/env.py` caps statement runtime at 120s and lock-acquisition at 5s** via `SET LOCAL statement_timeout` / `SET LOCAL lock_timeout`, issued inside the migration transaction so they apply to every statement the migration runs. `SET LOCAL` (rather than `PGOPTIONS` or session-level `SET`) is deliberate — Neon's `-pooler` endpoint and other PgBouncer transaction-pooled connections reject the libpq startup option and reset session state between transactions; the per-transaction form is the only one that works on all of pooled / unpooled / direct.
+1. **`api/migrations/env.py` caps statement runtime at 120s and lock-acquisition at 5s** via `SET LOCAL statement_timeout` / `SET LOCAL lock_timeout`. It issues them inside the migration transaction, so they apply to every statement that the migration runs. The choice of `SET LOCAL` (not `PGOPTIONS` or session-level `SET`) is deliberate. Neon's `-pooler` endpoint and other PgBouncer transaction-pooled connections reject the libpq startup option and reset session state between transactions. The per-transaction form is the only one that works on all of pooled / unpooled / direct.
 
-   The deploy log also prints `alembic current` and `alembic upgrade head --sql` before applying, so a problem migration is visible in CI output before it touches data.
+   The deploy log also prints `alembic current` and `alembic upgrade head --sql` before it applies the migration. Thus a problem migration is visible in CI output before it touches data.
 
-   If a legitimate migration genuinely needs longer (a backfill, `CREATE INDEX CONCURRENTLY`), bypass the guard by issuing its own `SET LOCAL statement_timeout = '<bigger>'` at the top of the migration body — explicit per-migration, not a global cap raise. Bigger caps on every migration mean a runaway one chews through more wall-clock before aborting.
+   If a legitimate migration needs more time (a backfill, `CREATE INDEX CONCURRENTLY`), bypass the guard: put its own `SET LOCAL statement_timeout = '<bigger>'` at the top of the migration body. Make the change explicit for that migration; do not raise the global cap. Bigger caps on every migration let a runaway migration use more wall-clock time before it aborts.
 
-2. **All destructive shape changes split into expand → backfill → contract across separate releases.** A column drop, a type narrowing, a `NOT NULL` on existing data — none of these can land in the same release as the code that depends on the new shape, because the old containers are still running when the migration starts. Concretely:
+2. **Split all destructive shape changes into expand → backfill → contract across separate releases.** A column drop, a type narrowing, or a `NOT NULL` on existing data must not go in the same release as the code that depends on the new shape. The old containers still run when the migration starts. For example:
 
    | bad: one release                                | good: three releases                                                                                                            |
    | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
    | drop `phone_numbers.legacy_field` + remove code | release 1: stop writing `legacy_field` (still readable) → release 2: backfill / verify → release 3: `ALTER TABLE … DROP COLUMN` |
    | rename `calls.requested_at` → `calls.queued_at` | release 1: add new column, dual-write → release 2: backfill, switch reads → release 3: drop old column                          |
 
-3. **Never edit, renumber, or remove a migration that has been applied to prod.** Author a new revision instead — treat any revision at or below the previous deploy's `alembic current` as immutable. Renumbering or history-rewriting an already-deployed migration is the same footgun as editing one: prod's `alembic_version` still holds the old revision id, so the next `alembic upgrade head` either can't locate it (`Can't locate revision '<id>'`) or silently skips the real DDL and collides downstream (`relation "…" already exists`). CI never catches this because test fixtures build the schema via `Base.metadata.create_all`, not alembic. Recovery is manual — apply whatever migrations genuinely never ran on prod, then reconcile the pointer with `alembic stamp <head>` (or `UPDATE alembic_version`) once the schema matches. See the Footguns table.
+3. **Never edit, renumber, or remove a migration that prod has applied.** Author a new revision instead. Treat each revision at or below the previous deploy's `alembic current` as immutable. A renumber or history rewrite of a deployed migration is the same footgun as an edit. Prod's `alembic_version` still holds the old revision id. The next `alembic upgrade head` then cannot locate it (`Can't locate revision '<id>'`), or it silently skips the real DDL and collides downstream (`relation "…" already exists`).
 
-The expand/contract rule is the one that the workflow cannot enforce. If you break it, auto-deploy ships the foot-gun and the rollback is "revert the code, write a new migration to restore the column, re-deploy" — which is hours of incident, not minutes.
+   CI never catches this, because test fixtures build the schema via `Base.metadata.create_all`, not alembic. Recovery is manual. Apply the migrations that never ran on prod, then reconcile the pointer with `alembic stamp <head>` (or `UPDATE alembic_version`) once the schema matches. Refer to the Footguns table.
+
+The expand/contract rule is the one that the workflow cannot enforce. If you break it, auto-deploy releases the footgun. The rollback is then "revert the code, write a new migration to restore the column, re-deploy" — hours of incident, not minutes.
 
 ### Cross-migration table ownership
 
@@ -229,26 +231,26 @@ Two services migrate the same Postgres database independently:
 | **hail-website** | `pnpm dlx @better-auth/cli migrate` (introspects `lib/auth.ts`) | `users`, `accounts`, `sessions`, `verifications`, `device_codes`, `api_keys`, `organizations`, `members`, `invitations`      |
 | **hail/api**     | alembic                                                         | `account_credits`, `usage_events`, `phone_numbers`, `conversations`, `calls`, `call_events`, `idempotency_keys`, `audit_log` |
 
-The website's schema source of truth is `lib/auth.ts`. After any change to that file, run `pnpm dlx @better-auth/cli generate -y` to emit the resulting SQL into `better-auth_migrations/` and commit it (audit trail), then `pnpm dlx @better-auth/cli migrate -y` to apply against the target DB. Both subcommands introspect the auth config; `generate` writes the SQL file, `migrate` runs the same diff against the DB.
+The schema source of truth for the website is `lib/auth.ts`. After each change to that file, run `pnpm dlx @better-auth/cli generate -y` to emit the resulting SQL into `better-auth_migrations/`, and commit it (audit trail). Then run `pnpm dlx @better-auth/cli migrate -y` to apply the diff against the target DB. Both subcommands introspect the auth config. `generate` writes the SQL file; `migrate` runs the same diff against the DB.
 
 Columns in hail/api-owned tables that reference a website-owned table — `organization_id` everywhere, `audit_log.api_key_id` — carry **no foreign-key constraint**. This is deliberate.
 
-**Why no FK:** the CLI regenerates the website schema from a TypeScript config on every relevant version bump. If alembic held a hard FK into `organizations(id)`, any rename or shape change on the website side would either need a coordinated alembic migration in the same release, or it would break the next `alembic upgrade head`. Cross-tool referential integrity is a coordination tax we don't want to pay on every dependency bump.
+**Why no FK:** the CLI regenerates the website schema from a TypeScript config on every relevant version bump. If alembic held a hard FK into `organizations(id)`, each rename or shape change on the website side would need a coordinated alembic migration in the same release, or it would break the next `alembic upgrade head`. Cross-tool referential integrity is a coordination tax we do not want to pay on every dependency bump.
 
 **What we trade off:**
 
-- No `ON DELETE CASCADE` from the auth side. Deleting an `organization` row in Postgres leaves orphaned rows in `account_credits`, `calls`, etc. v1 doesn't hard-delete orgs; if you start, write a sweep query or soft-delete.
-- No DB-level guarantee that `organization_id` points at a real row. The auth flow in `api/hailhq/api/deps.py` validates the org exists on every authenticated request, so application-layer integrity holds for the live path. Bulk inserts from migrations or fixtures need to mind it themselves.
+- No `ON DELETE CASCADE` from the auth side. If you delete an `organization` row in Postgres, orphaned rows stay in `account_credits`, `calls`, etc. v1 does not hard-delete orgs. If you start to do so, write a sweep query or a soft-delete.
+- No DB-level guarantee that `organization_id` points at a real row. The auth flow in `api/hailhq/api/deps.py` validates that the org exists on every authenticated request, so application-layer integrity holds for the live path. Bulk inserts from migrations or fixtures must keep this integrity themselves.
 
-**When to break the rule:** if you add a new hail/api-owned table that joins to another hail/api-owned table (e.g., `call_events.call_id → calls.id`), keep the FK. Both ends are alembic-owned, so the constraint is safe.
+**When to break the rule:** if you add a new hail/api-owned table that joins to another hail/api-owned table (for example, `call_events.call_id → calls.id`), keep the FK. Both ends are alembic-owned, so the constraint is safe.
 
 ### Shared-key sentinel
 
-Shared-key (`HAIL_API_KEY`) requests resolve to `organization_id = 00000000-0000-0000-0000-000000000000` (the nil UUID) — a sentinel, not a real row. Nothing seeds it; nothing reads from `organizations` for that path. Self-host operators can attach `phone_numbers`, `account_credits`, etc. to the sentinel by passing the nil UUID as the org id directly (see _Self-host: first-run setup_ above for the phone-number example).
+Shared-key (`HAIL_API_KEY`) requests resolve to `organization_id = 00000000-0000-0000-0000-000000000000` (the nil UUID) — a sentinel, not a real row. Nothing seeds it; nothing reads from `organizations` for that path. Self-host operators can attach `phone_numbers`, `account_credits`, etc. to the sentinel. To do so, pass the nil UUID as the org id directly (refer to _Self-host: first-run setup_ above for the phone-number example).
 
 ### Switching the database
 
-Compose ships as two files. `docker-compose.yml` is the deployable base and assumes `DATABASE_URL` reaches a Postgres you bring. `docker-compose.local.yml` is a thin overlay that adds a bundled `postgres` container and merges a `depends_on: postgres` into `api` and `voicebot`. Pick a mode:
+Compose comes as two files. `docker-compose.yml` is the deployable base and assumes that `DATABASE_URL` reaches a Postgres you bring. `docker-compose.local.yml` is a thin overlay that adds a bundled `postgres` container and merges a `depends_on: postgres` into `api` and `voicebot`. Pick a mode:
 
 **Bundled local Postgres** — layer both files:
 
@@ -256,9 +258,9 @@ Compose ships as two files. `docker-compose.yml` is the deployable base and assu
 docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
 ```
 
-`.env` should keep the default `DATABASE_URL=postgresql://hail:hail@postgres:5432/hail` (the in-network compose hostname).
+`.env` must keep the default `DATABASE_URL=postgresql://hail:hail@postgres:5432/hail` (the in-network compose hostname).
 
-**Reset the bundled DB** (lose all data, fresh start):
+**Reset the bundled DB** (this removes all data for a fresh start):
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.local.yml down -v   # -v removes volumes
@@ -284,7 +286,7 @@ docker compose run --rm api alembic upgrade head
 docker compose up -d
 ```
 
-The migration `0001_initial.py` issues `CREATE EXTENSION IF NOT EXISTS pgcrypto;`. Hosted providers that gate extensions need `pgcrypto` allowed.
+The migration `0001_initial.py` issues `CREATE EXTENSION IF NOT EXISTS pgcrypto;`. If a hosted provider gates extensions, allow `pgcrypto` on it.
 
 ## Releases
 
@@ -296,7 +298,7 @@ Tag conventions:
 | `cli-v<X.Y.Z>` | `.github/workflows/release-cli.yml`      | GoReleaser → multi-arch binaries on GitHub Releases + Homebrew formula push to `hail-hq/homebrew-tap` |
 | `v<X.Y.Z>`     | nothing — no workflow keys off bare `v*` | umbrella marker for "this is the v0.1.0 commit"                                                       |
 
-Service images (`hail-api`, `hail-voicebot`, `hail-mcp`) are **not** published. Self-hosters build from source via `docker compose up`. Publishing them is on the v1.x list.
+Hail does **not** release the service images (`hail-api`, `hail-voicebot`, `hail-mcp`) as versioned artifacts. The deploy workflow (`.github/workflows/deploy.yml`) pushes `latest` and `sha-<commit>` tags to GHCR on each push to `main` — the production VM pulls these. Self-hosters build from source via `docker compose up`. Versioned image releases are on the v1.x list.
 
 ### Releasing the SDK (Python)
 
@@ -309,7 +311,7 @@ git push origin sdk-v0.2.0
 # 4. Watch https://github.com/hail-hq/hail/actions
 ```
 
-Pre-flight (one-time): a PyPI Trusted Publisher must be configured for `hail-sdk` pointing at `hail-hq/hail` repo + `release-sdk.yml` workflow. After the project exists on PyPI, promote the _Pending_ publisher to a normal one (PyPI web UI).
+Pre-flight (one-time): configure a PyPI Trusted Publisher for `hail-sdk` that points at the `hail-hq/hail` repo + the `release-sdk.yml` workflow. After the project exists on PyPI, promote the _Pending_ publisher to a normal one (PyPI web UI).
 
 ### Releasing the CLI (Go)
 
@@ -322,12 +324,12 @@ git push origin cli-v0.2.0
 brew update && brew upgrade hail-hq/tap/hail
 ```
 
-Required secret: `HOMEBREW_TAP_TOKEN` — a fine-grained PAT with **Contents: read+write** on `hail-hq/homebrew-tap`. Set under repo Settings → Secrets → Actions. Without it, the binary build + GitHub Release succeed but the formula push fails.
+Required secret: `HOMEBREW_TAP_TOKEN` — a fine-grained PAT with **Contents: read+write** on `hail-hq/homebrew-tap`. Set it under repo Settings → Secrets → Actions. Without it, the binary build + GitHub Release succeed, but the formula push fails.
 
-GoReleaser quirks worth knowing:
+GoReleaser quirks to know:
 
-- OSS GoReleaser doesn't have the Pro `monorepo:` block. The workflow strips the `cli-` prefix into `GORELEASER_CURRENT_TAG` / `GORELEASER_PREVIOUS_TAG` env vars and passes `--skip=validate` so GoReleaser doesn't reject the env-var-overridden tag (the manual `git rev-parse` and `git diff --exit-code HEAD` steps before GoReleaser preserve the validate checks that _do_ matter).
-- Snapshot version template is the literal `0.0.0-snapshot-{{ .ShortCommit }}` (not `incpatch`) because the repo carries non-semver tags like `sdk-v0.0.1` that confuse the parser.
+- OSS GoReleaser does not have the Pro `monorepo:` block. The workflow strips the `cli-` prefix into the `GORELEASER_CURRENT_TAG` / `GORELEASER_PREVIOUS_TAG` env vars. It also passes `--skip=validate`, so GoReleaser does not reject the env-var-overridden tag. The manual `git rev-parse` and `git diff --exit-code HEAD` steps before GoReleaser keep the validate checks that _do_ matter.
+- The snapshot version template is the literal `0.0.0-snapshot-{{ .ShortCommit }}` (not `incpatch`), because the repo carries non-semver tags like `sdk-v0.0.1` that confuse the parser.
 
 ### Cutting an umbrella release
 
@@ -345,35 +347,36 @@ gh release create v0.2.0 --repo hail-hq/hail --notes-file CHANGELOG.md
 ## Conventions
 
 - **Commits**: [Conventional Commits](https://www.conventionalcommits.org). `feat(scope): …`, `fix(scope): …`, `chore: …`, `docs(scope): …`, etc.
-- **Markdown**: GitHub-flavored only. Binary task-list states `[ ]` / `[x]`; non-GFM `[~]` / `[-]` are not allowed.
+- **Markdown**: GitHub-flavored only. Use the binary task-list states `[ ]` / `[x]`; do not use the non-GFM `[~]` / `[-]`.
 - **Python namespaces**:
   - Internal monorepo: `hailhq.*` (PEP 420 implicit namespace; no `hailhq/__init__.py` at the namespace root).
   - External SDK: `hail` — published as `hail-sdk` on PyPI, imports as `import hail`. Standalone — does **not** depend on any `hailhq.*` package.
-- **Provider model IDs**: live only in `.env.example`; `Settings` fields default to empty strings. Editing `Settings.<provider>_model = "literal"` is wrong.
+- **Provider model IDs**: live only in `.env.example`; `Settings` fields default to empty strings. Do not set `Settings.<provider>_model = "literal"` — that is wrong.
 - **Tag prefix grammar**: `<package>-v<semver>` for component releases (`sdk-v…`, `cli-v…`); bare `v<semver>` for the umbrella.
 - **No Opero references** in any committed file.
 
 ## Footguns (every one of these has bitten us)
 
-| symptom                                                                                                     | root cause + fix                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `voicebot` container exits showing the typer help menu                                                      | CMD missing the `start` subcommand. Fixed in the Dockerfile; if you fork it, keep `["python", "-m", "hailhq.voicebot.main", "start"]`.                                                                                                                                                                                                                                                                                                             |
-| `ModuleNotFoundError: No module named 'hailhq'` after a Docker build                                        | Hatchling wheel config used `packages = ["hailhq/<service>"]` — strips the `hailhq/` prefix. Must be `packages = ["hailhq"]`.                                                                                                                                                                                                                                                                                                                      |
-| `exec /opt/venv/bin/uvicorn: no such file or directory`                                                     | Renaming `/app/.venv` → `/opt/venv` between builder and runtime breaks shebangs. Keep the same path in both stages (we use `/app/.venv`).                                                                                                                                                                                                                                                                                                          |
-| `RuntimeError: no running event loop` from `aiohttp.ClientSession()`                                        | A FastAPI dep that constructs LiveKit/aiohttp must be `async def`. Sync deps run in a threadpool worker thread with no loop.                                                                                                                                                                                                                                                                                                                       |
-| `google.auth.exceptions.DefaultCredentialsError: File  was not found.`                                      | `GOOGLE_GENAI_USE_VERTEXAI=true` with empty `GOOGLE_APPLICATION_CREDENTIALS`. Default is `false`; opt into Vertex by flipping it AND providing creds.                                                                                                                                                                                                                                                                                              |
-| `failed to parse tag 'cli-v0.1.0' as semver` from GoReleaser                                                | OSS GoReleaser doesn't handle tag prefixes. The workflow's `Compute GoReleaser current/previous tags` step + `--skip=validate` flag handle it; don't remove either.                                                                                                                                                                                                                                                                                |
-| `hailhq-core` references a workspace member, but is not one                                                 | Docker build context lacks the repo-root pyproject. The Dockerfile writes a minimal `/app/pyproject.toml` (workspace stub) inline before `uv sync`.                                                                                                                                                                                                                                                                                                |
-| `pytest` from repo root fails with `ImportPathMismatchError`                                                | Run each suite from its own directory. CI does this; replicate locally.                                                                                                                                                                                                                                                                                                                                                                            |
-| First `pip install hail-sdk` from a venv with `hailhq.*` already installed shadows imports                  | The SDK is standalone by design. If you mix it with internal packages in the same venv, the `hail` package wins for `import hail` (intended); don't co-install for production.                                                                                                                                                                                                                                                                     |
-| Deploy fails at `alembic upgrade head` with `Can't locate revision 'NNNN'` or `relation "…" already exists` | A migration already applied to prod was renumbered or removed by a branch reshuffle / history rewrite, so prod's `alembic_version` diverges from the code (see Migration discipline rule 3). Recover by hand: apply only the migrations that genuinely never ran on prod, then `UPDATE alembic_version SET version_num='<head>'` (or `alembic stamp <head>`) once the schema matches — do **not** re-run `upgrade head`, it re-hits the collision. |
+| symptom                                                                                                     | root cause + fix                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `voicebot` container exits showing the typer help menu                                                      | The CMD lacks the `start` subcommand. The Dockerfile fixes this; if you fork it, keep `["python", "-m", "hailhq.voicebot.main", "start"]`.                                                                                                                                                                                                                                                                                               |
+| `ModuleNotFoundError: No module named 'hailhq'` after a Docker build                                        | Hatchling wheel config used `packages = ["hailhq/<service>"]` — strips the `hailhq/` prefix. Must be `packages = ["hailhq"]`.                                                                                                                                                                                                                                                                                                            |
+| `exec /opt/venv/bin/uvicorn: no such file or directory`                                                     | Renaming `/app/.venv` → `/opt/venv` between builder and runtime breaks shebangs. Keep the same path in both stages (we use `/app/.venv`).                                                                                                                                                                                                                                                                                                |
+| `RuntimeError: no running event loop` from `aiohttp.ClientSession()`                                        | A FastAPI dep that constructs LiveKit/aiohttp must be `async def`. Sync deps run in a threadpool worker thread with no loop.                                                                                                                                                                                                                                                                                                             |
+| `google.auth.exceptions.DefaultCredentialsError: File  was not found.`                                      | `GOOGLE_GENAI_USE_VERTEXAI=true` with empty `GOOGLE_APPLICATION_CREDENTIALS`. Default is `false`; opt into Vertex by flipping it AND providing creds.                                                                                                                                                                                                                                                                                    |
+| `failed to parse tag 'cli-v0.1.0' as semver` from GoReleaser                                                | OSS GoReleaser does not handle tag prefixes. The workflow's `Compute GoReleaser current/previous tags` step + `--skip=validate` flag handle it; do not remove either.                                                                                                                                                                                                                                                                    |
+| `hailhq-core` references a workspace member, but is not one                                                 | Docker build context lacks the repo-root pyproject. The Dockerfile writes a minimal `/app/pyproject.toml` (workspace stub) inline before `uv sync`.                                                                                                                                                                                                                                                                                      |
+| `pytest` from repo root fails with `ImportPathMismatchError`                                                | Run each suite from its own directory. CI does this; replicate locally.                                                                                                                                                                                                                                                                                                                                                                  |
+| First `pip install hail-sdk` from a venv with `hailhq.*` already installed shadows imports                  | The SDK is standalone by design. If you mix it with internal packages in the same venv, the `hail` package wins for `import hail` (intended); do not co-install for production.                                                                                                                                                                                                                                                          |
+| Deploy fails at `alembic upgrade head` with `Can't locate revision 'NNNN'` or `relation "…" already exists` | A branch reshuffle / history rewrite renumbered or removed a migration that prod already applied, so prod's `alembic_version` diverges from the code (refer to Migration discipline rule 3). Recover by hand: apply only the migrations that never ran on prod, then `UPDATE alembic_version SET version_num='<head>'` (or `alembic stamp <head>`) once the schema matches — do **not** re-run `upgrade head`, it re-hits the collision. |
 
 ## Inbound email rollout
 
-End-to-end deployment of the inbound-email milestone (umbrella `v0.5.0`,
-`sdk-v0.3.0`, `cli-v0.5.0`). Five DB stages + infra + tag-driven
-component releases. Stage 1 needs a brief maintenance window (the table
-rename is not online-safe); everything else is online.
+This section records the end-to-end deployment of the inbound-email
+milestone (umbrella `v0.5.0`, `sdk-v0.3.0`, `cli-v0.5.0`). It covers
+five DB stages + infra + tag-driven component releases. Stage 1 needs
+a brief maintenance window (the table rename is not online-safe).
+Everything else is online.
 
 ### Full deployment order (copy-paste cheat-sheet)
 
@@ -440,20 +443,20 @@ dig MX mail.hail.so
 hail email list --direction inbound
 ```
 
-**Decoupling note.** Steps 1–6 can ship days ahead of steps 7–9; until
-the flag in step 6 flips, the system is outbound-only and the new CLI
-and SDK haven't gone public yet. If anything looks wrong after step 6,
-you can roll back by setting `HAIL_INBOUND_ENABLED=false` and
-restarting — no migration revert needed, no tag re-spin needed.
+**Decoupling note.** You can release steps 1–6 days before steps 7–9.
+Until the flag in step 6 flips, the system is outbound-only, and the
+new CLI and SDK are not yet public. If something looks wrong after
+step 6, roll back: set `HAIL_INBOUND_ENABLED=false` and restart. No
+migration revert is necessary; no tag re-spin is necessary.
 
 Detailed nuance per stage follows.
 
 ### Stage 1 — schema rename + new code (coordinated cutover, ~30s downtime)
 
 Migration `0006` renames `sender_domains` → `email_domains`. The new
-app code only references the new name, so the rename and the deploy
-have to land together. There's no incremental path that doesn't add
-view-shim complexity for marginal gain.
+app code references only the new name, so you must release the rename
+and the deploy together. Each incremental path adds view-shim
+complexity for marginal gain.
 
 ```bash
 # Take the API offline.
@@ -470,25 +473,26 @@ hail email domain list
 ```
 
 Rollback: `alembic downgrade 0005` reverses the rename. The new code
-breaks against the old name, so this only works if you also roll back
+breaks against the old name, so this works only if you also roll back
 the image.
 
 ### Stage 2 — additive inbound schema (online, anytime after stage 1)
 
-Migration `0007` is pure additive: nullable columns on `emails`, new
-`email_attachments` table, action columns on `email_domains`. Old and
+Migration `0007` is purely additive: nullable columns on `emails`, a new
+`email_attachments` table, and action columns on `email_domains`. Old and
 new code both run against it cleanly.
 
 ```bash
 DATABASE_URL=$DATABASE_URL uv run --directory api alembic upgrade 0007
 ```
 
-**Footgun on large tables.** `emails_inbound_message_id_uq` is a
+**Footgun on large tables.** If `emails` has more than a few million
+rows, edit the migration to `CREATE INDEX CONCURRENTLY` via
+`op.execute` before you apply it. `emails_inbound_message_id_uq` is a
 partial unique index whose `WHERE` is false for every existing row,
-but Postgres still scans the whole table to build it. If `emails` is
-north of a few million rows, edit the migration to `CREATE INDEX
-CONCURRENTLY` via `op.execute` (alembic's `create_index` runs in a
-transaction, which blocks the concurrent flag).
+but Postgres still scans the whole table to build it. Alembic's
+`create_index` runs in a transaction, which blocks the concurrent
+flag.
 
 ### Stage 3 — webhook tables (online, anytime after stage 2)
 
@@ -499,25 +503,25 @@ Pure new tables, no locks on existing tables.
 DATABASE_URL=$DATABASE_URL uv run --directory api alembic upgrade 0008
 ```
 
-At this point the API is ready to receive inbound mail and fire
-webhooks — but nothing's wired up yet on the AWS side, and the inbound
-flag is off, so the system is still effectively outbound-only.
+At this point, the API is ready to receive inbound mail and fire
+webhooks. But nothing is wired up yet on the AWS side, and the inbound
+flag is off, so the system stays effectively outbound-only.
 
 ### Stage 4 — provision AWS infrastructure
 
 The bare Terraform module under `infra/terraform/` provisions S3, the SES
 Receipt Rule + Rule Set, the Lambda, and IAM. A Terragrunt wrapper at
 `infra/terragrunt.hcl` adds an S3 remote backend with a DynamoDB lock
-table, and pulls every variable from the repo's `.env` so there's no
+table, and pulls every variable from the repo's `.env`, so there is no
 parallel `tfvars` file to keep in sync.
 
 **One-time bootstrap** per AWS account. Terragrunt's state backend
-can't bootstrap itself; create the bucket + lock table once with the
-AWS CLI (the AWS CLI doesn't read `.env` like Terragrunt does, so this
-one step needs the env exported into your shell). Note the state
-backend's region is `HAIL_TERRAFORM_STATE_REGION` — often shared
-across deployments and **separate from `AWS_REGION`** (which is where
-the SES + Lambda + raw-MIME bucket get provisioned). It falls back to
+cannot bootstrap itself. Create the bucket + lock table once with the
+AWS CLI. The AWS CLI does not read `.env` like Terragrunt does, so
+this one step needs the env exported into your shell. Note: the region
+of the state backend is `HAIL_TERRAFORM_STATE_REGION` — often shared
+across deployments and **separate from `AWS_REGION`** (where the SES +
+Lambda + raw-MIME bucket get provisioned). It falls back to
 `AWS_REGION` when unset.
 
 ```bash
@@ -539,7 +543,7 @@ aws --profile $AWS_PROFILE dynamodb create-table \
 ```
 
 **Each deploy.** Generate (or rotate) the shared HMAC secret in `.env`
-ahead of time — the same value is what the API uses to verify Lambda
+before the deploy. The API uses the same value to verify Lambda
 POSTs:
 
 ```bash
@@ -561,7 +565,7 @@ Outputs to capture:
   to run after apply.
 
 **Plain Terraform alternative.** The bare module under `infra/terraform/`
-still works with `terraform apply -var ...` if you'd rather skip
+still works with `terraform apply -var ...` if you prefer to skip
 Terragrunt. The Terragrunt wrapper is opinionated about remote state +
 `.env`-driven inputs; the underlying module is provider-vanilla.
 
@@ -579,14 +583,14 @@ aws sesv2 set-active-receipt-rule-set --rule-set-name hail-inbound-prod-rules
 # or skip the module's aws_ses_receipt_rule resource entirely.
 ```
 
-**Manual step: publish the MX record.** Whatever `inbound_mx_record`
-output prints, e.g.:
+**Manual step: publish the MX record.** Publish the value that the
+`inbound_mx_record` output prints, for example:
 
 ```
 mail.hail.so  MX  10  inbound-smtp.us-east-1.amazonaws.com
 ```
 
-DNS propagation is typically minutes; SES won't deliver until the
+DNS propagation usually takes minutes. SES does not deliver until the
 record is live.
 
 ### Stage 5 — flip the inbound flag
@@ -601,16 +605,16 @@ HAIL_WEBHOOK_SECRET_KEY=<generate with `uv run --directory core python -c "from 
 ```
 
 Restart the API. Until this step, `POST /internal/ses-events` returns
-503 even if the Lambda is wired — so steps 1–4 can land days ahead of
-step 5 and you keep a free rollback window (no migration revert
-required to disable inbound).
+503 even if the Lambda is wired. Thus steps 1–4 can land days before
+step 5, and you keep a free rollback window (no migration revert is
+necessary to disable inbound).
 
 ### Smoke test sequence
 
 After stage 5, in order:
 
 1. **Routing exists.** Pick an org you control. From the console or
-   the API, verify the hail-mail row exists and `inbound_enabled=true`:
+   the API, verify that the hail-mail row exists and `inbound_enabled=true`:
 
    ```bash
    hail email domain list
@@ -632,74 +636,75 @@ After stage 5, in order:
    ```
 
 4. **Raw + attachment access.** If the test mail had attachments,
-   the listing should include their metadata; fetching:
+   the listing must include their metadata. This fetch:
 
    ```bash
    hail email get <id> | jq .raw_url
    curl -L -H "Authorization: Bearer $HAIL_API_KEY" "$RAW_URL" > out.eml
    ```
 
-   should download the raw MIME bytes.
+   must download the raw MIME bytes.
 
 5. **Forwarding** (only if `forward_to` is configured on the domain):
-   the forward target should receive a copy from
+   the forward target must receive a copy from
    `forwarder+<org>@mail.hail.so` with the original sender in
-   `Reply-To:`. Check `hail email list --direction outbound` — a
-   row with `metadata.forwarded_from = <inbound id>` should land
-   in `status=sent`.
+   `Reply-To:`. Check `hail email list --direction outbound`. A
+   row with `metadata.forwarded_from = <inbound id>` must show
+   `status=sent`.
 
 6. **Webhook delivery** (only if a webhook is configured): the
-   target should receive a signed POST. Verify the signature header
-   parses, the body shape matches the documented event, and the
-   delivery row reaches `status=succeeded`:
+   target must receive a signed POST. Verify that the signature header
+   parses, that the body shape matches the documented event, and that
+   the delivery row reaches `status=succeeded`:
 
    ```bash
-   hail webhooks deliveries <subscription_id>
+   curl "$HAIL_API_URL/webhooks/<subscription-id>/deliveries" \
+     -H "Authorization: Bearer $HAIL_API_KEY"
    ```
 
-7. **Bounce/complaint plumbing.** Send a test bounce by addressing a
-   mail to `bounce@simulator.amazonses.com` from the verified sender;
+7. **Bounce/complaint plumbing.** To send a test bounce, address a
+   mail to `bounce@simulator.amazonses.com` from the verified sender.
    SES generates a bounce notification. The matching outbound row
-   should flip to `status=bounced` within a few seconds.
+   must change to `status=bounced` in a few seconds.
 
 8. **Rate cap.** Set `email_domains.forward_rate_per_hour=1`, then
-   send two inbounds with forwarding configured. The second's
-   `suppressed_reasons` should include `forward_rate_limit`.
+   send two inbounds with forwarding configured. The second one's
+   `suppressed_reasons` must include `forward_rate_limit`.
 
-### What can go wrong (failure modes I've seen first-hand or modeled)
+### What can go wrong (failure modes we have seen first-hand or modeled)
 
 - **DNS not propagated.** SES silently drops mail to a domain whose
   MX is wrong. `dig MX` is the first diagnostic.
-- **Receipt rule set not activated.** SES accepts mail but doesn't
-  route it; no S3 object appears. Re-check `aws sesv2
-describe-active-receipt-rule-set`.
-- **SES sandbox.** New SES accounts only accept mail from verified
-  addresses. The mail's `From:` must be on a verified SES identity
-  during sandbox.
+- **Receipt rule set not activated.** SES accepts mail but does not
+  route it; no S3 object appears. Check `aws sesv2
+describe-active-receipt-rule-set` again.
+- **SES sandbox.** New SES accounts accept mail only from verified
+  addresses. During sandbox, the mail's `From:` must be on a verified
+  SES identity.
 - **Private webhook target rejected.** `httpx_post` blocks RFC-1918
   addresses by default. Self-hosters with internal webhook targets
   set `HAIL_WEBHOOK_ALLOW_PRIVATE_NETWORKS=true`.
 - **Lambda → API connection refused.** Check the Lambda's
-  CloudWatch logs (`/aws/lambda/hail-inbound-prod-ingest`); the
+  CloudWatch logs (`/aws/lambda/hail-inbound-prod-ingest`). The
   POST URL must be reachable from AWS over the public internet.
-- **Forward loops.** Forwarding to a target on
-  `HAIL_MAIL_BASE_DOMAIN` is rejected; forwarding to a target whose
-  auto-responder replies to the forwarder will get caught by the
-  3-hop counter. If it isn't, raise `HAIL_FORWARD_MAX_HOPS` or
-  blacklist the target by clearing `forward_to`.
+- **Forward loops.** The system rejects a forward to a target on
+  `HAIL_MAIL_BASE_DOMAIN`. If a target's auto-responder replies to
+  the forwarder, the 3-hop counter catches the loop. If it does
+  not, raise `HAIL_FORWARD_MAX_HOPS`, or blacklist the target:
+  clear `forward_to`.
 
 ## SMS abuse monitor & channel suspensions
 
 All orgs share one Hail-owned A2P 10DLC campaign, so one org's high opt-out
-rate can get the whole platform throttled by carriers. `AbuseMonitorWorker`
+rate can cause carriers to throttle the whole platform. `AbuseMonitorWorker`
 (hourly by default; `HAIL_ABUSE_MONITOR_POLL_SECONDS`) computes each org's
-rolling opt-out rate and, past the threshold
-(`HAIL_SMS_ABUSE_*` — window, min sends, max rate), inserts a
+rolling opt-out rate. Past the threshold
+(`HAIL_SMS_ABUSE_*` — window, min sends, max rate), it inserts a
 `channel_suspensions` row. `check_sms_allowed` then blocks that org's
-outbound SMS. Thresholds are unvalidated starting guesses — expect to tune
-them once real traffic lands.
+outbound SMS. The thresholds are unvalidated starting guesses. Expect to
+tune them when real traffic arrives.
 
-**Lifting a suspension is manual for now — there is no CLI/route/expiry.**
+**You must lift a suspension manually for now — there is no CLI/route/expiry.**
 An auto-suspended org stays blocked until an operator runs raw SQL. Inspect
 and lift:
 
@@ -713,23 +718,23 @@ psql "$DATABASE_URL" -c \
   "DELETE FROM channel_suspensions WHERE organization_id = '<org-uuid>' AND channel = 'sms';"
 ```
 
-Before lifting, confirm the opt-out spike was benign (a burst of legitimate
-STOPs, not abuse) — otherwise the next hourly tick re-suspends. There is no
-cooldown/backoff yet, so a persistently-abusive org will re-trip on the next
-run. Tune `HAIL_SMS_ABUSE_MAX_OPT_OUT_RATE` up if you are seeing false
-positives.
+Before you lift a suspension, confirm that the opt-out spike was benign (a
+burst of legitimate STOPs, not abuse). Otherwise, the next hourly tick
+suspends the org again. There is no cooldown/backoff yet, so a
+persistently-abusive org trips again on the next run. If you see false
+positives, tune `HAIL_SMS_ABUSE_MAX_OPT_OUT_RATE` up.
 
 ## Carry-forwards / open work
 
-(See `CHANGELOG.md` "Deferred to v1.x" for the canonical list.)
+(Refer to `CHANGELOG.md` "Deferred to v1.x" for the canonical list.)
 
 - LiveKit Egress recording → S3 (currently `recording.py` returns `None`)
 - `idempotency_keys` GC sweeper
 - Inbound calls (`LIVEKIT_SIP_INBOUND_TRUNK_ID` reserved)
-- SMS, Email channels
+- SMTP-listener inbound email provider (`SmtpInboundProvider` is a stub)
 - `hail bootstrap` admin CLI (closes the manual DB-seed step above)
 - CallEvent dedupe across voicebot redispatch
 - **Un-suspend tooling for `channel_suspensions`** — auto-suspend has no
-  reverse path (see "SMS abuse monitor" above); add a `hail sms suspensions
+  reverse path (refer to "SMS abuse monitor" above); add a `hail sms suspensions
 lift <org>` command / operator route and/or an automatic cooldown column
   so recovery is not raw SQL.

--- a/docs/operations/litellm-upstream.md
+++ b/docs/operations/litellm-upstream.md
@@ -2,21 +2,21 @@
 
 ## Why
 
-[LiteLLM](https://github.com/BerriAI/litellm) is a Python SDK / proxy that unifies many model providers behind one interface. It ships an internal pricing database used for cost estimation (`litellm.model_cost`, sourced from `model_prices_and_context_window.json` in the repo root). That file is widely consumed — embedded in many agent stacks. Getting Hail Costs rows referenced there is a visibility win for the dataset.
+[LiteLLM](https://github.com/BerriAI/litellm) is a Python SDK / proxy that unifies many model providers behind one interface. It includes an internal pricing database for cost estimation (`litellm.model_cost`, sourced from `model_prices_and_context_window.json` in the repo root). Many agent stacks embed and consume that file. Hail Costs rows referenced there are a visibility win for the dataset.
 
 ## What to PR
 
-Two paths, in increasing scope:
+There are two paths, in increasing scope:
 
 ### Path A — Sync individual missing rows (recommended first PR)
 
-LiteLLM's pricing JSON is keyed by model identifier (e.g. `"claude-opus-4-7"`, `"gpt-5-mini"`, etc.) with a flat schema per entry. Map Hail Costs rows into LiteLLM's shape and submit a PR adding only models LiteLLM is missing.
+LiteLLM's pricing JSON is keyed by model identifier (for example, `"claude-opus-4-7"`, `"gpt-5-mini"`) with a flat schema per entry. Map Hail Costs rows into LiteLLM's shape. Submit a PR that adds only the models that LiteLLM does not have.
 
 Concrete steps:
 
 1. **Clone LiteLLM:** `gh repo fork BerriAI/litellm --clone`
-2. **Diff against Hail Costs.** Read `litellm/model_prices_and_context_window.json` and Hail Costs' `costs/llm.json`. List models present in Hail Costs but absent from LiteLLM.
-3. **Translate the shape.** LiteLLM's per-model entry looks like:
+2. **Diff against Hail Costs.** Read `litellm/model_prices_and_context_window.json` and Hail Costs' `costs/llm.json`. List the models that are present in Hail Costs but absent from LiteLLM.
+3. **Translate the shape.** LiteLLM's per-model entry has this form:
 
    ```json
    "claude-opus-4-7": {
@@ -35,7 +35,7 @@ Concrete steps:
    }
    ```
 
-   Hail Costs uses per-1M-token prices; LiteLLM uses per-token. Convert: `price_per_mtok / 1_000_000`. Decimal strings → number is fine here since LiteLLM's schema accepts numbers.
+   Hail Costs uses per-1M-token prices. LiteLLM uses per-token prices. Convert: `price_per_mtok / 1_000_000`. A decimal string → number conversion is acceptable here because LiteLLM's schema accepts numbers.
 
    Mapping table:
 
@@ -54,7 +54,7 @@ Concrete steps:
    | provider                          | `litellm_provider` (lowercased)           |
    | n/a                               | `mode: "chat"` (constant for LLM rows)    |
 
-   Drop fields that don't have a clean LiteLLM equivalent (`aggregators[]`, `aliases[]`, `cache_storage_per_mtok_per_hour_usd`, etc.). Note in PR description.
+   Drop the fields that do not have a clean LiteLLM equivalent (`aggregators[]`, `aliases[]`, `cache_storage_per_mtok_per_hour_usd`, and others). Note them in the PR description.
 
 4. **Open the PR.** Title: `feat: add N models from Hail Costs dataset`. Body template:
 
@@ -77,7 +77,7 @@ Concrete steps:
 
 ### Path B — Propose Hail Costs as an upstream data source (later, bigger ask)
 
-Once Path A has shipped and shown value, propose a richer integration: LiteLLM optionally consumes the Hail Costs raw JSON URLs (`https://raw.githubusercontent.com/hail-hq/hail/main/costs/llm.json`) as a source. Requires a config flag and adapter code in LiteLLM itself. Not in scope for the initial PR.
+After Path A is released and shows value, propose a richer integration: LiteLLM optionally consumes the Hail Costs raw JSON URLs (`https://raw.githubusercontent.com/hail-hq/hail/main/costs/llm.json`) as a source. This requires a config flag and adapter code in LiteLLM itself. It is not in scope for the initial PR.
 
 ## Practical setup commands
 
@@ -102,14 +102,14 @@ gh pr create --repo BerriAI/litellm --title "feat: add N models from Hail Costs 
 
 ## Status
 
-**Not yet executed.** This document is the recipe. The PR itself needs:
+**Not yet executed.** This document is the recipe. The PR itself needs three steps:
 
-1. The diff to be generated (Hail Costs models not in LiteLLM)
-2. The translated entries to be written
-3. The PR to be opened against `BerriAI/litellm`
+1. Generate the diff (Hail Costs models not in LiteLLM)
+2. Write the translated entries
+3. Open the PR against `BerriAI/litellm`
 
-All three can be done by a Claude Code session pointed at this document; the human just needs to confirm and click "Open PR" on GitHub.
+A Claude Code session pointed at this document can do all three steps. The human only needs to confirm and click "Open PR" on GitHub.
 
 ## Why not automate this?
 
-The LiteLLM project moves fast; their schema occasionally changes (new fields, renames). A hand-rolled adapter would break under their evolution. Periodic manual PRs (quarterly) following this recipe are more robust than a CI integration.
+The LiteLLM project moves fast. Their schema occasionally changes (new fields, renames). A hand-rolled adapter would break under their evolution. Periodic manual PRs (quarterly) that follow this recipe are more robust than a CI integration.

--- a/docs/operations/refresh-costs.md
+++ b/docs/operations/refresh-costs.md
@@ -1,38 +1,38 @@
 # Weekly cost-data refresh runbook
 
-> **For Claude Code sessions:** This document is self-contained. Read it end-to-end and follow the procedure. You do not need any session context beyond what's here plus the canonical sources it links to.
+> **For Claude Code sessions:** This document is self-contained. Read all of it and follow the procedure. You do not need other session context. This document and the canonical sources that it links to are sufficient.
 
 ## What this is
 
-The `costs/` dataset (`costs/llm.json`, `costs/stt.json`, `costs/tts.json`) needs periodic re-verification against vendor pricing pages. Prices drift, models get deprecated, new variants launch. This runbook is the procedure for a weekly pass.
+You must verify the `costs/` dataset (`costs/llm.json`, `costs/stt.json`, `costs/tts.json`) against the vendor pricing pages at regular intervals. Prices change, vendors deprecate models, and new variants launch. This runbook gives the procedure for a weekly pass.
 
-The pass is fundamentally a sequence of WebFetch dispatches, one per provider family, comparing the live pricing page against the existing rows and producing updates. Run by a Claude Code session (or any agent with web-fetch + git-edit access).
+The pass is a sequence of WebFetch dispatches, one for each provider family. Each dispatch compares the live pricing page with the existing rows and produces updates. A Claude Code session (or an agent with web-fetch and git-edit access) runs the pass.
 
 ## When to run
 
-- Triggered weekly by the `costs-stale.yml` GitHub Action — opens an issue every Monday listing rows whose `last_verified` is more than 30 days old.
-- Or manually any time, e.g. after a high-profile model launch.
-- Or as part of a release-tag cut (`costs-v0.2.<N>` or higher).
+- The `costs-stale.yml` GitHub Action triggers the pass each week. The action opens an issue each Monday that lists the rows with a `last_verified` more than 30 days old.
+- You can also run the pass manually at any time, for example after a high-profile model launch.
+- You can also run the pass as part of a release-tag cut (`costs-v0.2.<N>` or higher).
 
 ## Pre-flight
 
-Before starting, confirm:
+Before you start, confirm these items:
 
-1. **Working tree is clean** for `costs/` (no in-flight data PRs). Stash or commit pending work first.
-2. **Schema is at v2 with v2.1+v2.2 extensions.** Check `costs/schema/llm.schema.json`'s `version` const is `2` and that `audio_input_per_mtok_usd`, `price_per_second_usd`, `aggregators[]` are declared.
-3. **You can run `pnpm costs:validate`.** If `pipx run check-jsonschema` is broken on the host (Python ABI issues are common), fall back to `check-jsonschema --schemafile <schema> <data>` directly with whatever `check-jsonschema` binary is on PATH.
+1. **The working tree is clean** for `costs/` (no data PRs in flight). Stash or commit pending work first.
+2. **The schema is at v2 with the v2.1+v2.2 extensions.** Make sure that the `version` const in `costs/schema/llm.schema.json` is `2`. Make sure that `audio_input_per_mtok_usd`, `price_per_second_usd`, and `aggregators[]` are declared.
+3. **You can run `pnpm costs:validate`.** If `pipx run check-jsonschema` is broken on the host (Python ABI problems are common), use `check-jsonschema --schemafile <schema> <data>` directly with the `check-jsonschema` binary that is on PATH.
 
 ## Conventions you must follow
 
-These are non-negotiable per the project's tenets and the v0.2 design spec. Read [`costs/README.md`](../../costs/README.md) and [`docs/superpowers/specs/2026-05-17-costs-v0.2-design.md`](../superpowers/specs/2026-05-17-costs-v0.2-design.md) for context.
+These rules are mandatory per the project tenets and the v0.2 design spec. For context, refer to [`costs/README.md`](../../costs/README.md) and [`docs/superpowers/specs/2026-05-17-costs-v0.2-design.md`](../superpowers/specs/2026-05-17-costs-v0.2-design.md).
 
-1. **Two-source rule.** Every price-affecting change cites the vendor pricing page plus one secondary source (vendor announcement, third-party aggregator, vendor API docs). If only one source is available, set the row's `confidence: medium` and explain in `notes`.
-2. **Decimal-string prices.** All `*_per_*_usd` fields are JSON strings, not numbers, matching the pattern `^(0|[1-9][0-9]*)(\.[0-9]{1,8})?$`. The validator rejects floats.
-3. **Canonical model_ids.** Use the vendor's actual API model_id string. Never invent. If a marketing name doesn't correspond to a stable API identifier, defer the row.
-4. **Two source verifies = the bar.** "Vendor pricing page is unreachable" or "model_id not in docs" means defer with a documented reason. Do not guess.
-5. **`last_verified` always bumps** on touched rows. **`last_changed_at` only bumps** if a structured price field actually moved.
-6. **Field order convention** (see "Field order" below). Match exactly.
-7. **No destructive git in the shared tree.** This runbook's default model has every provider-agent editing the **same** working tree, so a subagent must never run a git command that reverts or discards it — `git checkout`, `git restore`, `git stash`, `git reset` — nor `git commit`/`git add`. A `checkout`/`restore` on a shared `costs/*.json` reverts the whole file and silently wipes every other provider's in-flight edits — it cost a full LLM sweep once. Fix broken formatting with the `Edit` tool or `pnpm exec prettier --write costs/<category>.json`, never git. Leave files modified-but-unstaged; produce a commit message; let the operator commit. (Giving each provider its **own** git worktree makes git safe per-agent — but then add a step to collate each worktree's single-file edit back, which is why the default is one shared tree + sequential dispatch.)
+1. **Two-source rule.** For every price-affecting change, cite the vendor pricing page plus one secondary source. A secondary source is a vendor announcement, a third-party aggregator, or the vendor API docs. If only one source is available, set `confidence: medium` on the row and give the reason in `notes`.
+2. **Decimal-string prices.** All `*_per_*_usd` fields are JSON strings, not numbers. They must match the pattern `^(0|[1-9][0-9]*)(\.[0-9]{1,8})?$`. The validator rejects floats.
+3. **Canonical model_ids.** Use the vendor's real API model_id string. Do not invent one. If a marketing name does not have a stable API identifier, defer the row.
+4. **Two source verifications are the bar.** If the vendor pricing page is unreachable, or the model_id is not in the docs, defer the row with a documented reason. Do not guess.
+5. **Always bump `last_verified`** on each row that you touch. **Bump `last_changed_at` only** if a structured price field changed.
+6. **Field order convention** (refer to "Field order" below). Match it exactly.
+7. **No destructive git in the shared tree.** In the default model of this runbook, every provider-agent edits the **same** working tree. Thus a subagent must never run a git command that reverts or discards the tree — `git checkout`, `git restore`, `git stash`, `git reset` — and must never run `git commit`/`git add`. A `checkout`/`restore` on a shared `costs/*.json` reverts the full file and silently erases the in-flight edits of every other provider — one such error caused the loss of a full LLM sweep. Repair broken formatting with the `Edit` tool or `pnpm exec prettier --write costs/<category>.json`, never with git. Leave the files modified but unstaged. Produce a commit message. Let the operator commit. (A separate git worktree for each provider makes git safe for each agent. But then you must add a step to collate the single-file edit of each worktree back. Thus the default is one shared tree plus sequential dispatch.)
 
 ## Per-row data model (cheat sheet)
 
@@ -97,7 +97,7 @@ Authoritative source: [`costs/schema/llm.schema.json`](../../costs/schema/llm.sc
 
 ## Field order (all categories)
 
-Keep this consistent across all rows. The order makes diffs reviewable and matches existing committed data.
+Keep this order the same across all rows. The order makes diffs easy to review and agrees with the existing committed data.
 
 **LLM:**
 
@@ -168,27 +168,27 @@ source_url, notes
 
 ## Featured models
 
-`featured: true` puts a model into the prerendered `/costs/compare/<a>-vs-<b>` page set. Every within-category pair of featured models becomes a static page. Design rationale: [`docs/superpowers/specs/2026-07-27-costs-compare-crawl-trap-design.md`](../superpowers/specs/2026-07-27-costs-compare-crawl-trap-design.md).
+`featured: true` puts a model into the prerendered `/costs/compare/<a>-vs-<b>` page set. Every within-category pair of featured models becomes a static page. For the design rationale, refer to [`docs/superpowers/specs/2026-07-27-costs-compare-crawl-trap-design.md`](../superpowers/specs/2026-07-27-costs-compare-crawl-trap-design.md).
 
 Rules for a refresh pass:
 
-- **New marquee model launched?** It is a candidate for `featured: true`. Adding the flag creates its comparison pages on the next deploy — nothing else to edit.
-- **Featured model deprecated?** **Keep the flag.** The page persists with a deprecation banner so an indexed URL never 404s. Make sure `replaced_by_model_id` resolves to a model in the same file.
-- **Never drop a featured flag** to tidy up. Removing one deletes indexed pages; `scripts/costs/check-featured.mjs` will fail the build if you do.
-- **Adding** a flag changes the generated slug set, so regenerate and commit the lockfile:
+- **If a new marquee model launched**, the model is a candidate for `featured: true`. When you add the flag, the next deploy creates the comparison pages for the model. You do not edit anything else.
+- **If a featured model is deprecated**, **keep the flag.** The page stays live with a deprecation banner, so an indexed URL never returns a 404. Make sure that `replaced_by_model_id` resolves to a model in the same file.
+- **Never remove a featured flag** to clean up. If you remove one, you delete indexed pages, and `scripts/costs/check-featured.mjs` fails the build.
+- When you **add** a flag, you change the generated slug set. Regenerate and commit the lockfile:
 
 ```bash
 pnpm costs:featured --write   # regenerates web/lib/featured.lock.json
 pnpm costs:featured           # verifies invariants; must print "Featured set OK"
 ```
 
-- Removing a flag is a deliberate de-indexing decision. Do **not** run `--write` to silence the resulting failure — restore the flag, or hand-edit `web/lib/featured.lock.json` in the same commit so the deletion is visible in review.
+- The removal of a flag is a deliberate de-indexing decision. Do **not** run `--write` to silence the failure that results. Restore the flag, or hand-edit `web/lib/featured.lock.json` in the same commit, so the deletion is visible in review.
 
-Keep the set small. Every model added creates a page against each existing featured model in its category, so N models produce N×(N−1)/2 pages.
+Keep the set small. Each model that you add creates a page against each existing featured model in its category. Thus N models produce N×(N−1)/2 pages.
 
 ## Provider catalog
 
-The agent re-verifies each provider against these primary + secondary sources. New providers are appended as the dataset grows.
+The agent verifies each provider again against these primary and secondary sources. Append new providers as the dataset grows.
 
 | Category | Provider         | Primary pricing URL                                                                   | Secondary URL                                                                     | Notes                                                                            |
 | -------- | ---------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
@@ -231,7 +231,7 @@ The agent re-verifies each provider against these primary + secondary sources. N
 
 ## Procedure
 
-Run the steps below in order. Each provider takes one focused dispatch.
+Do the steps below in sequence. Each provider gets one focused dispatch.
 
 ### Step 0 — Pre-flight
 
@@ -241,20 +241,20 @@ git status --short costs/      # must be empty
 pnpm costs:validate            # baseline must pass (fall back to direct check-jsonschema if needed)
 ```
 
-If `git status` shows anything under `costs/`, stop and reconcile. Don't proceed on a dirty tree.
+If `git status` shows changes under `costs/`, stop and reconcile them. Do not continue on a dirty tree.
 
 ### Step 1 — Dispatch one subagent per provider
 
-For each provider in the catalog above, dispatch a Claude Code subagent with the **per-provider prompt template** (next section). Run providers in sequence (not parallel — they all edit the same files).
+For each provider in the catalog above, dispatch a Claude Code subagent with the **per-provider prompt template** (next section). Run the providers in sequence, not in parallel, because they all edit the same files.
 
 Strategy hints:
 
-- Start with high-leverage providers (Anthropic, OpenAI, Google) — they're the most consumed and most volatile.
-- If a vendor's pricing page is unreachable on the first WebFetch, retry once with a fallback URL from the catalog. If still unreachable, defer the whole provider for this pass.
-- Watch for deprecations. They surfaced in 4 of 15 PRs during Phase 1; always check.
-- Watch for new models. New launches happen most weeks for the marquee providers.
+- Start with the high-leverage providers (Anthropic, OpenAI, Google). They are the most consumed and the most volatile.
+- If a vendor pricing page is unreachable on the first WebFetch, retry one time with a fallback URL from the catalog. If the page is still unreachable, defer the full provider for this pass.
+- Monitor for deprecations. They occurred in 4 of 15 PRs during Phase 1. Always check.
+- Monitor for new models. The marquee providers launch new models most weeks.
 
-### Step 2 — After each dispatch, the subagent should have:
+### Step 2 — After each dispatch, the subagent must have:
 
 - Edited `costs/{llm,stt,tts}.json` for that provider's rows
 - Bumped `last_verified` on touched rows; `last_changed_at` only where a price changed
@@ -267,27 +267,27 @@ Strategy hints:
 
 ### Step 3 — Stage and close out
 
-Once all providers have been processed (or deferred):
+When all providers are processed (or deferred):
 
 ```bash
 git add costs/llm.json costs/stt.json costs/tts.json
 git diff --cached --stat
 ```
 
-Produce a single rolled-up commit message summarizing:
+Produce one rolled-up commit message that summarizes:
 
 - How many rows touched
 - New rows added (provider + model_id)
 - New deprecations marked
 - Defers (with reasons)
 
-Commit (operator's call, manual):
+Commit (the operator does this step manually):
 
 ```
 git commit -m "feat(costs): weekly refresh YYYY-MM-DD"
 ```
 
-Optionally bump the patch tag:
+If applicable, bump the patch tag:
 
 ```
 git tag -a costs-v0.2.<next> -m "Weekly refresh YYYY-MM-DD"
@@ -296,7 +296,7 @@ git push origin main costs-v0.2.<next>
 
 ## Per-provider dispatch prompt template
 
-Copy-paste this into a `Task` tool call (or equivalent). Replace placeholders.
+Copy and paste this into a `Task` tool call (or equivalent). Replace the placeholders.
 
 ````
 You are running a weekly cost-data refresh for {provider} in the Hail Costs Dataset.
@@ -396,11 +396,11 @@ for f in costs/llm.json costs/stt.json costs/tts.json; do
 done
 ```
 
-Each line must end `[] ; replaced_by: []`. The CI workflow at `.github/workflows/costs-validate.yml` enforces the same.
+Each line must end with `[] ; replaced_by: []`. The CI workflow at `.github/workflows/costs-validate.yml` enforces the same checks.
 
 ## Closing checklist
 
-Before signing off the refresh:
+Before you sign off the refresh:
 
 - [ ] `pnpm costs:validate` passes (all three categories `ok -- validation done`)
 - [ ] jq referential checks pass (every line ends `[] ; replaced_by: []`)
@@ -411,12 +411,12 @@ Before signing off the refresh:
 - [ ] No row has both per-unit price fields set with conflicting math (STT: `price_per_minute = price_per_second × 60`; TTS: analogous if both populated)
 - [ ] No new aggregator added without at least one direct host in `deployment_options[]`
 - [ ] `git diff --cached` shows ONLY rows in `costs/{llm,stt,tts}.json` — no schema, no README, no unrelated files
-- [ ] Single rolled-up commit message documents row count, new additions, deprecations, defers
+- [ ] One rolled-up commit message documents the row count, new additions, deprecations, and defers
 - [ ] Stop. Let the operator run `git commit`.
 
 ## How to point a fresh Claude Code session at this document
 
-The fastest workflow:
+This is the fastest workflow:
 
 ```
 1. Open a new Claude Code session in the Hail repo.
@@ -430,16 +430,16 @@ The fastest workflow:
 4. You review the diff, commit when satisfied, optionally tag.
 ```
 
-The agent does not need any prior session context. This document plus the canonical sources it links to are complete inputs.
+The agent does not need prior session context. This document plus the canonical sources that it links to are the complete inputs.
 
 ## When this runbook needs updates
 
 Edit this file when:
 
-- A new provider is added to the catalog (append to the table in "Provider catalog")
-- A vendor URL changes (most common edit; vendors rename pricing pages frequently)
-- A new schema field lands (the v2.x evolution path) — update the "Per-row data model" section
-- The two-source rule, decimal-string rule, or field-order convention changes (would require a schema-version bump too)
-- The featured-model policy changes (see "Featured models") — update that section and the closing checklist together
+- You add a new provider to the catalog (append it to the table in "Provider catalog")
+- A vendor URL changes (the most common edit; vendors frequently rename pricing pages)
+- A new schema field is released (the v2.x evolution path) — update the "Per-row data model" section
+- The two-source rule, decimal-string rule, or field-order convention changes (this also requires a schema-version bump)
+- The featured-model policy changes (refer to "Featured models") — update that section and the closing checklist together
 
-Schema-shaped changes get their own design spec under `docs/superpowers/specs/`. Catalog edits do not — they're maintenance of this runbook.
+Schema-shaped changes get their own design spec under `docs/superpowers/specs/`. Catalog edits do not — they are maintenance of this runbook.

--- a/docs/runbooks/agent-outbound.md
+++ b/docs/runbooks/agent-outbound.md
@@ -1,9 +1,9 @@
 # Agent outbound — runbook
 
-Agent-origin orgs (organizations.origin = 'agent') self-signup via
-POST hail.so/api/agent/signup and send on free credit, gated by velocity
-caps (core/hailhq/core/agent_caps.py — the enforcement gate; defaults live
-in core/hailhq/core/config.py). Spec: hail-website
+Agent-origin orgs (organizations.origin = 'agent') do self-signup via
+POST hail.so/api/agent/signup and send on free credit. Velocity caps gate
+them (core/hailhq/core/agent_caps.py is the enforcement gate; the defaults
+are in core/hailhq/core/config.py). Refer to the spec: hail-website
 docs/superpowers/specs/2026-07-14-agent-self-signup-design.md.
 
 ## Kill switch (all agent outbound, instantly; humans unaffected)
@@ -15,21 +15,22 @@ OFF:
 UPDATE platform_flags SET value = 'false', updated_at = now()
 WHERE key = 'agent_outbound_disabled';
 
-Covers direct sends (POST /emails, /sms, /calls) AND inbound-forward relay for
-agent-origin orgs — both check the flag before hitting a provider. While the
-switch is ON, an agent-origin org's queued forwards defer (stay queued, resume
-when you flip it OFF); a queued agent forward at the head of the shared forward
-queue can briefly delay other orgs' forwards until the switch clears — expected
-during a short emergency stop.
+The switch covers direct sends (POST /emails, /sms, /calls) AND the
+inbound-forward relay for agent-origin orgs. Both check the flag before they
+call a provider. While the switch is ON, an agent-origin org's queued forwards
+defer: they stay queued and resume when you flip the switch OFF. A queued agent
+forward at the head of the shared forward queue can delay other orgs' forwards
+for a short time until the switch clears. This is expected during a short
+emergency stop.
 
 ## One abusive org (targeted, not the kill switch)
 
 Use the existing per-org channel suspension. `reason` is NOT NULL — always
-record why (ticket/link):
+record the reason (ticket/link):
 INSERT INTO channel_suspensions (organization_id, channel, reason)
 VALUES ('<org>', '<email|sms|voice>', '<why — ticket/link>');
 
-To lift the suspension once resolved:
+To lift the suspension after you resolve the issue:
 DELETE FROM channel_suspensions
 WHERE organization_id = '<org>' AND channel = '<email|sms|voice>';
 
@@ -41,7 +42,7 @@ AGENT_EMAIL_PER_DAY, AGENT_SMS_PER_DAY, AGENT_VOICE_PER_DAY,
 AGENT_EMAIL_RECIPIENTS_PER_DAY, AGENT_SMS_RECIPIENTS_PER_DAY,
 AGENT_VOICE_RECIPIENTS_PER_DAY, AGENT_GLOBAL_EMAIL_PER_HOUR,
 AGENT_GLOBAL_SMS_PER_HOUR, AGENT_GLOBAL_VOICE_PER_HOUR — pydantic-settings naming,
-no prefix). Restart the API to pick up changes.
+no prefix). Restart the API to apply the changes.
 
 ## Monitoring queries
 
@@ -72,33 +73,33 @@ GROUP BY ac.organization_id ORDER BY 2 DESC;
 
 ## Retention (agent_send_log grows unbounded)
 
-The gate only ever queries the last hour/day, so rows older than ~24h have no
-runtime value; the monitoring queries above cap at 7 days. Prune periodically to
-bound table + autovacuum cost (e.g. a daily job):
+The gate queries only the last hour/day. Thus rows older than approximately
+24h have no runtime value. The monitoring queries above cap at 7 days. Prune
+periodically to bound the table + autovacuum cost (for example, a daily job):
 DELETE FROM agent_send_log WHERE created_at < now() - interval '30 days';
 
 ## Accepted risk (from the spec)
 
-Agent traffic shares sender domains with paying customers — velocity caps +
-this kill switch are the mitigation. If deliverability dips
-(bounce/complaint rates on shared domains), flip the kill switch first,
-investigate second. Reputation isolation (dedicated subdomain/IP pool) is
+Agent traffic shares sender domains with paying customers. Velocity caps +
+this kill switch are the mitigation. If deliverability decreases
+(bounce/complaint rates on shared domains), flip the kill switch first.
+Investigate second. Reputation isolation (dedicated subdomain/IP pool) is
 the designated fast-follow.
 
 ---
 
 ## Launch checklist (operator — after deploy)
 
-**SEQUENCING WARNING:** Deploy order is critical. Each step must complete before the next:
+**SEQUENCING WARNING:** The deploy order is critical. Complete each step before you start the next:
 
-1. hail-website DB migration applies first (Global Constraint)
-2. hail-website deploy
-3. hail API deploy (alembic 0034 auto-applies per the repo's deploy flow — verify in GHA log)
-4. Only THEN publish SKILL.md to ClawHub and Moltbook — the doc promises 429 caps and Retry-After headers that don't exist until the API deploys
+1. Apply the hail-website DB migration first (Global Constraint)
+2. Deploy hail-website
+3. Deploy the hail API (alembic 0034 auto-applies per the repo's deploy flow — verify in the GHA log)
+4. Only THEN publish SKILL.md to ClawHub and Moltbook. The doc promises 429 caps and Retry-After headers that do not exist until the API deploys
 
 - [ ] **Step 1: Verify API deployment**
-  - Check GHA logs for successful hail-api deploy
-  - Confirm alembic 0034 migration ran (search logs for "agent_send_log" or "agent_signups")
+  - Check the GHA logs for a successful hail-api deploy
+  - Confirm that the alembic 0034 migration ran (search the logs for "agent_send_log" or "agent_signups")
 
 - [ ] **Step 2: Publish to ClawHub**
 
@@ -108,12 +109,12 @@ the designated fast-follow.
   clawhub skill publish /tmp/hail-skill
   ```
 
-  Expected: listing visible on clawhub. If `clawhub` CLI needs auth/setup, follow its login flow first (operator account).
+  Expected result: the listing is visible on clawhub. If the `clawhub` CLI needs auth/setup, follow its login flow first (operator account).
 
 - [ ] **Step 3: Moltbook presence**
-  1. Register a Hail-owned agent on moltbook.com per their flow (agent signs up, provides claim link, owner verifies via X).
-  2. First post: the skill doc — link `https://hail.so/skill.md?ref=moltbook`, framed as "you can sign up yourself, here's how."
-  3. Ongoing cadence via the `~/playground/hail-content` pipeline (manual posting first, per current content-engine practice): product notes and replies to comms-related threads, each carrying the `?ref=moltbook` link.
+  1. Register a Hail-owned agent on moltbook.com per their flow (the agent signs up and provides a claim link, then the owner verifies via X).
+  2. Make the first post the skill doc — link `https://hail.so/skill.md?ref=moltbook`, framed as "you can sign up yourself, here's how."
+  3. Keep an ongoing cadence via the `~/playground/hail-content` pipeline (manual posting first, per current content-engine practice). Post product notes and replies to comms-related threads. Each post carries the `?ref=moltbook` link.
 
 - [ ] **Step 4: Verify the funnel end-to-end in prod**
-      After all above steps complete: run the Task 4 Step 3 curl against `https://hail.so` with a real owner email you control; confirm 201 + key; send one email via the key; confirm the send succeeds, `agent_send_log` has the row, and the attribution query in this runbook shows the `ref`. Then delete/close the test workspace.
+      After all the steps above are complete, run the Task 4 Step 3 curl against `https://hail.so` with a real owner email that you control. Confirm 201 + key. Send one email via the key. Confirm that the send succeeds, that `agent_send_log` has the row, and that the attribution query in this runbook shows the `ref`. Then delete/close the test workspace.

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -1,15 +1,15 @@
 # Setup
 
-Connect the third-party services Hail needs — LiveKit Cloud for media, Twilio for phone numbers, and any MCP client for agent access.
+Connect the third-party services that Hail needs — LiveKit Cloud for media, Twilio for phone numbers and SMS, AWS SES for email, and any MCP client for agent access.
 
-Hail v1 wraps three external services. Provision each, drop credentials into `.env`, and `docker compose up` does the rest.
+Hail v1 wraps three external services. Provision each service. Put the credentials in `.env`. Then `docker compose up` does the rest.
 
 ## Order
 
-1. **[LiveKit Cloud](./livekit-cloud.md)** — media (SIP bridge + WebRTC). Required before voicebot can join calls.
-2. **[Twilio](./twilio.md)** — phone numbers + SIP trunk. The Origination URI from LiveKit goes into the Twilio trunk config.
-3. **[AWS SES](./aws-ses.md)** — outbound email. Independent of voice setup; needed only if you'll send mail.
-4. **[MCP clients](./mcp.md)** — connect Claude.ai / ChatGPT / Cursor / Claude Code to your Hail deployment. Independent of voice setup; needed only for agent-driven flows.
-5. **[VM deployment](./vm-deploy.md)** — run the whole stack on a single Ubuntu VM behind HTTPS, with GitHub Actions auto-deploying each commit on `main`.
+1. **[LiveKit Cloud](./livekit-cloud.md)** — media (SIP bridge + WebRTC). This is necessary before the voicebot can join calls.
+2. **[Twilio](./twilio.md)** — phone numbers, SMS, and the SIP trunk. Put the Origination URI from LiveKit in the Twilio trunk configuration.
+3. **[AWS SES](./aws-ses.md)** — outbound and inbound email. This is independent of the voice setup. You need it only if you send or receive mail.
+4. **[MCP clients](./mcp.md)** — connect Claude.ai / ChatGPT / Cursor / Claude Code to your Hail deployment. This is independent of the voice setup. You need it only for agent-driven flows.
+5. **[VM deployment](./vm-deploy.md)** — run the full stack on one Ubuntu VM behind HTTPS. GitHub Actions deploys each commit on `main` automatically.
 
-For one-click client setup snippets, also see the [client picker on hail.so/mcp](https://hail.so/mcp).
+For one-click client setup snippets, also refer to the [client picker on hail.so/mcp](https://hail.so/mcp).

--- a/docs/setup/aws-ses.md
+++ b/docs/setup/aws-ses.md
@@ -1,10 +1,10 @@
-# AWS SES (outbound email)
+# AWS SES (email)
 
-Outbound email goes through [Amazon SES](https://aws.amazon.com/ses/) ([SESv2 API](https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_Operations.html)). You need an AWS account, the SES service enabled in one region, and either IAM-role credentials (recommended for EC2/ECS/EKS deployments) or a long-lived access key.
+Outbound and inbound email go through [Amazon SES](https://aws.amazon.com/ses/) ([SESv2 API](https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_Operations.html)). You need an AWS account and the SES service enabled in one region. You also need IAM-role credentials (recommended for EC2/ECS/EKS deployments) or a long-lived access key.
 
 ## 1. Credentials
 
-The Python SDK uses the standard [boto3 credential chain](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html), so leave keys empty in `.env` if you run on AWS infra with an attached IAM role. Otherwise:
+The Python SDK uses the standard [boto3 credential chain](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html). If you run on AWS infrastructure with an attached IAM role, leave the keys empty in `.env`. Otherwise, set:
 
 ```bash
 AWS_REGION=us-east-1
@@ -12,7 +12,7 @@ AWS_ACCESS_KEY_ID=AKIA…
 AWS_SECRET_ACCESS_KEY=…
 ```
 
-Minimal IAM policy (one statement is enough for the v1 surface):
+Minimal IAM policy (one statement is sufficient for the v1 surface):
 
 ```json
 {
@@ -34,35 +34,35 @@ Minimal IAM policy (one statement is enough for the v1 surface):
 
 ## 2. Sandbox vs production
 
-Brand-new SES accounts are in the [sandbox](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html): 200 messages/day, 1 message/second, and you can only send **to verified addresses**. Request production access from **SES → Account dashboard → Request production access** once you're ready to send to arbitrary recipients.
+New SES accounts start in the [sandbox](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html): 200 messages/day, 1 message/second, and you can send only **to verified addresses**. When you are ready to send to arbitrary recipients, request production access from **SES → Account dashboard → Request production access**.
 
 ## 3. Why `mail.hail.so` (a subdomain), not `hail.so`
 
-Always send transactional mail from a **dedicated subdomain**, not your apex domain. The two reasons:
+Always send transactional mail from a **dedicated subdomain**, not from your apex domain. There are two reasons:
 
-- **Reputation isolation.** If a bounce spike or spam-report cluster damages the sender's reputation, only the subdomain takes the hit. Your apex domain (website, marketing email if any) stays clean.
-- **Standard practice.** Postmark uses `mtasv.net`, SendGrid `sendgrid.net`, Resend has tenants verify their own subdomains. Mixing transactional volume with brand traffic on the apex is a known footgun.
+- **Reputation isolation.** If a bounce spike or a spam-report cluster damages the sender reputation, only the subdomain takes the damage. Your apex domain (website, marketing email if any) stays clean.
+- **Standard practice.** Postmark uses `mtasv.net`, and SendGrid uses `sendgrid.net`. Resend has tenants verify their own subdomains. Do not mix transactional volume with brand traffic on the apex domain — it is a known risk.
 
-Recommended for the Hail public cloud: `mail.hail.so`. Self-hosters: pick a subdomain you own, e.g. `mail.<your-domain>`.
+The recommended subdomain for the Hail public cloud is `mail.hail.so`. Self-hosters: select a subdomain that you own, for example `mail.<your-domain>`.
 
 ## 4. Set up the SES identity
 
-Operator setup, once per deployment. Hail does not configure SES on your behalf for the parent `HAIL_MAIL_BASE_DOMAIN` — that identity has to exist (and be verified) before the first `POST /emails`, and the MAIL FROM subdomain is also operator-configured. Custom tenant domains follow a separate, fully-automated flow (Hail calls `CreateEmailIdentity` **and** configures their MAIL FROM; see §7).
+This is operator setup, done once per deployment. Hail does not configure SES for the parent `HAIL_MAIL_BASE_DOMAIN`. That identity must exist, and be verified, before the first `POST /emails`. The operator also configures the MAIL FROM subdomain. Custom tenant domains follow a separate, fully automated flow: Hail calls `CreateEmailIdentity` **and** configures their MAIL FROM (refer to §7).
 
-1. **AWS Console → SES → Verified identities → Create identity → Domain**. Enter the bare subdomain (`mail.hail.so`). Enable **DKIM** (default; leave the bit-length at 2048).
-2. SES returns three CNAMEs of the form `<token>._domainkey.mail.hail.so → <token>.dkim.amazonses.com`. **Publish all three** at your DNS provider. Wait for SES to flip status to **Verified** (usually < 1 hour).
-3. **Configure a custom MAIL FROM domain** — **not optional** for production deliverability (see §5 below). On the identity detail page → **Edit MAIL FROM** → set to `bounces.mail.hail.so`. SES returns one MX and one TXT record. Publish both at DNS:
+1. Open **AWS Console → SES → Verified identities → Create identity → Domain**. Enter the bare subdomain (`mail.hail.so`). Enable **DKIM** (the default; keep the bit-length at 2048).
+2. SES returns three CNAMEs of the form `<token>._domainkey.mail.hail.so → <token>.dkim.amazonses.com`. **Publish all three** at your DNS provider. Wait until SES sets the status to **Verified** (usually less than 1 hour).
+3. **Configure a custom MAIL FROM domain** — this step is **mandatory** for production deliverability (refer to §5 below). On the identity detail page, select **Edit MAIL FROM** and set the value to `bounces.mail.hail.so`. SES returns one MX record and one TXT record. Publish both at DNS:
    ```
    bounces.mail.hail.so  MX   10  feedback-smtp.us-east-1.amazonses.com
    bounces.mail.hail.so  TXT  "v=spf1 include:amazonses.com ~all"
    ```
-4. Wait for the MAIL FROM domain to flip to **Success**.
+4. Wait until the MAIL FROM domain status is **Success**.
 
-> This MAIL FROM subdomain — `bounces.mail.hail.so` on the **operator parent** — is operator-managed: you configure it once, by hand, in the steps above. **Custom tenant domains are different**: Hail auto-configures their MAIL FROM. `POST /email-domains` (kind=`custom`) calls `PutEmailIdentityMailFromAttributes` for `send.<domain>` and returns the MX + SPF records to publish alongside the DKIM CNAMEs; `POST /email-domains/{id}/verify` then re-polls both DKIM and MAIL FROM status. See §7.
+> This MAIL FROM subdomain — `bounces.mail.hail.so` on the **operator parent** — is operator-managed: you configure it once, manually, in the steps above. **Custom tenant domains are different**: Hail configures their MAIL FROM automatically. `POST /email-domains` (kind=`custom`) calls `PutEmailIdentityMailFromAttributes` for `send.<domain>` and returns the MX + SPF records to publish together with the DKIM CNAMEs. `POST /email-domains/{id}/verify` then re-polls both the DKIM status and the MAIL FROM status. Refer to §7.
 
 ## 5. DMARC alignment (required for inbox delivery)
 
-Without an aligned MAIL FROM, SES uses `<random>@amazonses.com` as the Return-Path. SPF then authenticates against `amazonses.com`, not your domain — and that breaks DMARC alignment, so recipients' DMARC policies push your mail to spam.
+Without an aligned MAIL FROM, SES uses `<random>@amazonses.com` as the Return-Path. SPF then authenticates against `amazonses.com`, not against your domain. This breaks DMARC alignment, and the DMARC policies of recipients push your mail to spam.
 
 With `bounces.mail.hail.so` as MAIL FROM:
 
@@ -70,15 +70,15 @@ With `bounces.mail.hail.so` as MAIL FROM:
 - **DKIM** signs with `mail.hail.so` → aligns.
 - Both aligned → DMARC `pass` → inbox.
 
-Publish a DMARC record. Start at `p=none` (monitor-only), then ratchet up after a couple of weeks of clean reports:
+Publish a DMARC record. Start at `p=none` (monitor-only). Increase the policy after some weeks of clean reports:
 
 ```
 _dmarc.mail.hail.so  TXT  "v=DMARC1; p=none; rua=mailto:dmarc-reports@hail.so; adkim=s; aspf=s"
 ```
 
-Field cheat-sheet: `p=none` reports but doesn't block (start here); `quarantine` shunts unaligned mail to spam; `reject` drops it. `adkim=s` and `aspf=s` require strict alignment between the DKIM/SPF authentication domain and the From domain.
+Field summary: `p=none` reports but does not block (start here). `quarantine` moves unaligned mail to spam. `reject` drops it. `adkim=s` and `aspf=s` require strict alignment between the DKIM/SPF authentication domain and the From domain.
 
-> **TODO(dmarc-ratchet):** Hail's public `mail.hail.so` currently sits at `p=none`. After 30+ days of clean DMARC aggregate reports (no unauthenticated mail in `rua=` feeds), step the policy to `p=quarantine`, monitor another 30 days, then move to `p=reject`. Self-hosters should follow the same staged rollout on their own subdomain.
+> **TODO(dmarc-ratchet):** Hail's public `mail.hail.so` is currently at `p=none`. After 30 or more days of clean DMARC aggregate reports (no unauthenticated mail in `rua=` feeds), step the policy to `p=quarantine`. Monitor for 30 more days, then move to `p=reject`. Self-hosters must follow the same staged rollout on their own subdomain.
 
 ## 6. Configure Hail
 
@@ -95,18 +95,18 @@ HAIL_MAIL_FROM=admin+selfhost@mail.hail.so
 AWS_REGION=us-east-1
 ```
 
-Hail-mail addresses always have the shape `<user>+<org>@<HAIL_MAIL_BASE_DOMAIN>` — e.g. `alice+acme@mail.hail.so`. Both `<user>` and `<org>` are validated against `^[a-z0-9]([a-z0-9-]{0,18}[a-z0-9])?$` (1–20 chars, lowercase alphanumeric + hyphens, no leading/trailing hyphen).
+Hail-mail addresses always have the shape `<user>+<org>@<HAIL_MAIL_BASE_DOMAIN>` — for example `alice+acme@mail.hail.so`. Hail validates both `<user>` and `<org>` against `^[a-z0-9]([a-z0-9-]{0,18}[a-z0-9])?$` (1–20 characters, lowercase alphanumeric plus hyphens, no leading or trailing hyphen).
 
 Precedence at send time (highest wins):
 
 - **User prefix:** explicit `local_prefix_user` → `HAIL_MAIL_FROM` (user part) → `HAIL_MAIL_DEFAULT_USER_PREFIX`.
-- **Org prefix:** explicit `local_prefix_org` → `HAIL_MAIL_FROM` (org part, single-tenant) → derived per-org from the organization id. Never a deploy-wide constant — that would make every org collide on one address.
+- **Org prefix:** explicit `local_prefix_org` → `HAIL_MAIL_FROM` (org part, single-tenant) → derived per-org from the organization id. The org prefix is never a deploy-wide constant — that constant would make every org collide on one address.
 
 ### Self-host vs managed
 
-**Self-hosters**: there's no console, so the env vars _are_ the configuration. Set them in `.env` once, restart, and `POST /emails` works without any prior `POST /email-domains` — the server auto-mints a hail-mail row from the env defaults on first send.
+**Self-hosters**: there is no console, so the env vars _are_ the configuration. Set them in `.env` once, then restart. `POST /emails` then works without a prior `POST /email-domains` — the server auto-mints a hail-mail row from the env defaults on the first send.
 
-**Managed cloud**: the website provisions each org's hail-mail row at signup (calling `POST /email-domains` with prefixes derived from the org slug + user identity). Org admins then change the visible address through the console, which writes via `PATCH /email-domains/{id}`. The env vars provide deploy-time defaults but rarely surface to tenants directly.
+**Managed cloud**: the website provisions the hail-mail row of each org at signup. It calls `POST /email-domains` with prefixes derived from the org slug and the user identity. Org admins then change the visible address through the console, which writes via `PATCH /email-domains/{id}`. The env vars provide deploy-time defaults but rarely surface to tenants directly.
 
 ## 7. Custom (tenant) domains
 
@@ -128,7 +128,7 @@ The response returns the full DNS record set to publish:
   send.acme.com  TXT      "v=spf1 include:amazonses.com ~all"
   ```
 
-After publishing all of them, the tenant calls `POST /email-domains/{id}/verify` to re-poll SES for **both** DKIM and MAIL FROM status.
+After the tenant publishes all records, the tenant calls `POST /email-domains/{id}/verify` to re-poll SES for **both** the DKIM status and the MAIL FROM status.
 
 ```bash
 hail email domain register --kind custom --domain acme.com
@@ -137,7 +137,7 @@ hail email domain verify <id>
 # → re-polls SES; flips the row to verified once the records are live
 ```
 
-> Inbound on a custom domain: once the row is `verified`, enabling inbound (`forward_to` and/or a webhook) lets it receive — matched by identity, so each receiving domain yields its own inbound row + webhook. Receiving still relies on the operator's region-wide SES receipt rule (§10).
+> Inbound on a custom domain: after the row is `verified`, enable inbound (`forward_to` and/or a webhook) to receive mail. Matching is by identity, so each receiving domain yields its own inbound row + webhook. Receiving still relies on the operator's region-wide SES receipt rule (§10).
 
 ## 8. Send
 
@@ -161,14 +161,14 @@ curl -X POST $HAIL_API_URL/emails \
 The `from` field is optional. Resolution order:
 
 1. Explicit `from` — must match a `verified` email_domain row owned by the caller's org.
-2. First verified org-owned domain (ordered by `created_at`, so the default sender stays stable as more get added).
-3. Auto-minted hail-mail row, if `HAIL_MAIL_BASE_DOMAIN` and prefixes are configured.
+2. The first verified org-owned domain (ordered by `created_at`, so the default sender stays stable when you add more domains).
+3. The auto-minted hail-mail row, if `HAIL_MAIL_BASE_DOMAIN` and the prefixes are configured.
 
-If none of those resolve, the call returns `503` pointing at how to register a domain.
+If none of these resolve, the call returns `503` with instructions to register a domain.
 
 ## 8a. Attachments
 
-Upload files once and attach them to as many sends as you like. File size limit is 10MB per upload; total message size (including all attachments) is capped at SES's 10MB raw-message limit.
+Upload a file once and attach it to as many sends as you want. The file size limit is 10MB per upload. SES caps the total message size (including all attachments) at its 10MB raw-message limit.
 
 ### Upload a file
 
@@ -198,7 +198,7 @@ curl -X POST $HAIL_API_URL/emails \
   }'
 ```
 
-You can attach the same uploaded file to multiple sends without re-uploading. CLI shortcut — upload and attach in one step:
+You can attach the same uploaded file to multiple sends without a new upload. CLI shortcut — upload and attach in one step:
 
 ```bash
 hail email send --to alice@example.com --subject "Invoice" --body "See attached." --attach invoice.pdf
@@ -206,27 +206,27 @@ hail email send --to alice@example.com --subject "Invoice" --body "See attached.
 
 ### Lifecycle
 
-Unused uploads (not attached to any send) are garbage-collected 24 hours after upload. Once attached to a send, the file is retained indefinitely and reusable across as many messages as you want.
+Hail garbage-collects unused uploads (not attached to any send) 24 hours after upload. After you attach the file to a send, Hail retains it indefinitely. You can reuse it across as many messages as you want.
 
-## 9. What v1 doesn't do
+## 9. What v1 does not do
 
-Skip these until later milestones — they're called out so you don't reach for SES features that aren't wired yet:
+Skip these until later milestones. This list names them so that you do not use SES features that are not wired yet:
 
-- **Templates** — the API takes raw `body_text` / `body_html`. SES templates are a v2 ask.
+- **Templates** — the API takes raw `body_text` / `body_html`. SES templates are a v2 request.
 - **Cloud-agnostic inbound** — the SMTP listener is stubbed at [`docs/setup/smtp-inbound.md`](smtp-inbound.md); inbound currently runs on AWS only.
 
 ## 10. Inbound email
 
-Receiving mail at `<user>+<org>@<HAIL_MAIL_BASE_DOMAIN>` requires four things:
+To receive mail at `<user>+<org>@<HAIL_MAIL_BASE_DOMAIN>`, you need four things:
 
-1. An MX record on `mail.hail.so` pointing at SES inbound.
-2. An S3 bucket SES can write raw MIME into.
+1. An MX record on `mail.hail.so` that points at SES inbound.
+2. An S3 bucket that SES can write raw MIME into.
 3. A SES Receipt Rule that writes the object and invokes a Lambda.
 4. A small Lambda that signs the SES event and POSTs it to Hail.
 
-Provisioning is automated by a Terragrunt wrapper at `infra/terragrunt.hcl`
+A Terragrunt wrapper at `infra/terragrunt.hcl` automates provisioning
 around the bare Terraform module in `infra/terraform/`. The wrapper
-configures an S3-backed remote state with a DynamoDB lock table and
+configures an S3-backed remote state with a DynamoDB lock table. It
 pulls every input from the repo's `.env` — no parallel `tfvars` file.
 
 ### 10.1 Terragrunt apply
@@ -243,36 +243,36 @@ terragrunt plan                # `run_cmd`; no manual export step.
 terragrunt apply
 ```
 
-One-time bootstrap per AWS account before the first `terragrunt init`:
-the state bucket + lock table don't auto-create. See the comment block
+Do a one-time bootstrap per AWS account before the first `terragrunt init`:
+the state bucket + lock table do not auto-create. Refer to the comment block
 at the top of [`infra/terragrunt.hcl`](../../infra/terragrunt.hcl) for
-the AWS CLI one-liners, and [`docs/operations.md`](../operations.md) →
+the AWS CLI one-liners. Refer to [`docs/operations.md`](../operations.md) →
 "Inbound email rollout → Stage 4" for the full sequence.
 
 Outputs:
 
 - `inbound_mx_record` — publish at DNS for `HAIL_MAIL_BASE_DOMAIN`.
-- `inbound_bucket` — this is `${HAIL_MAIL_NAME_PREFIX}-mail`; set `HAIL_MAIL_NAME_PREFIX` in the API `.env` to match the Terraform `name_prefix` var (not settable directly — there is no `HAIL_MAIL_BUCKET` var).
+- `inbound_bucket` — this is `${HAIL_MAIL_NAME_PREFIX}-mail`. Set `HAIL_MAIL_NAME_PREFIX` in the API `.env` to match the Terraform `name_prefix` var. The bucket name is not settable directly — there is no `HAIL_MAIL_BUCKET` var.
 - `activate_command` — the `aws sesv2 set-active-receipt-rule-set ...` to run once.
 
-The bare Terraform module at `infra/terraform/` is provider-vanilla and
-still works with `terraform apply -var=...` if you'd prefer to skip
-Terragrunt.
+The bare Terraform module at `infra/terraform/` is provider-vanilla. If
+you prefer to skip Terragrunt, it still works with
+`terraform apply -var=...`.
 
 ### 10.2 Activate the receipt rule set (manual)
 
 SES has **one active receipt rule set per region per AWS account.** The module
-creates the rule set but does **not** activate it (activation is destructive when
-an account already has another rule set active).
+creates the rule set but does **not** activate it. If an account already has
+another rule set active, activation is destructive.
 
 - **Greenfield AWS account**: run the `activate_command` output verbatim.
 - **Account with existing rules**: import the existing rule set into Terraform
-  state and merge Hail's rule into it, or skip the module's rule resource and
-  add Hail's rule manually via the AWS console.
+  state and merge Hail's rule into it. As an alternative, skip the module's rule
+  resource and add Hail's rule manually via the AWS console.
 
 ### 10.3 Publish the MX record
 
-At your DNS provider, publish what the Terraform output prints, e.g.:
+At your DNS provider, publish what the Terraform output prints, for example:
 
 ```
 mail.hail.so  MX  10  inbound-smtp.us-east-1.amazonaws.com
@@ -295,15 +295,15 @@ curl "$HAIL_API_URL/emails?direction=inbound" \
   -H "Authorization: Bearer $HAIL_API_KEY"
 ```
 
-Or, using the Python SDK:
+Or, with the Python SDK:
 
 ```python
 emails = await client.emails.list(direction="inbound")
 ```
 
 If the API is down beyond the Lambda's async retries, failed deliveries land in
-the `<name_prefix>-ingest-dlq` SQS queue (`ingest_dlq_url` terraform output) —
-replay by re-driving each message's body at `POST /internal/ses-events`; the raw
+the `<name_prefix>-ingest-dlq` SQS queue (`ingest_dlq_url` terraform output). To
+replay, re-drive each message's body at `POST /internal/ses-events`. The raw
 MIME is still in S3.
 
 ## Delivery & engagement events
@@ -311,7 +311,7 @@ MIME is still in S3.
 Outbound sends carry the SES configuration set named by
 `HAIL_SES_CONFIGURATION_SET` (Terraform default: `hail-events`). SES
 publishes Delivery / Bounce / Complaint / Reject / DeliveryDelay / Open /
-Click events to SNS; the ingest Lambda relays them to
+Click events to SNS. The ingest Lambda relays them to
 `POST /internal/ses-events`, which records them in `email_events`,
 advances `emails.status`, and fans out webhooks.
 
@@ -330,13 +330,13 @@ hail email stats --from 2026-06-01T00:00:00Z --bucket day
 Notes:
 
 - Open/Click tracking rewrites links through the default SES tracking
-  domain. A custom tracking domain is not yet supported.
-- Open counts are approximate (image-proxying mail clients inflate them).
-- Events for mail sent outside Hail from the same SES account are
-  acknowledged and dropped (`status: unmatched` in the API log).
-- Forwarded inbound mail (see below) is re-sent as normal outbound — it
-  carries the config set and writes a synthetic `sent` event, so it counts
-  in `/emails/stats` like any other send.
+  domain. Hail does not yet support a custom tracking domain.
+- Open counts are approximate (mail clients that proxy images inflate them).
+- Hail acknowledges and drops events for mail sent outside Hail from the
+  same SES account (`status: unmatched` in the API log).
+- Hail re-sends forwarded inbound mail (refer to §10.5) as normal outbound.
+  It carries the config set and writes a synthetic `sent` event, so it
+  counts in `/emails/stats` like any other send.
 
 ### 10.5 Forwarding and webhooks
 
@@ -358,19 +358,20 @@ curl -X PATCH $HAIL_API_URL/email-domains/$DOMAIN_ID \
 For org-wide multi-event delivery (firehose pattern):
 
 ```bash
-hail webhooks create \
-  --url https://hooks.acme.com/all \
-  --events email.received,email.bounced,email.complained
+curl -X POST $HAIL_API_URL/webhooks \
+  -H "Authorization: Bearer $HAIL_API_KEY" \
+  -d '{"target_url":"https://hooks.acme.com/all","event_types":["email.received","email.bounced","email.complained"]}'
 ```
 
 ### 10.6 Webhook secrets at rest
 
-Webhook signing secrets are **encrypted at rest** with a deployment-scoped
+Hail encrypts webhook signing secrets **at rest** with a deployment-scoped
 [Fernet](https://cryptography.io/en/latest/fernet/) key
 ([`core/hailhq/core/secret_cipher.py`](../../core/hailhq/core/secret_cipher.py)).
 The worker decrypts on each delivery, so deliveries survive API restarts and
 work across multi-process deployments. If `HAIL_WEBHOOK_SECRET_KEY` is unset,
-webhook creation returns `500` — generate and set it before enabling webhooks:
+webhook creation returns `500`. Generate and set the key before you enable
+webhooks:
 
 ```bash
 # Generate a key (run once; store in .env, never commit). Run inside the

--- a/docs/setup/livekit-cloud.md
+++ b/docs/setup/livekit-cloud.md
@@ -1,12 +1,12 @@
 # LiveKit Cloud
 
-LiveKit Cloud handles media (SIP bridge + WebRTC) in v1. Self-hosted SFU is a later milestone.
+LiveKit Cloud supplies the media (SIP bridge + WebRTC) in v1. A self-hosted SFU is a later milestone.
 
 ## 1. Project + keys
 
 1. Sign up at [cloud.livekit.io](https://cloud.livekit.io).
 2. Create a project.
-3. From **Settings → Keys**, copy into `.env`:
+3. From **Settings → Keys**, copy these values into `.env`:
    - `LIVEKIT_URL` — `wss://<project>-<region>.livekit.cloud`
    - `LIVEKIT_API_KEY`
    - `LIVEKIT_API_SECRET`
@@ -14,11 +14,11 @@ LiveKit Cloud handles media (SIP bridge + WebRTC) in v1. Self-hosted SFU is a la
 ## 2. SIP inbound trunk
 
 1. **SIP → Inbound Trunks → Create**.
-2. Allow calls from your Twilio SIP trunk (IP/user auth per your Twilio config).
-3. Add a **Dispatch Rule** routing incoming calls to a per-call `individual` room.
+2. Allow calls from your Twilio SIP trunk. Use the IP/user auth that matches your Twilio configuration.
+3. Add a **Dispatch Rule** that routes incoming calls to a per-call `individual` room.
 
 ## 3. Voicebot worker
 
-`docker compose up voicebot` — on startup, registers with LiveKit as a dispatchable agent. The Hail API dispatches it into a room per call.
+Run `docker compose up voicebot`. At startup, the worker registers with LiveKit as a dispatchable agent. The Hail API dispatches it into a room for each call.
 
-Full flow: [Architecture](../architecture.md).
+For the full flow, refer to [Architecture](../architecture.md).

--- a/docs/setup/mcp.md
+++ b/docs/setup/mcp.md
@@ -1,78 +1,86 @@
 # MCP clients
 
-Hail exposes MCP as a **remote server**. Cloud is OAuth: paste the URL into your client, click Allow in the browser, your agent gets call/sms/mail tools. No keys to manage, no install.
+Hail exposes MCP as a **remote server**. Hail Cloud uses OAuth. Paste the URL into your client. Click Allow in the browser. Your agent then gets the call/sms/mail tools. There are no keys to manage and no installation.
 
-> Looking for the easy onboarding path? The [client picker on hail.so/mcp](https://hail.so/mcp) has copy-paste setup for the 8 most common clients (Claude.ai, ChatGPT, Cursor, Gemini, …). This page is the technical reference behind those snippets.
+> For the easy onboarding path, refer to the [client picker on hail.so/mcp](https://hail.so/mcp). It has copy-paste setup for the 8 most common clients (Claude.ai, ChatGPT, Cursor, Gemini, …). This page is the technical reference behind those snippets.
 
 ## URL
 
 - **Hail Cloud**: `https://mcp.hail.so`
-- **Self-hosted**: `http://<your-host>:8081` — see [Self-host](#self-host) below.
+- **Self-hosted**: `http://<your-host>:8081` — refer to [Self-host](#self-host) below.
 
-The Streamable HTTP transport serves the MCP root path; no `/mcp` suffix, no SSE.
+The Streamable HTTP transport serves the MCP root path. There is no `/mcp` suffix and no SSE.
 
-> For web-based clients (Claude.ai, ChatGPT) the URL must be reachable from the client's servers — public DNS + TLS. Tunnel a self-hosted instance via cloudflared / tailscale funnel if you want it reachable to web clients.
+> For web-based clients (Claude.ai, ChatGPT), the URL must be reachable from the client's servers — public DNS + TLS. If you want web clients to reach a self-hosted instance, tunnel it via cloudflared / tailscale funnel.
 
 ## Tools
 
-The server exposes ten tools. Schemas (args, validation, return shapes) are the source of truth — see [`mcp/hailhq/mcp/tools.py`](../../mcp/hailhq/mcp/tools.py).
+The server exposes 18 tools. Schemas (args, validation, return shapes) are the source of truth — refer to [`mcp/hailhq/mcp/tools.py`](../../mcp/hailhq/mcp/tools.py).
 
 | Tool                      | Does                                                    |
 | ------------------------- | ------------------------------------------------------- |
 | `place_call`              | Originate an outbound phone call.                       |
-| `send_email`              | Send an outbound email (supports `attachment_ids`).     |
-| `upload_email_attachment` | Upload a file, get back a reusable id.                  |
 | `get_call`                | Fetch the current state of one call.                    |
 | `list_calls`              | List recent calls (cursor-paginated).                   |
+| `send_sms`                | Send an outbound SMS (recipient consent is required).   |
+| `get_sms`                 | Fetch the current state of one SMS.                     |
+| `list_sms`                | List recent SMS messages (cursor-paginated).            |
+| `send_email`              | Send an outbound email (supports `attachment_ids`).     |
+| `upload_email_attachment` | Upload a file, get back a reusable id.                  |
 | `get_email`               | Fetch one email's full record (body + inbound headers). |
 | `list_emails`             | List emails (`direction="inbound"` for replies).        |
 | `get_email_raw`           | Presigned URL for an inbound email's raw MIME.          |
 | `get_email_attachment`    | Presigned URL for one inbound attachment.               |
+| `get_email_events`        | Page through one email's event history.                 |
+| `get_email_stats`         | Aggregate email counts for a time window.               |
 | `get_events`              | Page through the event stream.                          |
+| `list_contacts`           | List the org's contacts (members + manual contacts).    |
+| `lookup_contact`          | Find one contact by name, email, or phone fragment.     |
+| `create_contact`          | Add a manual contact.                                   |
 
 ## Claude.ai (web)
 
 1. **Settings → Connectors → Add custom connector**
 2. Server URL: `https://mcp.hail.so`
-3. Save. Claude prompts you to authorize on first use; click **Allow** in the browser tab that opens.
+3. Save. Claude prompts you to authorize on first use. Click **Allow** in the browser tab that opens.
 
-That's it. No API key field.
+That is all. There is no API key field.
 
 ## ChatGPT (web)
 
-Custom MCP connectors live behind Developer Mode on ChatGPT today:
+Custom MCP connectors are behind Developer Mode on ChatGPT today:
 
 1. **Settings → Connectors → Advanced → Developer mode**
 2. **Create** → paste `https://mcp.hail.so`
-3. Save. ChatGPT walks you through the OAuth consent on first call.
+3. Save. ChatGPT guides you through the OAuth consent on the first call.
 
 ## Other clients
 
-The [client picker](https://hail.so/mcp) has setup snippets for Cursor, Gemini, Windsurf, Copilot, Zed, Raycast, and Claude Desktop. All follow the same shape: paste URL, click Allow.
+The [client picker](https://hail.so/mcp) has setup snippets for Cursor, Gemini, Windsurf, Copilot, Zed, Raycast, and Claude Desktop. All follow the same shape: paste the URL, then click Allow.
 
 ## Authorized apps
 
-Each cloud client you connect appears as a row at [`hail.so/console/apps`](https://hail.so/console/apps). Revoke deletes the consent + every active access and refresh token for that client; the client's next tool call returns 401 and re-runs OAuth from scratch.
+Each cloud client that you connect appears as a row at [`hail.so/console/apps`](https://hail.so/console/apps). Revoke deletes the consent and every active access and refresh token for that client. The client's next tool call returns 401 and runs OAuth again from the start.
 
-Access tokens last 30 days, refresh tokens 180. In practice you'll re-authorize each client roughly every six months — the consent screen pops, you click **Allow**, and the client resumes.
+Access tokens last 30 days, and refresh tokens last 180 days. In practice, you authorize each client again approximately every six months. The consent screen opens, you click **Allow**, and the client continues.
 
 ## Self-host
 
-Self-hosters skip OAuth — set `HAIL_API_KEY` and send it as a bearer:
+Self-hosted deployments do not use OAuth. Set `HAIL_API_KEY` and send it as a bearer token:
 
 ```sh
 curl -H "Authorization: Bearer ${HAIL_API_KEY}" http://localhost:8081/
 ```
 
-The MCP service picks its auth mode from env at boot — see the [MCP modes table in the operations runbook](../operations.md#mcp-modes) for the full env-var contract (`HAIL_AUTH_URL` for cloud, `HAIL_API_KEY` for self-host, mutually exclusive).
+The MCP service selects its auth mode from env at boot. For the full env-var contract, refer to the [MCP modes table in the operations runbook](../operations.md#mcp-modes) (`HAIL_AUTH_URL` for cloud, `HAIL_API_KEY` for self-host, mutually exclusive).
 
 ## Why remote-only (no stdio / no PyPI install)
 
-We ship one MCP distribution — a remote HTTP endpoint, bundled with every Hail deploy. We deliberately do **not** publish a stdio MCP server on PyPI. Reasons:
+We release one MCP distribution: a remote HTTP endpoint. It is bundled with every Hail deploy. We deliberately do **not** publish a stdio MCP server on PyPI. The reasons:
 
-1. **Web UIs can't run stdio servers.** Claude.ai's MCP Connectors and ChatGPT's Custom Connectors only accept remote URLs — they can't spawn local processes from a browser.
-2. **Every terminal client also accepts a remote URL.** Claude Code, Claude Desktop, Cursor, Zed all connect to a URL. The URL flow works universally; stdio works only for a subset.
-3. **Stdio fragments distribution.** Two artifacts (PyPI stdio wrapper + HTTP service) mean two versions to keep in sync, two install paths, two failure modes.
-4. **Install friction.** Stdio requires Python + pip/uv on the user's dev machine. Remote HTTP requires nothing — paste a URL.
+1. **Web UIs cannot run stdio servers.** Claude.ai's MCP Connectors and ChatGPT's Custom Connectors accept only remote URLs. They cannot start local processes from a browser.
+2. **Every terminal client also accepts a remote URL.** Claude Code, Claude Desktop, Cursor, and Zed all connect to a URL. The URL flow works for all clients. Stdio works only for a subset.
+3. **Stdio fragments distribution.** Two artifacts (PyPI stdio wrapper + HTTP service) cause two versions to keep in sync, two install paths, and two failure modes.
+4. **Installation friction.** Stdio requires Python + pip/uv on the user's dev machine. Remote HTTP requires nothing. You only paste a URL.
 
-If a restricted client ever needs stdio, we'll ship a thin stdio-to-HTTP proxy on PyPI (≈50 LOC).
+If a restricted client ever needs stdio, we will release a thin stdio-to-HTTP proxy on PyPI (approximately 50 LOC).

--- a/docs/setup/smtp-inbound.md
+++ b/docs/setup/smtp-inbound.md
@@ -2,10 +2,10 @@
 
 The `SmtpInboundProvider` interface exists in
 [`core/hailhq/core/providers/email/inbound/smtp.py`](../../core/hailhq/core/providers/email/inbound/smtp.py)
-but is not implemented. It is the cloud-agnostic / OSS-only path,
-deferred to a follow-up milestone.
+but is not implemented. It is the cloud-agnostic / OSS-only path.
+We defer it to a follow-up milestone.
 
-When it lands, this page will describe:
+When it is released, this page will describe:
 
 - the `mailbot/` container (`aiosmtpd`-backed), parallel to `voicebot/`
 - listen ports + TLS configuration
@@ -13,9 +13,9 @@ When it lands, this page will describe:
   DMARC verification and flood resistance
 - self-host quickstart
 
-In the meantime, use the SES-backed inbound path documented in
+Until then, use the SES-backed inbound path documented in
 [`docs/setup/aws-ses.md`](aws-ses.md). If you must avoid AWS, file an
-issue tracking your need so the SMTP listener gets prioritized.
+issue that tracks your need. Then we can give the SMTP listener priority.
 
 ## References
 

--- a/docs/setup/twilio.md
+++ b/docs/setup/twilio.md
@@ -1,46 +1,48 @@
 # Twilio
 
-You need a Twilio account, a phone number, and a SIP trunk bridged to LiveKit Cloud.
+You need a Twilio account, a phone number, and a SIP trunk that bridges to LiveKit Cloud.
 
 ## 1. Account credentials
 
-From [console.twilio.com](https://console.twilio.com):
+From [console.twilio.com](https://console.twilio.com), copy these values:
 
 - `TWILIO_ACCOUNT_SID` — starts with `AC…`
-- `TWILIO_AUTH_TOKEN` — click "Show" to reveal
+- `TWILIO_AUTH_TOKEN` — click "Show" to see the value
 
 Put them in `.env`.
 
 ## 2. Phone number
 
-**Phone Numbers → Buy a number** → pick a number with Voice capability. Note the E.164 format (`+1…`).
+Go to **Phone Numbers → Buy a number**. Select a number with the Voice capability. Note the E.164 format (`+1…`).
 
 ## 3. SIP trunk
 
 1. **Elastic SIP Trunking → Trunks → Create new Trunk**.
 2. **Origination**: add the URI from [LiveKit Cloud setup](./livekit-cloud.md).
 3. **Numbers**: attach the phone number from step 2.
-4. Put the Termination URI (e.g. `your-trunk.pstn.twilio.com`) in `.env` as `TWILIO_SIP_TRUNK_DOMAIN`.
+4. Put the Termination URI (for example, `your-trunk.pstn.twilio.com`) in `.env` as `TWILIO_SIP_TRUNK_DOMAIN`.
 
 ## 4. Inbound SMS & opt-out
 
 Point the number's **A Message Comes In** webhook at
 `https://<your-api-host>/sms/inbound` (HTTP POST). Hail verifies Twilio's
-`X-Twilio-Signature` against `HAIL_API_URL`, so that value must match the public
-URL Twilio posts to.
+`X-Twilio-Signature` against `HAIL_API_URL`. Make sure that this value matches
+the public URL that Twilio posts to.
 
-**Recognized keywords** (matched on the message body, case-insensitive):
+**Recognized keywords** (Hail matches them on the message body, case-insensitive):
 
 - Opt out (STOP): `STOP`, `STOPALL`, `UNSUBSCRIBE`, `CANCEL`, `END`, `QUIT`
 - Opt in (START): `START`, `YES`, `UNSTOP`
 - Help: `HELP`, `INFO`
 
-Hail records opt-outs in its own suppression list (checked before every send)
-regardless of Twilio configuration.
+Hail records opt-outs in its own suppression list, regardless of the Twilio
+configuration. Hail checks this list before every send.
 
-**Opt-out replies:** By default **Twilio** auto-replies to STOP/HELP/START and
-carrier-blocks opted-out numbers. Leave `HAIL_SMS_COMPLIANCE_REPLIES_ENABLED=false`
-in that setup. To have **Hail** own the replies (e.g. a non-Twilio provider, or a
-custom keyword experience), first disable Twilio's default opt-out handling — this
-is **account-wide and requires a Twilio Support request; there is no API for it** —
-then set `HAIL_SMS_COMPLIANCE_REPLIES_ENABLED=true`.
+**Opt-out replies:** By default, **Twilio** replies automatically to
+STOP/HELP/START and carrier-blocks opted-out numbers. In that setup, keep
+`HAIL_SMS_COMPLIANCE_REPLIES_ENABLED=false`. If you want **Hail** to own the
+replies (for example, a non-Twilio provider, or a custom keyword experience),
+do the two steps that follow. **Caution: if you disable Twilio's default
+opt-out handling, the change is account-wide and requires a Twilio Support
+request; there is no API for it.** First, disable Twilio's default opt-out
+handling. Then set `HAIL_SMS_COMPLIANCE_REPLIES_ENABLED=true`.

--- a/docs/setup/vm-deploy.md
+++ b/docs/setup/vm-deploy.md
@@ -1,6 +1,6 @@
 # VM deployment
 
-Self-host Hail on a single Ubuntu VM behind HTTPS, with GitHub Actions deploying every commit on `main`. Database is **managed** (Neon, Supabase, RDS, whatever you like); the VM only runs the stateless services.
+Self-host Hail on one Ubuntu VM behind HTTPS. GitHub Actions deploys every commit on `main`. The database is **managed** (Neon, Supabase, RDS, or your choice). The VM runs only the stateless services.
 
 ```
         ┌───────────────────────────────────────────────────────┐
@@ -22,17 +22,17 @@ Self-host Hail on a single Ubuntu VM behind HTTPS, with GitHub Actions deploying
                                   └──▶ managed Postgres (Neon / RDS / …)
 ```
 
-Voicebot is a worker — it dials out to LiveKit Cloud and needs no inbound port. Only `api.<domain>` and `mcp.<domain>` are public.
+The voicebot is a worker. It dials out to LiveKit Cloud and needs no inbound port. Only `api.<domain>` and `mcp.<domain>` are public.
 
 ## Prerequisites
 
-- An Ubuntu 22.04+ VM with a public IPv4 address. 2 vCPU / 4 GB RAM is enough to start.
-- A managed Postgres reachable from the VM. Grab its connection string (typically `postgresql://USER:PASS@HOST/DB?sslmode=require`).
-- A domain you control. You'll point `api.<domain>` and `mcp.<domain>` at the VM's IP.
+- An Ubuntu 22.04+ VM with a public IPv4 address. 2 vCPU / 4 GB RAM is sufficient to start.
+- A managed Postgres that the VM can reach. Copy its connection string (typically `postgresql://USER:PASS@HOST/DB?sslmode=require`).
+- A domain that you control. You point `api.<domain>` and `mcp.<domain>` at the VM's IP.
 
 ## 1. Prepare the VM
 
-SSH in as a sudo-capable user and run:
+Connect with SSH as a sudo-capable user. Then run:
 
 ```bash
 # Docker engine + compose plugin.
@@ -54,20 +54,20 @@ git clone https://github.com/hail-hq/hail /opt/hail
 cd /opt/hail
 ```
 
-If your fork is private, clone via SSH (`git@github.com:<owner>/hail.git`) and authorise a deploy key on the VM — the CI deploy step runs `git fetch origin` on every push and will 403 otherwise.
+If your fork is private, clone via SSH (`git@github.com:<owner>/hail.git`) and authorize a deploy key on the VM. The CI deploy step runs `git fetch origin` on every push and gets a 403 error otherwise.
 
-> **UFW + Docker caveat:** Docker writes its own iptables rules that _bypass_ UFW. The compose file already binds api/mcp/minio ports to `127.0.0.1`, so external traffic can't reach them even though UFW would allow it locally. If you add any new published port, keep the `127.0.0.1:` prefix unless you intend it to be public.
+> **UFW + Docker caveat:** Docker writes its own iptables rules that _bypass_ UFW. The compose file binds the api/mcp/minio ports to `127.0.0.1`. Thus external traffic cannot reach them, even if UFW permits it locally. If you add a new published port, keep the `127.0.0.1:` prefix, unless you intend the port to be public.
 
 ## 2. DNS
 
-Create two A records (or one wildcard) pointing at the VM:
+Create two A records (or one wildcard) that point at the VM:
 
 | record         | type | value     |
 | -------------- | ---- | --------- |
 | `api.<domain>` | A    | _VM IPv4_ |
 | `mcp.<domain>` | A    | _VM IPv4_ |
 
-Verify before continuing — Caddy will fail to mint Let's Encrypt certs if either name doesn't resolve to the VM yet.
+If either name does not resolve to the VM yet, Caddy cannot get Let's Encrypt certs. Verify the records before you continue.
 
 ```bash
 dig +short api.<domain>
@@ -83,16 +83,16 @@ cp .env.example .env
 
 Edit `/opt/hail/.env` and fill in:
 
-- All provider secrets (Twilio, LiveKit, Deepgram, Cartesia (+ optional ElevenLabs fallback), at least one LLM key — see `docs/setup/`).
+- All provider secrets (Twilio, LiveKit, Deepgram, Cartesia (+ optional ElevenLabs fallback), at least one LLM key — refer to `docs/setup/`).
 - `HAIL_API_KEY` — generate with `openssl rand -base64 32 | tr -d '/+=' | head -c 40 | sed 's/^/hk_/'`.
 - `DATABASE_URL` — the managed Postgres connection string. Most providers require `?sslmode=require`.
-- `HAIL_DOMAIN` — your apex (e.g. `hail.example.com`). Both `api.` and `mcp.` subdomains derive from it.
+- `HAIL_DOMAIN` — your apex (for example, `hail.example.com`). Both `api.` and `mcp.` subdomains derive from it.
 
-`.env` is already gitignored — never commit it.
+The `.env` file is already gitignored. Never commit it.
 
 ## 4. First boot
 
-The compose invocations below are verbose because the prod overlay isn't the default — drop a shell alias into the deploy user's `~/.bashrc` if you'll be on the VM often:
+The compose invocations below are verbose because the prod overlay is not the default. If you use the VM often, add a shell alias to the deploy user's `~/.bashrc`:
 
 ```bash
 echo "alias dcprod='docker compose -f /opt/hail/docker-compose.yml -f /opt/hail/docker-compose.prod.yml'" >> ~/.bashrc
@@ -110,15 +110,15 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 docker compose -f docker-compose.yml -f docker-compose.prod.yml ps
 ```
 
-If you'd rather skip the manual GHCR login, trigger the GitHub Actions workflow (step 6) first — its `docker login` step writes credentials the VM can reuse.
+To skip the manual GHCR login, trigger the GitHub Actions workflow (step 6) first. Its `docker login` step writes credentials that the VM can use again.
 
-Seed your first phone number using the snippet in `docs/operations.md` → _Self-host: first-run setup_, swapping `docker compose exec postgres …` for `psql "$DATABASE_URL" -c …`.
+Seed your first phone number with the snippet in `docs/operations.md` → _Self-host: first-run setup_. Replace `docker compose exec postgres …` with `psql "$DATABASE_URL" -c …`.
 
-Hit `https://api.<domain>/healthz` from your laptop — you should see `{"status":"ok"}`. Caddy mints a Let's Encrypt cert on first request; the first call after boot can take 10–20 seconds.
+Send a request to `https://api.<domain>/healthz` from your laptop. You must see `{"status":"ok"}`. Caddy gets a Let's Encrypt cert on the first request. The first call after boot can take 10–20 seconds.
 
 ## 5. Configure GitHub Actions
 
-Under **Settings → Secrets and variables → Actions**:
+Set these under **Settings → Secrets and variables → Actions**:
 
 | name                     | type   | value                                                 |
 | ------------------------ | ------ | ----------------------------------------------------- |
@@ -128,7 +128,7 @@ Under **Settings → Secrets and variables → Actions**:
 | `DEPLOY_SSH_PORT`        | secret | _(optional)_ SSH port; omit to default to 22          |
 | `DEPLOY_PATH`            | _var_  | _(optional)_ repo checkout path; defaults `/opt/hail` |
 
-Generate a deploy key dedicated to CI rather than reusing a personal one:
+Generate a deploy key dedicated to CI. Do not use a personal key again:
 
 ```bash
 ssh-keygen -t ed25519 -f hail-deploy -C "github-actions@hail" -N ""
@@ -136,18 +136,18 @@ ssh-keygen -t ed25519 -f hail-deploy -C "github-actions@hail" -N ""
 # In GitHub: paste hail-deploy (the private key) into DEPLOY_SSH_PRIVATE_KEY.
 ```
 
-Optionally create a `production` GitHub Environment (Settings → Environments → New → `production`) with required reviewers if every deploy should gate on a manual approval — the deploy job targets `environment: production` and inherits any protection rules automatically.
+If every deploy must gate on a manual approval, create a `production` GitHub Environment (Settings → Environments → New → `production`) with required reviewers. The deploy job targets `environment: production` and inherits any protection rules automatically.
 
-GHCR push uses the workflow's `GITHUB_TOKEN` (already scoped `packages: write`); no extra PAT needed.
+The GHCR push uses the workflow's `GITHUB_TOKEN` (already scoped `packages: write`). No extra PAT is necessary.
 
 ## 6. Trigger the first deploy
 
 Push any commit to `main`, or run **Actions → Deploy → Run workflow** in the GitHub UI. The workflow:
 
 1. Builds `api`, `voicebot`, `mcp` images in parallel and pushes both `sha-<commit>` and `latest` to ghcr.io/hail-hq/hail-\*.
-2. SSHes the VM, fetches the new commit, runs `alembic upgrade head`, and `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d` rolls the containers onto the freshly-pulled `:latest`.
+2. Connects to the VM with SSH, fetches the new commit, and runs `alembic upgrade head`. Then `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d` rolls the containers onto the newly pulled `:latest`.
 
-`concurrency: deploy-prod` means simultaneous merges queue rather than race.
+`concurrency: deploy-prod` makes simultaneous merges queue. They do not race.
 
 ## Day-2
 
@@ -161,17 +161,17 @@ Push any commit to `main`, or run **Actions → Deploy → Run workflow** in the
   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d api
   ```
 
-  Repeat per service. The cleanest rollback is still to revert the commit on `main` and let CI redeploy.
+  Repeat for each service. The cleanest rollback is to revert the commit on `main` and let CI deploy again.
 
 - **Update Caddy config**: edit `/opt/hail/Caddyfile`, then `docker compose -f docker-compose.yml -f docker-compose.prod.yml exec caddy caddy reload --config /etc/caddy/Caddyfile`.
-- **Reclaim disk**: each deploy leaves the previous `sha-<commit>` image behind. Prune monthly with `docker image prune -f` (safe — only removes images with no container reference).
+- **Reclaim disk**: each deploy leaves the previous `sha-<commit>` image behind. Prune monthly with `docker image prune -f`. This is safe; it removes only images with no container reference.
 
 ## Footguns
 
 | symptom                                                      | fix                                                                                                                                                                                                |
 | ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Caddy logs `tls: no certificates configured` on first start  | DNS hasn't propagated yet, or :80/:443 isn't open. Confirm `dig api.<domain>` returns the VM IP and `sudo ufw status` shows both ports open.                                                       |
+| Caddy logs `tls: no certificates configured` on first start  | DNS has not propagated yet, or :80/:443 is not open. Confirm that `dig api.<domain>` returns the VM IP and `sudo ufw status` shows both ports open.                                                |
 | `docker pull` 401 / "denied" from GHCR                       | The package is private by default. Set its visibility to public under GitHub → Packages → hail-\_ → Package settings, or rely on the workflow's `docker login` step.                               |
 | `permission denied while trying to connect to docker daemon` | The deploy user must be in the `docker` group. Run `sudo usermod -aG docker $USER` on the VM and re-establish the SSH session.                                                                     |
-| Caddy 502s for api.<domain>                                  | Caddy resolves `api` and `mcp` via Compose's internal DNS — all services share the `hail` project network. Don't split the project name across files.                                              |
+| Caddy 502s for api.<domain>                                  | Caddy resolves `api` and `mcp` via Compose's internal DNS — all services share the `hail` project network. Do not split the project name across files.                                             |
 | api/mcp port reachable from the public internet              | A published port without the `127.0.0.1:` prefix bypasses UFW. Check `docker compose -f docker-compose.yml -f docker-compose.prod.yml port api 8080` returns `127.0.0.1:8080`, not `0.0.0.0:8080`. |

--- a/docs/setup/webhooks.md
+++ b/docs/setup/webhooks.md
@@ -1,16 +1,18 @@
 # Webhooks
 
-When mail arrives for an address you've configured, Hail `POST`s a signed JSON
-event to your URL. Verify the `X-Hail-Signature` header against the once-shown
-secret, return any `2xx`, and you're done. A non-2xx (or a timeout) is retried
-on a fixed ladder.
+When a subscribed event occurs — inbound mail or SMS, a delivery report, a
+call outcome — Hail `POST`s a signed JSON event to your URL. Verify the
+`X-Hail-Signature` header against the once-shown secret. Return any `2xx`,
+and you are done. Hail retries a non-2xx response (or a timeout) on a fixed
+ladder.
 
 ## Verify the signature (Python)
 
 The signature is HMAC-SHA256 over `f"{t}.{body}"` — the timestamp from the
 header, a literal `.`, then the **raw request bytes**. This is a runnable
-example; the `assert` passes (the fixture was produced by the real signer in
-[`core/hailhq/core/webhooks.py`](../../core/hailhq/core/webhooks.py)):
+example. The `assert` passes (the real signer in
+[`core/hailhq/core/webhooks.py`](../../core/hailhq/core/webhooks.py) produced
+the fixture):
 
 ```python
 import hashlib, hmac
@@ -52,19 +54,19 @@ function verify(secret, signatureHeader, rawBody) {
 }
 ```
 
-In Express, capture raw bytes with `express.raw({ type: "application/json" })`;
-in Next.js route handlers use `await req.text()` / `req.arrayBuffer()` and pass
+In Express, capture the raw bytes with `express.raw({ type: "application/json" })`.
+In Next.js route handlers, use `await req.text()` / `req.arrayBuffer()` and pass
 those bytes, not `await req.json()`.
 
 ## Headers
 
-Every delivery carries these (see
+Every delivery carries these headers (refer to
 [`core/hailhq/core/webhook_worker.py`](../../core/hailhq/core/webhook_worker.py)):
 
 | Header                | Meaning                                                                                                                     |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `X-Hail-Signature`    | `t=<unix>,v1=<hex hmac_sha256>` — verify this.                                                                              |
-| `X-Hail-Event`        | Event type, e.g. `email.received`.                                                                                          |
+| `X-Hail-Event`        | Event type, for example `email.received`.                                                                                   |
 | `X-Hail-Delivery`     | Unique delivery id (stable across retries; use to dedupe).                                                                  |
 | `X-Hail-Subscription` | Always present — identifies the subscription that produced this delivery.                                                   |
 | `X-Hail-Email-Domain` | Informational: the source email domain for inbound events (when known). Branch on this to route per-domain in your handler. |
@@ -74,9 +76,9 @@ Every delivery carries these (see
 The full set is the `WebhookEventType` enum in
 [`core/hailhq/core/schemas.py`](../../core/hailhq/core/schemas.py):
 
-- **`email.received`** — a message arrived and was accepted.
-- **`email.received.suppressed`** — a message arrived but fan-out/forwarding was
-  held back. `data.reason` is one of `forward_loop`, `forward_rate_limit`,
+- **`email.received`** — a message arrived, and Hail accepted it.
+- **`email.received.suppressed`** — a message arrived, but Hail held back
+  fan-out/forwarding. `data.reason` is one of `forward_loop`, `forward_rate_limit`,
   `inbound_rate_limit`, `insufficient_funds`. One event fires _per reason_
   (a single message can produce more than one suppressed event).
 - **`email.delivered`** — SES accepted the message for delivery.
@@ -86,9 +88,10 @@ The full set is the `WebhookEventType` enum in
 - **`email.opened`** — the recipient opened the message (image tracked, approximate).
 - **`email.clicked`** — the recipient clicked a tracked link.
 - **`email.send_failed`** — an outbound email failed to send.
-- **`sms.received`** — an inbound SMS arrived and was accepted. Delivered through
-  the same signed, retried webhook worker as the email events (`X-Hail-Signature`,
-  `X-Hail-Event`, `X-Hail-Delivery`); the `X-Hail-Email-Domain` header is omitted.
+- **`sms.received`** — an inbound SMS arrived, and Hail accepted it. Hail delivers
+  it through the same signed, retried webhook worker as the email events
+  (`X-Hail-Signature`, `X-Hail-Event`, `X-Hail-Delivery`). Hail omits the
+  `X-Hail-Email-Domain` header.
 - **`sms.delivered`** — the carrier confirmed delivery (requires Twilio delivery receipts).
 - **`sms.undelivered`** — the carrier reported the message was not delivered.
 - **`sms.failed`** — the send failed (transport error or carrier rejection).
@@ -99,14 +102,14 @@ only (no `ringing` or `canceled` events; no data source):
 - **`call.answered`** — the callee picked up (call entered in-progress).
 - **`call.completed`** — the call ended normally.
 - **`call.failed`** — the call failed (setup error, trunk/media failure, or force-closed).
-- **`call.busy`** — the callee was busy or rejected.
+- **`call.busy`** — the callee was busy or rejected the call.
 - **`call.no_answer`** — the callee did not answer.
 
 ## Payload
 
-Hail wraps every event in this envelope (assembled by `build_event_payload` in
-[`webhooks.py`](../../core/hailhq/core/webhooks.py)); the `data` shape comes from
-the event type. Inbound events use [`build_event_data`](../../core/hailhq/core/webhook_fanout.py) for `email.received*`; delivery events use [`build_delivery_event_data`](../../core/hailhq/core/email_delivery_events.py) for the lifecycle events.
+Hail wraps every event in this envelope (`build_event_payload` in
+[`webhooks.py`](../../core/hailhq/core/webhooks.py) assembles it). The `data`
+shape comes from the event type. Inbound events use [`build_event_data`](../../core/hailhq/core/webhook_fanout.py) for `email.received*`. Delivery events use [`build_delivery_event_data`](../../core/hailhq/core/email_delivery_events.py) for the lifecycle events.
 
 **Inbound example** (`email.received`):
 
@@ -194,38 +197,37 @@ presigned S3 URL on access. `email.received.suppressed` carries a trimmed `data`
 }
 ```
 
-The `detail` field varies by event type: `bounced` and `complained` carry SES metadata; `delivered` and `delivery_delayed` carry SES status details; `opened` and `clicked` carry `ip_address` and `user_agent`, with `clicked` adding `link` (the event time is the sibling `occurred_at` field). For `bounced`, the provider-neutral `hard` flag distinguishes hard from soft bounces — only hard bounces move the email to `status=bounced` and count toward `bounced_hard` in `GET /emails/stats`.
+The `detail` field varies by event type. `bounced` and `complained` carry SES metadata. `delivered` and `delivery_delayed` carry SES status details. `opened` and `clicked` carry `ip_address` and `user_agent`; `clicked` adds `link` (the event time is the sibling `occurred_at` field). For `bounced`, the provider-neutral `hard` flag distinguishes hard bounces from soft bounces. Only hard bounces move the email to `status=bounced` and count toward `bounced_hard` in `GET /emails/stats`.
 
 ## Retries
 
-A delivery that doesn't get a `2xx` is retried on this fixed ladder
+Hail retries a delivery that does not get a `2xx` on this fixed ladder
 (`RETRY_SCHEDULE_SECONDS` in [`webhooks.py`](../../core/hailhq/core/webhooks.py)):
 
 ```
 0s → 30s → 2m → 10m → 1h → 6h → 24h
 ```
 
-After the 7th attempt fails the delivery is marked **dead**. When an org-wide
-subscription accrues **50 consecutive dead** deliveries it auto-disables; re-enable
-it by setting its status back to `active`. Replay a single delivery from the
-console or with the CLI:
+After the 7th attempt fails, Hail marks the delivery **dead**. When an org-wide
+subscription accrues **50 consecutive dead** deliveries, it auto-disables. To
+re-enable it, set its status back to `active`. Replay a single delivery from the
+console or through the API:
 
 ```bash
-hail webhooks redeliver <subscription-id> <delivery-id>
+curl -X POST "$HAIL_API_URL/webhooks/<subscription-id>/deliveries/<delivery-id>/redeliver" \
+  -H "Authorization: Bearer $HAIL_API_KEY"
 ```
 
 ## Subscribe
 
-Create a subscription — the signing secret is returned **once** at create:
+Create a subscription. The response returns the signing secret **once**, at create:
 
 ```bash
 POST /webhooks   {"target_url": "https://example.com/hooks/hail",
                   "event_types": ["email.received", "email.received.suppressed"]}
 ```
 
-CLI equivalent: `hail webhooks create`.
-
 The `event_types` enum and request/response schemas are in
 [`openapi/openapi.yaml`](../../openapi/openapi.yaml) (`WebhookSubscriptionCreate`).
-CLI equivalents: `hail webhooks create`, `list`, `deliveries`, `redeliver` — see
-[the CLI reference](../cli.md).
+The CLI has no `webhooks` command group — for the full endpoint list, refer to
+[the CLI reference](../cli.md#webhooks).


### PR DESCRIPTION
Prose converted to Simplified Technical English (active voice, one instruction per sentence, no contractions); code blocks, commands, tables, and links untouched. Also corrects claims verified against the code: SMS/email are inbound+outbound, 18 MCP tools, no CLI webhooks command group (curl instead), nil-UUID self-host sentinel, GHCR image tagging, and adds the missing SMS section to architecture.md and sms/numbers/contacts to cli.md and the README.