### PR TITLE
feat(docs): add an OpenAPI-generated API reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,8 @@ docs-site/.next/
 docs-site/.source/
 docs-site/next-env.d.ts
 docs-site/tsconfig.tsbuildinfo
+# Generated API reference (rebuilt from openapi.yaml before every build)
+docs-site/content/api/
 
 # Local Claude Code tooling
 .claude/workflows/

--- a/docs-site/app/(docs)/layout.tsx
+++ b/docs-site/app/(docs)/layout.tsx
@@ -10,6 +10,7 @@ export default function Layout({ children }: { children: ReactNode }) {
       // on the apex, which is a different Next zone.
       nav={{ title: "Hail docs", url: "https://hail.so" }}
       links={[
+        { text: "API Reference", url: "/api" },
         { text: "Pricing", url: "https://hail.so/pricing" },
         { text: "GitHub", url: "https://github.com/hail-hq/hail" },
       ]}

--- a/docs-site/app/api/[[...slug]]/page.tsx
+++ b/docs-site/app/api/[[...slug]]/page.tsx
@@ -1,0 +1,77 @@
+import { DocsBody, DocsPage } from "fumadocs-ui/page";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { ComponentProps } from "react";
+import { OpenAPIPage } from "@/components/openapi-page";
+import { openapi } from "@/lib/openapi";
+import { getMDXComponents } from "@/mdx-components";
+import { apiSource } from "@/lib/source";
+
+// The /docs/api root has no generated page, so render an index that lists every
+// operation. Deeper slugs render the generated OpenAPI page for one endpoint.
+function ApiIndex() {
+  const pages = apiSource
+    .getPages()
+    .slice()
+    .sort((a, b) => a.data.title.localeCompare(b.data.title));
+  return (
+    <DocsPage>
+      <DocsBody>
+        <h1>API Reference</h1>
+        <p>
+          Hail exposes a REST API. Every endpoint below is generated from{" "}
+          <code>openapi/openapi.yaml</code>, the canonical contract that CI verifies
+          against the live service, so this reference never drifts from the code.
+        </p>
+        <ul>
+          {pages.map((page) => (
+            <li key={page.url}>
+              <Link href={page.url}>{page.data.title}</Link>
+            </li>
+          ))}
+        </ul>
+      </DocsBody>
+    </DocsPage>
+  );
+}
+
+export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
+  const { slug } = await props.params;
+  if (!slug || slug.length === 0) return <ApiIndex />;
+
+  const page = apiSource.getPage(slug);
+  if (!page) notFound();
+
+  // The generated MDX renders <OpenAPIPage document operations/>, but the client
+  // component needs the bundled schema too. Preload it on the server and inject.
+  const { preloaded } = await openapi.preloadOpenAPIPage(page);
+  const PreloadedOpenAPIPage = (p: ComponentProps<typeof OpenAPIPage>) => (
+    <OpenAPIPage {...p} preloaded={preloaded} />
+  );
+
+  const MDX = page.data.body;
+  return (
+    <DocsPage toc={page.data.toc} full={page.data.full}>
+      <DocsBody>
+        <MDX components={getMDXComponents({ OpenAPIPage: PreloadedOpenAPIPage })} />
+      </DocsBody>
+    </DocsPage>
+  );
+}
+
+export function generateStaticParams() {
+  return apiSource.generateParams();
+}
+
+export async function generateMetadata(props: {
+  params: Promise<{ slug?: string[] }>;
+}): Promise<Metadata> {
+  const { slug } = await props.params;
+  if (!slug || slug.length === 0) {
+    return { title: "API Reference", description: "REST API reference for Hail." };
+  }
+  const page = apiSource.getPage(slug);
+  if (!page) notFound();
+  return { title: page.data.title, description: page.data.description };
+}

--- a/docs-site/app/api/layout.tsx
+++ b/docs-site/app/api/layout.tsx
@@ -1,0 +1,18 @@
+import { DocsLayout } from "fumadocs-ui/layouts/docs";
+import type { ReactNode } from "react";
+import { apiSource } from "@/lib/source";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <DocsLayout
+      tree={apiSource.pageTree}
+      nav={{ title: "Hail API", url: "/" }}
+      links={[
+        { text: "Docs", url: "/" },
+        { text: "GitHub", url: "https://github.com/hail-hq/hail" },
+      ]}
+    >
+      {children}
+    </DocsLayout>
+  );
+}

