### PR TITLE
feat(docs): wire the API playground through a same-origin proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@
 
 # Self-host shared-key auth (generate: openssl rand -base64 32). Empty in cloud.
 HAIL_API_KEY=
+# Also the docs-site playground proxy target (default: https://api.hail.so).
 HAIL_API_URL=http://localhost:8080
 
 # Signs GET /unsubscribe tokens (generate: openssl rand -base64 32). A

--- a/docs-site/app/api/proxy/route.ts
+++ b/docs-site/app/api/proxy/route.ts
@@ -1,0 +1,13 @@
+import { openapi } from "@/lib/openapi";
+
+// Server-side relay for the API playground. The browser can't call
+// api.hail.so from a hail.so page (CORS), so the playground posts here and we
+// forward. `allowedOrigins` is the SSRF guard: this route forwards to the Hail
+// API and nothing else — any other target (including redirects) gets a 400.
+// Auth is pass-through; the user's API key travels in the proxied request's
+// Authorization header and is never stored here.
+const proxy = openapi.createProxy({
+  allowedOrigins: ["https://api.hail.so"],
+});
+
+export const { GET, POST, PUT, DELETE, PATCH, HEAD } = proxy;

--- a/docs-site/app/api/proxy/route.ts
+++ b/docs-site/app/api/proxy/route.ts
@@ -1,13 +1,14 @@
+import { HAIL_API_ORIGIN } from "@/lib/api-url";
 import { openapi } from "@/lib/openapi";
 
-// Server-side relay for the API playground. The browser can't call
-// api.hail.so from a hail.so page (CORS), so the playground posts here and we
+// Server-side relay for the API playground. The browser can't call the API
+// origin from a hail.so page (CORS), so the playground posts here and we
 // forward. `allowedOrigins` is the SSRF guard: this route forwards to the Hail
-// API and nothing else — any other target (including redirects) gets a 400.
-// Auth is pass-through; the user's API key travels in the proxied request's
-// Authorization header and is never stored here.
+// API (HAIL_API_URL, default api.hail.so) and nothing else — any other target
+// (including redirects) gets a 400. Auth is pass-through; the user's API key
+// travels in the proxied request's Authorization header and is never stored.
 const proxy = openapi.createProxy({
-  allowedOrigins: ["https://api.hail.so"],
+  allowedOrigins: [HAIL_API_ORIGIN],
 });
 
 export const { GET, POST, PUT, DELETE, PATCH, HEAD } = proxy;

--- a/docs-site/lib/api-url.ts
+++ b/docs-site/lib/api-url.ts
@@ -1,0 +1,12 @@
+/**
+ * Origin of the Hail API the docs playground proxies to.
+ *
+ * HAIL_API_URL is the stack-wide convention (docker-compose sets it per
+ * service, .env.example documents it), so a self-hosted docs-site pointed at
+ * its own API works with the var it already has. Unset — the Vercel deploy —
+ * means Hail Cloud. `new URL(...).origin` normalizes paths and trailing
+ * slashes away; only the origin matters for the proxy allowlist.
+ */
+export const HAIL_API_ORIGIN = new URL(
+  process.env.HAIL_API_URL || "https://api.hail.so",
+).origin;

--- a/docs-site/lib/openapi.ts
+++ b/docs-site/lib/openapi.ts
@@ -5,4 +5,9 @@ import { createOpenAPI } from "fumadocs-openapi/server";
 // generator straight at it so the docs never drift from the code.
 export const openapi = createOpenAPI({
   input: ["../openapi/openapi.yaml"],
+  // The playground's "Send" button fires from the browser, where a direct call
+  // to api.hail.so is blocked by CORS. Requests go to this same-origin route
+  // (app/api/proxy) instead, which forwards them server-side. Path includes the
+  // /docs basePath — the client fetches it as-is.
+  proxyUrl: "/docs/api/proxy",
 });


### PR DESCRIPTION
The "Send" button on /docs/api endpoint pages fired a direct browser call to `api.hail.so`, which CORS blocks from a hail.so page — the playground was dead. This routes it through `app/api/proxy`, a server-side relay built with fumadocs' `createProxy`, and sets `proxyUrl` on the OpenAPI server so every endpoint page uses it.

## Safety
- `allowedOrigins: ["https://api.hail.so"]` — the relay forwards to the Hail API and nothing else; foreign targets (and redirects to them) get 400. Not an open proxy.
- Auth is pass-through: the key a user types travels in the proxied request's `Authorization` header, never stored.

## Verified against production
| Check | Result |
|---|---|
| `proxy?url=https://api.hail.so/healthz` | 200 `{"status":"ok"}` |
| `proxy?url=https://example.com/` | 400 (blocked) |
| `/calls` without a key | API's own 401 passed through unchanged |
| Endpoint pages carry the proxyUrl | yes |