### PR TITLE
fix(mcp): bound mcp sdk to <2 — 2.0.0 removed mcp.server.fastmcp

### DIFF
--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 classifiers = ["Private :: Do Not Upload"]
 dependencies = [
     "hailhq-core",
-    "mcp>=1.0",
+    "mcp>=1.0,<2",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.32",
     "httpx>=0.27",

--- a/uv.lock
+++ b/uv.lock
@@ -1157,7 +1157,7 @@ requires-dist = [
     { name = "hailhq-core", editable = "core" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'dev'" },
-    { name = "mcp", specifier = ">=1.0" },
+    { name = "mcp", specifier = ">=1.0,<2" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },


### PR DESCRIPTION
The mcp Docker image resolves deps fresh (synthetic workspace, no uv.lock), so the unbounded 'mcp>=1.0' picked up 2.0.0 (released 2026-07-28), which drops the mcp.server.fastmcp module and crashes the container at boot.