### PR TITLE
feat(web): add PostHog analytics to the costs site

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -226,6 +226,16 @@ S3_ACCESS_KEY=
 S3_SECRET_KEY=
 S3_REGION=us-east-1
 
+# ─── Analytics (PostHog — costs site under web/) ─────────────────────────────
+# Read by web/instrumentation-client.ts and web/lib/posthog-server.ts.
+# Use the SAME project and values as hail-website: hail.so rewrites /costs/* to
+# a separate deployment, so hail-website's client script never runs there and
+# those pageviews are otherwise invisible. One project keeps the funnel whole.
+# t.hail.so is a PostHog custom domain, so events post there directly — no
+# reverse-proxy rewrite in web/next.config.ts.
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=https://t.hail.so
+
 # ─── Telephony catalog (acquire allow-list) ──────────────────────────────────
 # Path to costs/telephony.json — the number price/capability catalog the
 # acquire endpoint reads. Defaults to the repo's committed file; the API

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,12 @@ importers:
       next:
         specifier: ^16.2.0
         version: 16.2.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      posthog-js:
+        specifier: ^1.257.2
+        version: 1.407.3
+      posthog-node:
+        specifier: ^4.13.0
+        version: 4.18.0
       react:
         specifier: ^19.2.0
         version: 19.2.6
@@ -389,6 +395,24 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  "@posthog/browser-common@0.2.3":
+    resolution:
+      {
+        integrity: sha512-LJOUcBLLjFOqw6ZZsjrCuojliJHFU/GYeOV88T+lXyePXJQnxFzuAouDtwwHFHtoaaOjfQ0OvDMR7J468Nkomw==,
+      }
+
+  "@posthog/core@1.45.1":
+    resolution:
+      {
+        integrity: sha512-tLtvzomavb2PPWdGYKsusyIzIeL2Px47v348Smibkay7sMy/83TyPk+Ptsp2NdeOgJsbuwSxWkR2+XA0aSCAaA==,
+      }
+
+  "@posthog/types@1.398.0":
+    resolution:
+      {
+        integrity: sha512-sJMkl4k+u8yS/0fjHsKqE9xTdsAh30a2WvgChiptellnVoE0e8QJKFgqOMD2sk8FaEArPdeFklAhXvmENAt3Sg==,
+      }
+
   "@swc/helpers@0.5.15":
     resolution:
       {
@@ -565,6 +589,19 @@ packages:
         integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==,
       }
 
+  "@types/trusted-types@2.0.7":
+    resolution:
+      {
+        integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==,
+      }
+
+  agent-base@6.0.2:
+    resolution:
+      {
+        integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==,
+      }
+    engines: { node: ">= 6.0.0" }
+
   ansi-escapes@7.3.0:
     resolution:
       {
@@ -586,6 +623,18 @@ packages:
       }
     engines: { node: ">=12" }
 
+  asynckit@0.4.0:
+    resolution:
+      {
+        integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==,
+      }
+
+  axios@1.18.1:
+    resolution:
+      {
+        integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==,
+      }
+
   baseline-browser-mapping@2.10.27:
     resolution:
       {
@@ -593,6 +642,13 @@ packages:
       }
     engines: { node: ">=6.0.0" }
     hasBin: true
+
+  call-bind-apply-helpers@1.0.2:
+    resolution:
+      {
+        integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   caniuse-lite@1.0.30001792:
     resolution:
@@ -626,6 +682,13 @@ packages:
         integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
       }
 
+  combined-stream@1.0.8:
+    resolution:
+      {
+        integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==,
+      }
+    engines: { node: ">= 0.8" }
+
   commander@14.0.3:
     resolution:
       {
@@ -633,11 +696,36 @@ packages:
       }
     engines: { node: ">=20" }
 
+  core-js@3.49.0:
+    resolution:
+      {
+        integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==,
+      }
+
   csstype@3.2.3:
     resolution:
       {
         integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==,
       }
