### PR TITLE
docs(setup): document outbound SMS setup in twilio guide

### DIFF
--- a/docs/public/setup/twilio.md
+++ b/docs/public/setup/twilio.md
@@ -13,7 +13,7 @@ Put them in `.env`.
 
 ## 2. Phone number
 
-Go to **Phone Numbers → Buy a number**. Select a number with the Voice capability. Note the E.164 format (`+1…`).
+Go to **Phone Numbers → Buy a number**. Select a number with the Voice capability. For outbound SMS, select a number that also has the SMS capability. The carrier fixes these capabilities when you buy the number; you cannot add SMS to a voice-only number later. Note the E.164 format (`+1…`).
 
 ## 3. SIP trunk
 
@@ -22,7 +22,40 @@ Go to **Phone Numbers → Buy a number**. Select a number with the Voice capabil
 3. **Numbers**: attach the phone number from step 2.
 4. Put the Termination URI (for example, `your-trunk.pstn.twilio.com`) in `.env` as `TWILIO_SIP_TRUNK_DOMAIN`.
 
-## 4. Inbound SMS & opt-out
+## 4. Outbound SMS
+
+Hail sends SMS from a dedicated number that you enable for messaging.
+
+1. **Acquire an SMS-capable number** (step 2 above), or pick one you already
+   hold. Only numbers with the SMS capability can send.
+2. **Enable SMS on the number.** Call `POST /numbers/{id}/enable-sms`. Hail
+   attaches the number to your organization's Twilio Messaging Service and
+   creates that service the first time. There is one Messaging Service per
+   organization; every enabled number joins the same shared sender pool. The
+   call is idempotent — an already-enabled number returns its current state.
+3. **Send.** Call `POST /sms` with the recipient and body. Hail sends from your
+   organization's dedicated number.
+
+**A2P 10DLC (United States).** US carriers deliver application-to-person SMS on
+long-code numbers only after you register an A2P 10DLC brand and campaign. Do
+this in the Twilio console (**Messaging → Regulatory Compliance → A2P 10DLC**)
+before you send to US numbers. Registration is a Twilio-side requirement; Hail
+does not manage it.
+
+**Sender ID (optional, rest-of-world).** For destinations that allow it, set a
+custom alphanumeric sender with `PATCH /sms/sender-id` (read the current value
+with `GET /sms/sender-id`). Clear it by sending `null`. When you set none, Hail
+falls back to the platform default sender. The United States and Canada do not
+allow alphanumeric sender IDs — messages there always send from the dedicated
+number, regardless of this setting.
+
+**Rate limits.** Per-organization send velocity is capped by
+`HAIL_VELOCITY_SMS_PER_HOUR` (default 100) and `HAIL_VELOCITY_SMS_PER_DAY`
+(default 1000). An abuse monitor suspends an organization's SMS channel when its
+opt-out rate is too high — see [operations](../operations.md) for the
+`HAIL_SMS_ABUSE_*` variables and how to lift a suspension.
+
+## 5. Inbound SMS & opt-out
 
 Point the number's **A Message Comes In** webhook at
 `https://<your-api-host>/sms/inbound` (HTTP POST). Hail verifies Twilio's


### PR DESCRIPTION
Add an Outbound SMS section covering enable-sms (Messaging Service attachment), A2P 10DLC registration, optional alphanumeric Sender ID, and send velocity limits. Note the SMS number capability in step 2. Keeps SMS setup consolidated on the Twilio page alongside the existing inbound and opt-out section rather than a separate page.