### PR TITLE
fix(billing): gate JWT sessions on funds, not just API keys

### DIFF
--- a/api/hailhq/api/agent_gate.py
+++ b/api/hailhq/api/agent_gate.py
@@ -49,8 +49,12 @@ async def require_agent_send_allowed(
     to+cc+bcc (deduped/normalized); sms and calls pass a one-element list
     for their single destination. Every recipient counts toward the caps.
 
-    No-op for human-origin orgs and for the self-hosted shared-key path
-    (``api_key_id is None`` — same posture as require_funds)."""
+    No-op for human-origin callers: both the console/website JWT path and the
+    self-hosted shared key skip these agent velocity caps (``api_key_id`` is
+    None on both). Only API-key traffic is agent-origin and rate limited here.
+    NOTE: this is deliberately NOT the same predicate as require_funds — the
+    funds gate bills JWT sessions (``auth_kind``), the velocity gate exempts
+    them, because a JWT session is a human at the console, not an agent."""
     if principal.api_key_id is None:
         return
     denial = await check_agent_send_allowed(

--- a/api/hailhq/api/deps.py
+++ b/api/hailhq/api/deps.py
@@ -19,7 +19,7 @@ import json
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Annotated
+from typing import Annotated, Literal
 
 import jwt as _pyjwt
 from fastapi import Depends, Header, HTTPException, status
@@ -69,6 +69,13 @@ def reset_caches() -> None:
 class Principal(BaseModel):
     """The authenticated caller, exposed to route handlers.
 
+    ``auth_kind`` is the authentication path that produced this principal.
+    Prefer it over ``api_key_id is None`` for "is this a billed caller?"
+    questions: ``api_key_id`` is ``None`` on **both** the shared-key and JWT
+    paths, so it cannot tell a real (billable) console/website session apart
+    from the unbilled self-hosted master key. Only ``"shared"`` is exempt from
+    billing; ``"apikey"`` and ``"jwt"`` are both billed principals.
+
     ``api_key_id`` is ``None`` on shared-key (``HAIL_API_KEY``) and JWT
     requests — neither corresponds to a row in ``api_keys``.
 
@@ -77,6 +84,7 @@ class Principal(BaseModel):
     shared-key (``HAIL_API_KEY``) path, which carries no caller identity.
     """
 
+    auth_kind: Literal["apikey", "jwt", "shared"]
     api_key_id: uuid.UUID | None
     user_id: uuid.UUID | None
     organization_id: uuid.UUID
@@ -218,6 +226,7 @@ async def _principal_from_apikey_table(token: str, db: AsyncSession) -> Principa
         user_id = None
 
     return Principal(
+        auth_kind="apikey",
         api_key_id=api_key.id,
         user_id=user_id,
         organization_id=organization_id,
@@ -324,6 +333,7 @@ async def _principal_from_jwt(token: str, db: AsyncSession) -> Principal:
         )
 
     return Principal(
+        auth_kind="jwt",
         api_key_id=None,
         user_id=user_uuid,
         organization_id=organization_id,
@@ -339,6 +349,7 @@ async def get_current_principal(
 
     if _check_shared_key(token):
         return Principal(
+            auth_kind="shared",
             api_key_id=None,
             user_id=None,
             organization_id=SELF_HOSTED_ORG_ID,

--- a/api/hailhq/api/funds.py
+++ b/api/hailhq/api/funds.py
@@ -21,11 +21,13 @@ _NO_FUNDS_DETAIL = "insufficient credits; top up at https://hail.so/console/bill
 async def require_funds(
     db: AsyncSession, principal: Principal, idem: IdempotencyContext | None = None
 ) -> None:
-    """Raise 402 when the org has no credits. Cloud-only: shared-key auth
-    (``api_key_id is None`` ⇒ HAIL_API_KEY path) lands on the unbilled
-    "Self-hosted" org and skips the gate. The 402 is cached under the
-    idempotency key when one was supplied."""
-    if principal.api_key_id is None:
+    """Raise 402 when the org has no credits. Cloud-only: only shared-key auth
+    (``auth_kind == "shared"`` ⇒ HAIL_API_KEY path) lands on the unbilled
+    "Self-hosted" org and skips the gate. Both real API keys and console/website
+    session JWTs are billed principals and get the balance check — note
+    ``api_key_id`` is None on the JWT path too, so it must NOT be used here.
+    The 402 is cached under the idempotency key when one was supplied."""
+    if principal.auth_kind == "shared":
         return
     if not await has_funds(db, principal.organization_id):
         raise await cache_failure(

--- a/api/hailhq/api/routes/calls.py
+++ b/api/hailhq/api/routes/calls.py
@@ -311,7 +311,11 @@ async def create_call(
     call_metadata = dict(body.metadata)
     if pool_number is not None:
         call_metadata[CALL_META_FROM_POOL] = True
-    call_metadata[CALL_META_BILLED] = principal.api_key_id is not None
+    # Billed unless this is the unbilled self-hosted shared key. Both real API
+    # keys and console/website JWTs are billed, so the mid-call agent funds
+    # re-check (internal/agent._shared_denial) applies to them — keying on
+    # ``api_key_id is not None`` would wrongly exempt every JWT-placed call.
+    call_metadata[CALL_META_BILLED] = principal.auth_kind != "shared"
 
     call = Call(
         organization_id=principal.organization_id,

--- a/api/tests/test_billing.py
+++ b/api/tests/test_billing.py
@@ -2,6 +2,8 @@
 
 Covers:
   * the uniform 402 gate on POST /v1/calls (per-user apikey path)
+  * the same 402 gate on the JWT (console/website) path — a per-user key and a
+    session JWT are both billed principals; only the shared key is exempt
   * the shared-key (`HAIL_API_KEY`) bypass path via the ``self-hosted`` sentinel org
   * `AccountCredit` CHECK constraints
   * OSS fallback when the auth backend's apikey table is absent
@@ -9,6 +11,7 @@ Covers:
 
 from __future__ import annotations
 
+import uuid
 from decimal import Decimal
 
 import httpx
@@ -74,6 +77,93 @@ async def test_post_calls_succeeds_per_user_key_positive_balance(
             "recipient_consent": True,
         },
         headers={"Authorization": f"Bearer {plain}"},
+    )
+    assert resp.status_code == 201
+
+
+# --------------------------------------------------------------------------- #
+# JWT (console / website) path — a session JWT is a billed principal too
+# --------------------------------------------------------------------------- #
+
+
+def _configure_jwt(monkeypatch: pytest.MonkeyPatch, claims: dict) -> None:
+    """Make a JWT-shaped bearer authenticate as ``claims`` without real crypto.
+
+    ``_jwt_configured()`` must see an auth url + audiences, and the two JWT
+    helpers are stubbed so ``Bearer a.b.c`` resolves to the crafted claim set.
+    Mirrors ``_patch_jwt`` in test_jwt_active_org.py.
+    """
+    monkeypatch.setattr(
+        "hailhq.core.config.settings.hail_auth_url", "https://issuer.example.com"
+    )
+    monkeypatch.setattr(
+        "hailhq.core.config.settings.hail_auth_audiences", "https://api.example.com"
+    )
+    monkeypatch.setattr(deps_module, "get_jwks_cache", lambda: object())
+
+    async def _fake_verify(*_a, **_k) -> dict:
+        return claims
+
+    monkeypatch.setattr(deps_module, "verify_jwt", _fake_verify)
+
+
+async def test_post_calls_402_jwt_zero_balance(
+    client: httpx.AsyncClient,
+    async_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JWT (console/welcome) principal + zero balance returns 402.
+
+    Regression guard: the funds gate keyed on ``api_key_id is None``, which is
+    also None on the JWT path, so every browser-session call skipped the
+    balance check. A new $0 org placing a call from the website must 402.
+    """
+    user_id = str(uuid.uuid4())
+    org_id, _, _ = await insert_org_and_key(
+        async_session,
+        org_slug="jwt-broke",
+        auth_user_id=user_id,
+        initial_credit_cents=0,
+    )
+    _configure_jwt(monkeypatch, {"sub": user_id, "activeOrganizationId": str(org_id)})
+
+    resp = await client.post(
+        "/calls",
+        json=_DEFAULT_BODY,
+        headers={"Authorization": "Bearer a.b.c"},
+    )
+    assert resp.status_code == 402
+    assert "credits" in resp.json()["detail"].lower()
+
+
+async def test_post_calls_succeeds_jwt_positive_balance(
+    client: httpx.AsyncClient,
+    async_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    add_phone_number,
+) -> None:
+    """JWT principal + positive balance + active number → call queued.
+
+    Proves the gate fix does not break paying console/website users.
+    """
+    user_id = str(uuid.uuid4())
+    org_id, _, _ = await insert_org_and_key(
+        async_session,
+        org_slug="jwt-flush",
+        auth_user_id=user_id,
+        initial_credit_cents=10_000,
+    )
+    await add_phone_number(async_session, org_id, e164="+14155551234")
+    _configure_jwt(monkeypatch, {"sub": user_id, "activeOrganizationId": str(org_id)})
+
+    resp = await client.post(
+        "/calls",
+        json={
+            "to": "+14155559999",
+            "system_prompt": "hi",
+            "recipient_consent": True,
+        },
+        headers={"Authorization": "Bearer a.b.c"},
     )
     assert resp.status_code == 201
 


### PR DESCRIPTION
The 402 funds gate skipped on api_key_id is None, which is None for both the self-host master key and every console/website session JWT. New $0 orgs placing calls from the website bypassed billing entirely. Add Principal. auth_kind; only shared-key is exempt. Apply the same to CALL_META_BILLED so the mid-call agent re-check covers JWT calls.