+
+  debug@4.4.3:
+    resolution:
+      {
+        integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
+      }
+    engines: { node: ">=6.0" }
+    peerDependencies:
+      supports-color: "*"
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  delayed-stream@1.0.0:
+    resolution:
+      {
+        integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==,
+      }
+    engines: { node: ">=0.4.0" }
 
   detect-libc@2.1.2:
     resolution:
@@ -645,6 +733,19 @@ packages:
         integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
       }
     engines: { node: ">=8" }
+
+  dompurify@3.4.12:
+    resolution:
+      {
+        integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==,
+      }
+
+  dunder-proto@1.0.1:
+    resolution:
+      {
+        integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==,
+      }
+    engines: { node: ">= 0.4" }
 
   emoji-regex@10.6.0:
     resolution:
@@ -666,10 +767,69 @@ packages:
       }
     engines: { node: ">=18" }
 
+  es-define-property@1.0.1:
+    resolution:
+      {
+        integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==,
+      }
+    engines: { node: ">= 0.4" }
+
+  es-errors@1.3.0:
+    resolution:
+      {
+        integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
+      }
+    engines: { node: ">= 0.4" }
+
+  es-object-atoms@1.1.2:
+    resolution:
+      {
+        integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==,
+      }
+    engines: { node: ">= 0.4" }
+
+  es-set-tostringtag@2.1.0:
+    resolution:
+      {
+        integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==,
+      }
+    engines: { node: ">= 0.4" }
+
   eventemitter3@5.0.4:
     resolution:
       {
         integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==,
+      }
+
+  fflate@0.4.9:
+    resolution:
+      {
+        integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==,
+      }
+
+  follow-redirects@1.16.0:
+    resolution:
+      {
+        integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==,
+      }
+    engines: { node: ">=4.0" }
+    peerDependencies:
+      debug: "*"
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.6:
+    resolution:
+      {
+        integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==,
+      }
+    engines: { node: ">= 6" }
+
+  function-bind@1.1.2:
+    resolution:
+      {
+        integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
       }
 
   get-east-asian-width@1.5.0:
@@ -679,11 +839,60 @@ packages:
       }
     engines: { node: ">=18" }
 
+  get-intrinsic@1.3.0:
+    resolution:
+      {
+        integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==,
+      }
+    engines: { node: ">= 0.4" }
+
+  get-proto@1.0.1:
+    resolution:
+      {
+        integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==,
+      }
+    engines: { node: ">= 0.4" }
+
+  gopd@1.2.0:
+    resolution:
+      {
+        integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
+      }
+    engines: { node: ">= 0.4" }
+
   graceful-fs@4.2.11:
     resolution:
       {
         integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
       }
+
+  has-symbols@1.1.0:
+    resolution:
+      {
+        integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==,
+      }
+    engines: { node: ">= 0.4" }
+
+  has-tostringtag@1.0.2:
+    resolution:
+      {
+        integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==,
+      }
+    engines: { node: ">= 0.4" }
+
+  hasown@2.0.4:
+    resolution:
+      {
+        integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==,
+      }
+    engines: { node: ">= 0.4" }
+
+  https-proxy-agent@5.0.1:
+    resolution:
+      {
+        integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==,
+      }
+    engines: { node: ">= 6" }
 
   husky@9.1.7:
     resolution:
@@ -841,12 +1050,39 @@ packages:
         integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
       }
 
+  math-intrinsics@1.1.0:
+    resolution:
+      {
+        integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
+      }
+    engines: { node: ">= 0.4" }
+
+  mime-db@1.52.0:
+    resolution:
+      {
+        integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==,
+      }
+    engines: { node: ">= 0.6" }
+
+  mime-types@2.1.35:
+    resolution:
+      {
+        integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==,
+      }
+    engines: { node: ">= 0.6" }
+
   mimic-function@5.0.1:
     resolution:
       {
         integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==,
       }
     engines: { node: ">=18" }