--- a/docs-site/app/global.css
+++ b/docs-site/app/global.css
@@ -1,3 +1,4 @@
 @import "tailwindcss";
 @import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
+@import "fumadocs-openapi/css/preset.css";

--- a/docs-site/components/openapi-page.tsx
+++ b/docs-site/components/openapi-page.tsx
@@ -1,0 +1,7 @@
+"use client";
+import { createOpenAPIPage } from "fumadocs-openapi/ui";
+
+// createOpenAPIPage is a client factory (it wires up the interactive schema
+// viewer), so it must be constructed inside a client module. The generated
+// content/api MDX pulls this in through the MDX component map.
+export const OpenAPIPage = createOpenAPIPage();

--- a/docs-site/lib/openapi.ts
+++ b/docs-site/lib/openapi.ts
@@ -1,0 +1,8 @@
+import { createOpenAPI } from "fumadocs-openapi/server";
+
+// The API spec is the repo's canonical contract, CI-verified against the live
+// FastAPI app (see ../.github/workflows/openapi-check.yml). Point the reference
+// generator straight at it so the docs never drift from the code.
+export const openapi = createOpenAPI({
+  input: ["../openapi/openapi.yaml"],
+});

--- a/docs-site/lib/source.ts
+++ b/docs-site/lib/source.ts
@@ -1,5 +1,5 @@
 import { loader } from "fumadocs-core/source";
-import { docs } from "@/.source/server";
+import { apiDocs, docs } from "@/.source/server";
 import { slugSegments } from "@/lib/doc-slug.mjs";
 
 /**
@@ -13,4 +13,13 @@ export const source = loader({
   baseUrl: "/",
   source: docs.toFumadocsSource(),
   slugs: (file) => slugSegments(file.path),
+});
+
+/**
+ * The generated API reference lives at /docs/api/*. baseUrl "/api" → with the
+ * app's /docs basePath the pages resolve to /docs/api/<operation>.
+ */
+export const apiSource = loader({
+  baseUrl: "/api",
+  source: apiDocs.toFumadocsSource(),
 });

--- a/docs-site/mdx-components.tsx
+++ b/docs-site/mdx-components.tsx
@@ -1,6 +1,9 @@
 import defaultComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
+import { OpenAPIPage } from "@/components/openapi-page";
 
+// The generated API-reference MDX (content/api/*) expects an `OpenAPIPage`
+// component in its component map; it renders endpoint docs from the spec.
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
-  return { ...defaultComponents, ...components };
+  return { ...defaultComponents, OpenAPIPage, ...components };
 }

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -4,13 +4,15 @@
   "type": "module",
   "scripts": {
     "dev": "next dev --port 3002",
-    "build": "next build",
+    "build": "node --experimental-strip-types scripts/generate-openapi.mjs && next build",
     "start": "next start --port 3002",
-    "postinstall": "node -e \"import('fumadocs-mdx/next').then(m=>m.postInstall())\""
+    "postinstall": "node -e \"import('fumadocs-mdx/next').then(m=>m.postInstall())\"",
+    "generate:api": "node --experimental-strip-types scripts/generate-openapi.mjs"
   },
   "dependencies": {
     "fumadocs-core": "^16.12.0",
     "fumadocs-mdx": "^15.2.0",
+    "fumadocs-openapi": "^11.2.2",
     "fumadocs-ui": "^16.12.0",
     "next": "^16.2.11",
     "react": "^19.2.0",

--- a/docs-site/scripts/generate-openapi.mjs
+++ b/docs-site/scripts/generate-openapi.mjs
@@ -1,0 +1,14 @@
+import { rm } from "node:fs/promises";
+import { generateFiles } from "fumadocs-openapi";
+import { openapi } from "../lib/openapi.ts";
+
+// Regenerate the API-reference MDX from the OpenAPI spec into content/api.
+// Grouped by tag so the sidebar mirrors the spec's own sections.
+await rm("content/api", { recursive: true, force: true });
+await generateFiles({
+  input: openapi,
+  output: "content/api",
+  per: "operation",
+
+});
+console.log("generated API reference into content/api");

--- a/docs-site/source.config.ts
+++ b/docs-site/source.config.ts
@@ -31,4 +31,13 @@ export const docs = defineDocs({
   meta: { schema: metaSchema },
 });
 
+/**
+ * API reference pages, generated from openapi/openapi.yaml into content/api by
+ * scripts/generate-openapi.mjs (run before every build). Generated files carry
+ * their own frontmatter, so no derivation is needed here.
+ */
+export const apiDocs = defineDocs({
+  dir: "content/api",
+});
+
 export default defineConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       fumadocs-mdx:
         specifier: ^15.2.0
         version: 15.2.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.14)(fumadocs-core@16.14.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.28.0(react@19.2.6))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      fumadocs-openapi:
+        specifier: ^11.2.2
+        version: 11.2.2(@types/react@19.2.14)(fumadocs-core@16.14.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.28.0(react@19.2.6))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(fumadocs-ui@16.14.0(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.14.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.28.0(react@19.2.6))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       fumadocs-ui:
         specifier: ^16.12.0
         version: 16.14.0(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.14.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.28.0(react@19.2.6))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4)
@@ -116,6 +119,46 @@ packages:
         integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==,
       }
     engines: { node: ">=10" }
+
+  "@babel/runtime@7.29.7":
+    resolution:
+      {
+        integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@base-ui/react@1.6.0":
+    resolution:
+      {
+        integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==,
+      }
+    engines: { node: ">=14.0.0" }
+    peerDependencies:
+      "@date-fns/tz": ^1.2.0
+      "@types/react": ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      "@date-fns/tz":
+        optional: true
+      "@types/react":
+        optional: true
+      date-fns:
+        optional: true
+
+  "@base-ui/utils@0.3.1":
+    resolution:
+      {
+        integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==,
+      }
+    peerDependencies:
+      "@types/react": ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
 
   "@emnapi/runtime@1.10.0":
     resolution:
@@ -397,6 +440,24 @@ packages:
       "@types/react":
         optional: true
 
+  "@fumadocs/api-docs@0.2.1":
+    resolution:
+      {
+        integrity: sha512-kt46+I6/ACScikHpyY5NbR20vo74pLgG2bagl3CHUOdiH3Pg15ecpuHSPbXw2ZhDg68t1XUGZbrGE/JvxhSVBg==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      fumadocs-core: ^16.9.0
+      fumadocs-ui: ^16.9.0
+      json-schema-typed: "*"
+      react: ^19.2.0
+      react-dom: ^19.2.0
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      json-schema-typed:
+        optional: true
+
   "@fumadocs/tailwind@0.1.1":
     resolution:
       {
@@ -406,6 +467,30 @@ packages:
       tailwindcss: ^4.0.0
     peerDependenciesMeta:
       tailwindcss:
+        optional: true
+
+  "@fumari/json-schema-ts@1.0.2":
+    resolution:
+      {
+        integrity: sha512-1NHGl8Oqg50mhpWMvbhqnwFRLBugkGCRubLSH/TrAzTAS99x4z0xFgOVcbJne+yfaZv94ZNdmRWobDvUiZswPg==,
+      }
+    peerDependencies:
+      json-schema-typed: "*"
+    peerDependenciesMeta:
+      json-schema-typed:
+        optional: true
+
+  "@fumari/stf@1.1.0":
+    resolution:
+      {
+        integrity: sha512-ta/qVbB03SSQ29185hNkF4E+DcteLTuX6FOjzRpQehk5738VLkfw2mIZuejqrubmoRAeKfxSrtqLwnS9W9XgKQ==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^19.2.0
+      react-dom: ^19.2.0
+    peerDependenciesMeta:
+      "@types/react":
         optional: true
 
   "@img/colour@1.1.0":
@@ -1289,6 +1374,20 @@ packages:
         integrity: sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==,
       }
 
+  "@scalar/helpers@0.9.2":
+    resolution:
+      {
+        integrity: sha512-hjyMpMZjTBZQhyByZmz5oUgRKUQJO5V5AOiJxsVEGbUmgA7sJRQeTrXLB+BEwzaKS5nm2opJeNyMBYLFNK4hiQ==,
+      }
+    engines: { node: ">=22" }
+
+  "@scalar/json-magic@0.12.19":
+    resolution:
+      {
+        integrity: sha512-1T4QoFYZ1nKt25xFeHtghAuZzaLq2X4CpCSLFXG0Fjcz6K2HIZqo+RtywfI0WD8RRRRgS34keo7X4Gv1BQUNoQ==,
+      }
+    engines: { node: ">=22" }
+
   "@shikijs/core@4.4.1":
     resolution:
       {
@@ -1861,6 +1960,13 @@ packages:
       }
     engines: { node: ">=6" }
 
+  cnfast@0.0.8:
+    resolution:
+      {
+        integrity: sha512-EjXKMfGfdwtV4AcNSQ6AwQaVzpC1B7IxeiwA3FlhTXz+YFlMKVi4c1JX9tgD2QOlahQXjB8KUXrBaYG+3v871Q==,
+      }
+    hasBin: true
+
   cnfast@0.1.0:
     resolution:
       {
@@ -2278,6 +2384,27 @@ packages:
       satteri:
         optional: true
       vite:
+        optional: true
+
+  fumadocs-openapi@11.2.2:
+    resolution:
+      {
+        integrity: sha512-jec0EOMDtUm9/h1tnPY2YSXAQ0oSv2KJCKae0C78iTCtkZgy6qdZH1otzOPX9eJuE/gFtaYvMszrdXmvvz2oWw==,
+      }
+    peerDependencies:
+      "@scalar/api-client-react": ^2.0.20
+      "@types/react": "*"
+      fumadocs-core: ^16.10.0
+      fumadocs-ui: ^16.10.0
+      json-schema-typed: "*"
+      react: ^19.2.0
+      react-dom: ^19.2.0
+    peerDependenciesMeta:
+      "@scalar/api-client-react":
+        optional: true
+      "@types/react":
+        optional: true
+      json-schema-typed:
         optional: true
 
   fumadocs-ui@16.14.0:
@@ -3142,6 +3269,12 @@ packages:
         integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==,
       }
 
+  pathe@2.0.3:
+    resolution:
+      {
+        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
+
   picocolors@1.1.1:
     resolution:
       {
@@ -3378,6 +3511,12 @@ packages:
     resolution:
       {
         integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==,
+      }
+
+  reselect@5.2.0:
+    resolution:
+      {
+        integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==,
       }
 
   restore-cursor@5.1.0:
@@ -3670,6 +3809,14 @@ packages:
       "@types/react":
         optional: true
 
+  use-sync-external-store@1.6.0:
+    resolution:
+      {
+        integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==,
+      }
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   vfile-location@5.0.3:
     resolution:
       {
@@ -3756,6 +3903,31 @@ packages:
 
 snapshots:
   "@alloc/quick-lru@5.2.0": {}
+
+  "@babel/runtime@7.29.7": {}
+
+  "@base-ui/react@1.6.0(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+    dependencies:
+      "@babel/runtime": 7.29.7
+      "@base-ui/utils": 0.3.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@floating-ui/react-dom": 2.1.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@floating-ui/utils": 0.2.12
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      use-sync-external-store: 1.6.0(react@19.2.6)
+    optionalDependencies:
+      "@types/react": 19.2.14
+
+  "@base-ui/utils@0.3.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+    dependencies:
+      "@babel/runtime": 7.29.7
+      "@floating-ui/utils": 0.2.12
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.6)
+    optionalDependencies:
+      "@types/react": 19.2.14
 
   "@emnapi/runtime@1.10.0":
     dependencies:
@@ -3864,9 +4036,38 @@ snapshots:
     optionalDependencies:
       "@types/react": 19.2.14
 
+  "@fumadocs/api-docs@0.2.1(@types/react@19.2.14)(fumadocs-core@16.14.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.28.0(react@19.2.6))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(fumadocs-ui@16.14.0(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.14.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.28.0(react@19.2.6))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+    dependencies:
+      "@base-ui/react": 1.6.0(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@fuma-translate/react": 1.0.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@fumari/stf": 1.1.0(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@scalar/json-magic": 0.12.19
+      class-variance-authority: 0.7.1
+      cnfast: 0.0.8
+      fumadocs-core: 16.14.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.28.0(react@19.2.6))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3)
+      fumadocs-ui: 16.14.0(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.14.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.28.0(react@19.2.6))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4)
+      github-slugger: 2.0.0
+      lucide-react: 1.28.0(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      "@types/react": 19.2.14
+    transitivePeerDependencies:
+      - "@date-fns/tz"
+      - date-fns
+
   "@fumadocs/tailwind@0.1.1(tailwindcss@4.2.4)":
     optionalDependencies:
       tailwindcss: 4.2.4
+
+  "@fumari/json-schema-ts@1.0.2": {}
+
+  "@fumari/stf@1.1.0(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      "@types/react": 19.2.14
 
   "@img/colour@1.1.0":
     optional: true
@@ -4428,6 +4629,14 @@ snapshots:
 
   "@radix-ui/rect@1.1.3": {}
 
+  "@scalar/helpers@0.9.2": {}
+
+  "@scalar/json-magic@0.12.19":
+    dependencies:
+      "@scalar/helpers": 0.9.2
+      pathe: 2.0.3
+      yaml: 2.9.0
+
   "@shikijs/core@4.4.1":
     dependencies:
       "@shikijs/primitive": 4.4.1
@@ -4712,6 +4921,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cnfast@0.0.8: {}
+
   cnfast@0.1.0: {}
 
   collapse-white-space@2.1.0: {}
@@ -4962,6 +5173,34 @@ snapshots:
       next: 16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
     transitivePeerDependencies:
+      - supports-color
+
+  fumadocs-openapi@11.2.2(@types/react@19.2.14)(fumadocs-core@16.14.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.28.0(react@19.2.6))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(fumadocs-ui@16.14.0(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.14.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.28.0(react@19.2.6))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      "@fuma-translate/react": 1.0.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@fumadocs/api-docs": 0.2.1(@types/react@19.2.14)(fumadocs-core@16.14.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.28.0(react@19.2.6))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(fumadocs-ui@16.14.0(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.14.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.28.0(react@19.2.6))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@fumari/json-schema-ts": 1.0.2
+      "@fumari/stf": 1.1.0(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@scalar/json-magic": 0.12.19
+      chokidar: 5.0.0
+      class-variance-authority: 0.7.1
+      cnfast: 0.0.8
+      fumadocs-core: 16.14.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.28.0(react@19.2.6))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3)
+      fumadocs-ui: 16.14.0(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.14.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.28.0(react@19.2.6))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4)
+      github-slugger: 2.0.0
+      hast-util-to-jsx-runtime: 2.3.6
+      lucide-react: 1.28.0(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      remark: 15.0.1
+      remark-rehype: 11.1.2
+      shiki: 4.4.1
+      yaml: 2.9.0
+    optionalDependencies:
+      "@types/react": 19.2.14
+    transitivePeerDependencies:
+      - "@date-fns/tz"
+      - date-fns
       - supports-color
 
   fumadocs-ui@16.14.0(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.14.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.28.0(react@19.2.6))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(next@16.2.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4):
@@ -5809,6 +6048,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -5996,6 +6237,8 @@ snapshots:
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
+
+  reselect@5.2.0: {}
 
   restore-cursor@5.1.0:
     dependencies:
@@ -6188,6 +6431,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       "@types/react": 19.2.14
+
+  use-sync-external-store@1.6.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
 
   vfile-location@5.0.3:
     dependencies:


### PR DESCRIPTION
Stacked on #63 (the link/favicon fix). Once #63 merges, this diff reduces to just the API-reference files.

## What
Adds a browsable REST API reference at **/docs/api**, generated from `openapi/openapi.yaml` — the CI-verified contract the code is checked against — so it never drifts from the service.

- `lib/openapi.ts` + `scripts/generate-openapi.mjs`: `createOpenAPI` over the spec; one MDX page per operation is generated into `content/api` (gitignored, regenerated before every build).
- Second fumadocs collection + loader (`apiSource`) at baseUrl `/api`.
- `app/api/*`: an index listing every operation, plus per-endpoint pages rendering fumadocs-openapi's `OpenAPIPage`. The bundled schema is preloaded server-side and injected (the component is client-side).
- "API Reference" link in the docs nav.

## Renders
Method/path, header + body parameters, request/response schemas, TypeScript definitions, and copy-paste samples in cURL / JavaScript / Go / Python / Java / C# / Rust. Verified: `/docs/api` → 200, all 46 endpoint pages → 200, screenshot confirms.

## Deferred
The interactive "Send" playground button renders but needs a hosted CORS proxy to actually call the API — that is infra, not a docs change. The static reference does not depend on it.