+
+  ms@2.1.3:
+    resolution:
+      {
+        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+      }
 
   nanoid@3.3.12:
     resolution:
@@ -914,6 +1150,30 @@ packages:
       }
     engines: { node: ^10 || ^12 || >=14 }
 
+  posthog-js@1.407.3:
+    resolution:
+      {
+        integrity: sha512-b9Kc7HVN6nh+xsh1JrcLYHv9bbYLwYUM9belJtNVUFZSJWWfFcZRJJP6L+KeanAeu2VxSFSpioVA39pjjolv4A==,
+      }
+
+  posthog-node@4.18.0:
+    resolution:
+      {
+        integrity: sha512-XROs1h+DNatgKh/AlIlCtDxWzwrKdYDb2mOs58n4yN8BkGN9ewqeQwG5ApS4/IzwCb7HPttUkOVulkYatd2PIw==,
+      }
+    engines: { node: ">=15.0.0" }
+
+  preact@10.29.7:
+    resolution:
+      {
+        integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==,
+      }
+    peerDependencies:
+      preact-render-to-string: ">=5"
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
+
   prettier@3.8.3:
     resolution:
       {
@@ -921,6 +1181,19 @@ packages:
       }
     engines: { node: ">=14" }
     hasBin: true
+
+  proxy-from-env@2.1.0:
+    resolution:
+      {
+        integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==,
+      }
+    engines: { node: ">=10" }
+
+  query-selector-shadow-dom@1.0.1:
+    resolution:
+      {
+        integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==,
+      }
 
   react-dom@19.2.6:
     resolution:
@@ -1081,6 +1354,12 @@ packages:
     resolution:
       {
         integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
+      }
+
+  web-vitals@5.3.0:
+    resolution:
+      {
+        integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==,
       }
 
   wrap-ansi@9.0.2:
@@ -1248,6 +1527,17 @@ snapshots:
   "@next/swc-win32-x64-msvc@16.2.5":
     optional: true
 
+  "@posthog/browser-common@0.2.3":
+    dependencies:
+      "@posthog/core": 1.45.1
+      "@posthog/types": 1.398.0
+
+  "@posthog/core@1.45.1":
+    dependencies:
+      "@posthog/types": 1.398.0
+
+  "@posthog/types@1.398.0": {}
+
   "@swc/helpers@0.5.15":
     dependencies:
       tslib: 2.8.1
@@ -1341,6 +1631,15 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  "@types/trusted-types@2.0.7":
+    optional: true
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
@@ -1349,7 +1648,24 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  asynckit@0.4.0: {}
+
+  axios@1.18.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   baseline-browser-mapping@2.10.27: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   caniuse-lite@1.0.30001792: {}
 
@@ -1366,11 +1682,33 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@14.0.3: {}
+
+  core-js@3.49.0: {}
 
   csstype@3.2.3: {}
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  delayed-stream@1.0.0: {}
+
   detect-libc@2.1.2: {}
+
+  dompurify@3.4.12:
+    optionalDependencies:
+      "@types/trusted-types": 2.0.7
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   emoji-regex@10.6.0: {}
 
@@ -1381,11 +1719,77 @@ snapshots:
 
   environment@1.1.0: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
   eventemitter3@5.0.4: {}
+
+  fflate@0.4.9: {}
+
+  follow-redirects@1.16.0: {}
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
+  function-bind@1.1.2: {}
 
   get-east-asian-width@1.5.0: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   husky@9.1.7: {}
 
@@ -1474,7 +1878,17 @@ snapshots:
     dependencies:
       "@jridgewell/sourcemap-codec": 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   mimic-function@5.0.1: {}
+
+  ms@2.1.3: {}
 
   nanoid@3.3.12: {}
 
@@ -1522,7 +1936,34 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.407.3:
+    dependencies:
+      "@posthog/browser-common": 0.2.3
+      "@posthog/core": 1.45.1
+      "@posthog/types": 1.398.0
+      core-js: 3.49.0
+      dompurify: 3.4.12
+      fflate: 0.4.9
+      preact: 10.29.7
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+    transitivePeerDependencies:
+      - preact-render-to-string
+
+  posthog-node@4.18.0:
+    dependencies:
+      axios: 1.18.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  preact@10.29.7: {}
+
   prettier@3.8.3: {}
+
+  proxy-from-env@2.1.0: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   react-dom@19.2.6(react@19.2.6):
     dependencies:
@@ -1622,6 +2063,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  web-vitals@5.3.0: {}
 
   wrap-ansi@9.0.2:
     dependencies:

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,1 @@
+.env.local

--- a/web/components/category-section.tsx
+++ b/web/components/category-section.tsx
@@ -1,14 +1,16 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
+import { useCallback, useState } from "react";
 import {
   type ColumnDef,
   type SortingState,
+  type Updater,
   flexRender,
   getCoreRowModel,
   getSortedRowModel,
   useReactTable,
-} from '@tanstack/react-table';
+} from "@tanstack/react-table";
+import posthog from "posthog-js";
 
 export interface CategorySectionProps<T> {
   id: string;
@@ -31,15 +33,34 @@ export function CategorySection<T>({
   data,
   columns,
   defaultSort,
-  noun = 'model',
+  noun = "model",
 }: CategorySectionProps<T>) {
-  const [sorting, setSorting] = useState<SortingState>(defaultSort ? [defaultSort] : []);
+  const [sorting, setSorting] = useState<SortingState>(
+    defaultSort ? [defaultSort] : [],
+  );
+
+  const handleSortingChange = useCallback(
+    (updater: Updater<SortingState>) => {
+      setSorting((prev) => {
+        const next = typeof updater === "function" ? updater(prev) : updater;
+        if (next.length > 0) {
+          posthog.capture("table_sorted", {
+            category: id,
+            column: next[0].id,
+            direction: next[0].desc ? "desc" : "asc",
+          });
+        }
+        return next;
+      });
+    },
+    [id],
+  );
 
   const table = useReactTable({
     data,
     columns,
     state: { sorting },
-    onSortingChange: setSorting,
+    onSortingChange: handleSortingChange,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });
@@ -65,11 +86,18 @@ export function CategorySection<T>({
                     const meta = h.column.columnDef.meta as
                       | { num?: boolean; killer?: boolean }
                       | undefined;
-                    const cls = [meta?.num ? 'num' : '', meta?.killer ? 'killer' : '']
+                    const cls = [
+                      meta?.num ? "num" : "",
+                      meta?.killer ? "killer" : "",
+                    ]
                       .filter(Boolean)
-                      .join(' ');
-                    const ariaSort: 'ascending' | 'descending' | undefined =
-                      sorted === 'asc' ? 'ascending' : sorted === 'desc' ? 'descending' : undefined;
+                      .join(" ");
+                    const ariaSort: "ascending" | "descending" | undefined =
+                      sorted === "asc"
+                        ? "ascending"
+                        : sorted === "desc"
+                          ? "descending"
+                          : undefined;
                     return (
                       <th
                         key={h.id}
@@ -77,7 +105,7 @@ export function CategorySection<T>({
                         aria-sort={ariaSort}
                         onClick={h.column.getToggleSortingHandler()}
                         onKeyDown={(e) => {
-                          if (e.key === 'Enter' || e.key === ' ') {
+                          if (e.key === "Enter" || e.key === " ") {
                             e.preventDefault();
                             h.column.toggleSorting();
                           }
@@ -99,12 +127,18 @@ export function CategorySection<T>({
                     const meta = cell.column.columnDef.meta as
                       | { num?: boolean; killer?: boolean }
                       | undefined;
-                    const cls = [meta?.num ? 'num' : '', meta?.killer ? 'killer' : '']
+                    const cls = [
+                      meta?.num ? "num" : "",
+                      meta?.killer ? "killer" : "",
+                    ]
                       .filter(Boolean)
-                      .join(' ');
+                      .join(" ");
                     return (
                       <td key={cell.id} className={cls || undefined}>
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
                       </td>
                     );
                   })}

--- a/web/components/compare-picker.tsx
+++ b/web/components/compare-picker.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
+import posthog from "posthog-js";
 import {
   LLMCompareTable,
   STTCompareTable,
@@ -43,13 +44,29 @@ export function CompareModels({ llm, stt, tts }: Props) {
     }
   }, [ids]);
 
+  // One event per page view that arrives with a selection, not per add/remove.
+  useEffect(() => {
+    if (ids.length === 0) return;
+    posthog.capture("compare_viewed", {
+      model_count: ids.length,
+      llm_count: ids.filter((id) => llm.some((m) => m.model_id === id)).length,
+      stt_count: ids.filter((id) => stt.some((m) => m.model_id === id)).length,
+      tts_count: ids.filter((id) => tts.some((m) => m.model_id === id)).length,
+      model_ids: ids,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const add = useCallback((id: string) => {
     setIds((prev) =>
       prev.includes(id) || prev.length >= MAX_COMPARE ? prev : [...prev, id],
     );
   }, []);
 
-  const clear = useCallback(() => setIds([]), []);
+  const clear = useCallback(() => {
+    posthog.capture("compare_cleared");
+    setIds([]);
+  }, []);
 
   const today = new Date().toISOString().slice(0, 10);
 
@@ -294,7 +311,14 @@ function ModelGroup({
               cursor:
                 currentIds.length >= MAX_COMPARE ? "not-allowed" : undefined,
             }}
-            onClick={() => onAdd(m.model_id)}
+            onClick={() => {
+                posthog.capture("model_added_to_compare", {
+                  model_id: m.model_id,
+                  provider: m.provider,
+                  category: label,
+                });
+                onAdd(m.model_id);
+              }}
           >
             <span className="add-pill-plus">+</span>
             <span>

--- a/web/components/copyable-code.tsx
+++ b/web/components/copyable-code.tsx
@@ -1,6 +1,7 @@
-'use client';
+"use client";
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from "react";
+import posthog from "posthog-js";
 
 export function CopyableCode({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
@@ -22,6 +23,7 @@ export function CopyableCode({ value }: { value: string }) {
       } catch {
         return;
       }
+      posthog.capture("model_id_copied", { model_id: value });
       setCopied(true);
       if (timerRef.current !== null) clearTimeout(timerRef.current);
       timerRef.current = setTimeout(() => setCopied(false), 1400);
@@ -33,18 +35,36 @@ export function CopyableCode({ value }: { value: string }) {
     <button
       type="button"
       onClick={onClick}
-      className={`copy-chip${copied ? ' copy-chip--copied' : ''}`}
-      title={copied ? 'Copied!' : 'Click to copy'}
+      className={`copy-chip${copied ? " copy-chip--copied" : ""}`}
+      title={copied ? "Copied!" : "Click to copy"}
       aria-label={copied ? `Copied ${value}` : `Copy model id ${value}`}
     >
       <span className="copy-chip-text">{value}</span>
       <span className="copy-chip-icon" aria-hidden="true">
         {copied ? (
-          <svg viewBox="0 0 16 16" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <svg
+            viewBox="0 0 16 16"
+            width="11"
+            height="11"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
             <polyline points="3 8.5 6.5 12 13 4.5" />
           </svg>
         ) : (
-          <svg viewBox="0 0 16 16" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+          <svg
+            viewBox="0 0 16 16"
+            width="11"
+            height="11"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
             <rect x="5.5" y="5.5" width="8" height="8" rx="1" />
             <path d="M3 10.5V3.5A1 1 0 0 1 4 2.5h7" />
           </svg>

--- a/web/components/toolbar.tsx
+++ b/web/components/toolbar.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import posthog from "posthog-js";
+
 export function Toolbar({ categories }: { categories: { id: string; label: string }[] }) {
   return (
     <div className="toolbar">
@@ -10,10 +14,19 @@ export function Toolbar({ categories }: { categories: { id: string; label: strin
           ))}
         </div>
         <div style={{ display: 'flex', gap: 8, marginLeft: 'auto' }}>
-          <a className="btn btn-accent" href="/costs/compare" rel="nofollow">
+          <a
+            className="btn btn-accent"
+            href="/costs/compare"
+            rel="nofollow"
+            onClick={() => posthog.capture("compare_cta_clicked")}
+          >
             Compare
           </a>
-          <a className="btn btn-filled" href="/costs/costs.md">
+          <a
+            className="btn btn-filled"
+            href="/costs/costs.md"
+            onClick={() => posthog.capture("markdown_downloaded")}
+          >
             ↓ .md
           </a>
         </div>

--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -1,0 +1,23 @@
+import posthog from "posthog-js";
+
+const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+if (!key) {
+  if (process.env.NODE_ENV === "development") {
+    throw new Error(
+      "NEXT_PUBLIC_POSTHOG_KEY variable required by PostHog is missing or un-configured, " +
+        "this causes events to be silently missed. This error stops appearing once NEXT_PUBLIC_POSTHOG_KEY is configured",
+    );
+  }
+} else {
+  posthog.init(key, {
+    // t.hail.so is a PostHog custom domain, so events go straight there — no
+    // reverse-proxy rewrite needed. Matches hail-website, which uses the same
+    // project so /costs traffic joins the same funnel rather than splitting off.
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST!,
+    ui_host: "https://eu.posthog.com",
+    defaults: "2026-01-30",
+    capture_exceptions: true,
+    debug: process.env.NODE_ENV === "development",
+  });
+}

--- a/web/lib/posthog-server.ts
+++ b/web/lib/posthog-server.ts
@@ -1,0 +1,24 @@
+import { PostHog } from "posthog-node";
+
+let posthogClient: PostHog | null = null;
+
+export function getPostHogClient(): PostHog | null {
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (!key) {
+    if (process.env.NODE_ENV === "development") {
+      console.error(
+        "NEXT_PUBLIC_POSTHOG_KEY variable required by PostHog is missing or un-configured, " +
+          "this causes events to be silently missed. This error stops appearing once NEXT_PUBLIC_POSTHOG_KEY is configured",
+      );
+    }
+    return null;
+  }
+  if (!posthogClient) {
+    posthogClient = new PostHog(key, {
+      host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://t.hail.so",
+      flushAt: 1,
+      flushInterval: 0,
+    });
+  }
+  return posthogClient;
+}

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -4,6 +4,11 @@ import type { NextConfig } from "next";
 // deployment, so a proxied request presents the same Host as a direct hit on
 // the raw *.vercel.app domain — a host-based redirect cannot tell them apart
 // and loops against the rewrite. See PR #54 / the 2026-07-27 incident.
+//
+// No PostHog /ingest reverse-proxy rewrite either: NEXT_PUBLIC_POSTHOG_HOST is
+// t.hail.so, already a PostHog custom domain, so the client posts there
+// directly. A rewrite here would also have to carry the /costs basePath, which
+// the generated default did not.
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@tanstack/react-table": "^8.20.0",
     "next": "^16.2.0",
+    "posthog-js": "^1.257.2",
+    "posthog-node": "^4.13.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },


### PR DESCRIPTION
  The costs app is a separate deployment that hail.so rewrites /costs/* to, so
  hail-website analytics never ran there and those pageviews were invisible.
  Uses the same project via t.hail.so, a PostHog custom domain, so no
  reverse-proxy rewrite is needed and the /costs basePath cannot break the
  ingest path.