### PR TITLE
feat: BYO speechmatics operating point + consent-gated rerouting

### DIFF
--- a/api/hailhq/api/routes/calls.py
+++ b/api/hailhq/api/routes/calls.py
@@ -230,14 +230,36 @@ async def create_call(
     )
     if lang is not None:
         caps = SUPPORTED_LANGUAGES[lang]
-        # Asymmetric by design: the STT side never 422s here — STT provider
-        # selection is console-BYO-only (no per-call knob), and routing
-        # (org BYO row > language auto-route) degrades safely inside the
-        # voicebot (deepgram covers every supported language). TTS has no
-        # per-call pin either; the org's BYO TTS row is the sole source of
-        # truth, so it's checked here regardless of voice_config contents.
+        # Both layers share one consent rule: an org BYO row (STT or TTS)
+        # that can't serve the requested language 422s here UNLESS the org
+        # set fallback_enabled — that flag is consent to house-provider
+        # rerouting, so a consenting org sails through and the mismatch is
+        # handled downstream in the voicebot (STT degrades to house
+        # deepgram; TTS skips the incapable BYO instance for the house
+        # chain). Neither layer has a per-call provider override — the
+        # org's BYO row (or its absence) is the sole source of truth, so
+        # this is checked here regardless of voice_config contents.
+        stt_row = org_rows.get("stt")
+        if (
+            stt_row is not None
+            and stt_row.provider not in caps.stt
+            and not stt_row.fallback_enabled
+        ):
+            raise await cache_failure(
+                idem,
+                unprocessable(
+                    f"your BYO stt provider '{stt_row.provider}' does not "
+                    f"support language '{lang}'; supported providers: "
+                    f"{sorted(caps.stt)}",
+                    loc=["body", "voice_config", "language"],
+                ),
+            )
         tts_row = org_rows.get("tts")
-        if tts_row is not None and tts_row.provider not in caps.tts:
+        if (
+            tts_row is not None
+            and tts_row.provider not in caps.tts
+            and not tts_row.fallback_enabled
+        ):
             raise await cache_failure(
                 idem,
                 unprocessable(

--- a/api/tests/test_calls_api.py
+++ b/api/tests/test_calls_api.py
@@ -1295,6 +1295,7 @@ async def test_byo_elevenlabs_tts_with_cartesia_only_language_422(
             layer="tts",
             provider="elevenlabs",
             params={},
+            fallback_enabled=False,
             is_active=True,
         )
     )
@@ -1313,3 +1314,108 @@ async def test_byo_elevenlabs_tts_with_cartesia_only_language_422(
     assert resp.status_code == 422, resp.text
     assert "elevenlabs" in resp.text
     livekit_mock.dispatch_agent.assert_not_awaited()
+
+
+async def test_byo_stt_incapable_language_without_fallback_422(
+    client: httpx.AsyncClient,
+    async_session: AsyncSession,
+    org_and_key: tuple[str, ApiKey, str],
+    livekit_mock: AsyncMock,
+    add_phone_number,
+) -> None:
+    org_id, _, plain = org_and_key
+    await add_phone_number(async_session, org_id)
+    async_session.add(
+        OrgProviderConfig(
+            organization_id=org_id,
+            layer="stt",
+            provider="speechmatics",
+            params={},
+            fallback_enabled=False,
+            is_active=True,
+        )
+    )
+    await async_session.commit()
+
+    resp = await client.post(
+        "/calls",
+        json={
+            "to": "+14155559999",
+            "system_prompt": "hi",
+            "recipient_consent": True,
+            "voice_config": {"language": "gu"},  # no speechmatics coverage
+        },
+        headers={"Authorization": f"Bearer {plain}"},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "speechmatics" in resp.text
+    assert "gu" in resp.text
+    livekit_mock.dispatch_agent.assert_not_awaited()
+
+
+async def test_byo_stt_incapable_language_with_fallback_201(
+    client: httpx.AsyncClient,
+    async_session: AsyncSession,
+    org_and_key: tuple[str, ApiKey, str],
+    livekit_mock: AsyncMock,
+    add_phone_number,
+) -> None:
+    org_id, _, plain = org_and_key
+    await add_phone_number(async_session, org_id)
+    async_session.add(
+        OrgProviderConfig(
+            organization_id=org_id,
+            layer="stt",
+            provider="speechmatics",
+            params={},
+            fallback_enabled=True,
+            is_active=True,
+        )
+    )
+    await async_session.commit()
+
+    resp = await client.post(
+        "/calls",
+        json={
+            "to": "+14155559999",
+            "system_prompt": "hi",
+            "recipient_consent": True,
+            "voice_config": {"language": "gu"},  # no speechmatics coverage
+        },
+        headers={"Authorization": f"Bearer {plain}"},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+async def test_byo_tts_incapable_language_with_fallback_201(
+    client: httpx.AsyncClient,
+    async_session: AsyncSession,
+    org_and_key: tuple[str, ApiKey, str],
+    livekit_mock: AsyncMock,
+    add_phone_number,
+) -> None:
+    org_id, _, plain = org_and_key
+    await add_phone_number(async_session, org_id)
+    async_session.add(
+        OrgProviderConfig(
+            organization_id=org_id,
+            layer="tts",
+            provider="elevenlabs",
+            params={},
+            fallback_enabled=True,
+            is_active=True,
+        )
+    )
+    await async_session.commit()
+
+    resp = await client.post(
+        "/calls",
+        json={
+            "to": "+14155559999",
+            "system_prompt": "hi",
+            "recipient_consent": True,
+            "voice_config": {"language": "th"},  # cartesia-only language
+        },
+        headers={"Authorization": f"Bearer {plain}"},
+    )
+    assert resp.status_code == 201, resp.text

--- a/api/tests/test_internal_provider_config.py
+++ b/api/tests/test_internal_provider_config.py
@@ -360,3 +360,69 @@ async def test_validate_inflight_bad_params_422(
         f"{BASE}/llm/validate", content=body, headers=_signed(body)
     )
     assert resp.status_code == 422
+
+
+async def test_put_speechmatics_operating_point_accepted(
+    client, internal_secret_set, provider_key_set  # noqa: F811
+) -> None:
+    body = (
+        b'{"provider":"speechmatics","api_key":"sk-sm-WXYZ",'
+        b'"params":{"operating_point":"standard"},"fallback_enabled":false}'
+    )
+    resp = await client.put(f"{BASE}/stt", content=body, headers=_signed(body))
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["params"] == {"operating_point": "standard"}
+
+    resp = await client.get(BASE, headers=_signed(b""))
+    providers = resp.json()["providers"]
+    assert providers == [
+        {
+            "layer": "stt",
+            "provider": "speechmatics",
+            "key_last4": "WXYZ",
+            "key_set_at": providers[0]["key_set_at"],
+            "params": {"operating_point": "standard"},
+            "fallback_enabled": False,
+            "is_active": True,
+        }
+    ]
+
+
+async def test_put_deepgram_operating_point_rejected_422(
+    client, internal_secret_set, provider_key_set  # noqa: F811
+) -> None:
+    body = (
+        b'{"provider":"deepgram","api_key":"sk-dg-AAAA",'
+        b'"params":{"operating_point":"standard"},"fallback_enabled":false}'
+    )
+    resp = await client.put(f"{BASE}/stt", content=body, headers=_signed(body))
+    assert resp.status_code == 422
+
+
+async def test_validate_inflight_speechmatics_operating_point(
+    client, internal_secret_set, provider_key_set, monkeypatch  # noqa: F811
+) -> None:
+    seen = {}
+
+    async def fake_validate(layer, provider, api_key, params, client=None):
+        seen.update(layer=layer, provider=provider, api_key=api_key, params=params)
+        return "valid", "checked"
+
+    monkeypatch.setattr(
+        "hailhq.api.routes.internal.provider_config.validate_provider_key",
+        fake_validate,
+    )
+    body = (
+        b'{"api_key":"sk-sm-inflight","provider":"speechmatics",'
+        b'"params":{"operating_point":"enhanced"}}'
+    )
+    resp = await client.post(
+        f"{BASE}/stt/validate", content=body, headers=_signed(body)
+    )
+    assert resp.json() == {"status": "valid", "message": "checked"}
+    assert seen == {
+        "layer": "stt",
+        "provider": "speechmatics",
+        "api_key": "sk-sm-inflight",
+        "params": {"operating_point": "enhanced"},
+    }

--- a/core/hailhq/core/provider_config.py
+++ b/core/hailhq/core/provider_config.py
@@ -86,6 +86,16 @@ class STTParams(BaseModel):
 
     provider: Literal["deepgram", "speechmatics"]
     model: str | None = None
+    # Speechmatics transcription tier. None -> enhanced. Ignored on deepgram
+    # rows (accepted-but-unused would violate "no hidden behavior", so the
+    # validator below rejects it there).
+    operating_point: Literal["enhanced", "standard"] | None = None
+
+    @model_validator(mode="after")
+    def _operating_point_is_speechmatics_only(self) -> STTParams:
+        if self.provider != "speechmatics" and self.operating_point is not None:
+            raise ValueError("operating_point only applies to speechmatics")
+        return self
 
 
 PARAMS_BY_LAYER: dict[str, type[BaseModel]] = {

--- a/core/tests/schemas/test_voice_config_language.py
+++ b/core/tests/schemas/test_voice_config_language.py
@@ -38,3 +38,13 @@ def test_openapi_schema_exposes_language_enum() -> None:
 
 def test_stt_params_accept_speechmatics() -> None:
     assert STTParams(provider="speechmatics").provider == "speechmatics"
+
+
+def test_stt_params_operating_point() -> None:
+    assert STTParams(provider="speechmatics").operating_point is None
+    assert (
+        STTParams(provider="speechmatics", operating_point="standard").operating_point
+        == "standard"
+    )
+    with pytest.raises(ValidationError):
+        STTParams(provider="speechmatics", operating_point="turbo")

--- a/docs/superpowers/plans/2026-08-07-console-speechmatics-byo.md
+++ b/docs/superpowers/plans/2026-08-07-console-speechmatics-byo.md
@@ -234,3 +234,71 @@ git add app/console/calls/providers/ && git commit -m "feat(console): speechmati
 ### Final: whole-branch reviews
 
 One review per repo diff (hail: `main..feat/stt-operating-point`; website worktree: `master..feat/console-speechmatics-stt`), then hand both branches to the user for push/PR (never push or create PRs).
+
+---
+
+## Part C — owner rulings on the four product calls (2026-08-07)
+
+Rulings: (1) = option c, (2) = option b, (3) = accept/no work, (4) = leave + startup warning.
+Unifying rule for C1: **`fallback_enabled` on a BYO row is consent to house-provider rerouting; without it, a capability mismatch is an error, never a silent reroute.**
+
+### Task C1: consent-gated STT/TTS rerouting
+
+**Files:**
+
+- Modify: `api/hailhq/api/routes/calls.py` (the language/provider gate)
+- Modify: `voicebot/hailhq/voicebot/pipeline.py` (`build_session` STT degrade branch; `build_tts` org branch)
+- Test: `api/tests/test_calls_api.py`, `voicebot/tests/test_pipeline.py`, `voicebot/tests/test_pipeline_byo.py`
+
+**Interfaces:**
+
+- Consumes: `SUPPORTED_LANGUAGES`, `tts_providers_for` (existing); `OrgProviderConfig.fallback_enabled` column (existing); `ResolvedLayer.fallback_enabled` (existing).
+- Produces: API — 422 when an org BYO row (STT or TTS) cannot serve the requested language AND `fallback_enabled` is false; allowed when true. Voicebot — with consent, STT degrades to house Deepgram (as today) and TTS skips the incapable BYO instance (house chain only); without consent, `ProviderKeyError` (defense-in-depth behind the API gate).
+
+- [ ] **Step 1: Write the failing API tests** (mirror the existing gate tests' fixtures exactly; seed `OrgProviderConfig` the way `test_byo_elevenlabs_tts_with_cartesia_only_language_422` does):
+
+```python
+async def test_byo_stt_incapable_language_without_fallback_422(...):
+    # org row: layer="stt", provider="speechmatics", fallback_enabled=False
+    # POST language="gu" -> 422, message names speechmatics and gu
+async def test_byo_stt_incapable_language_with_fallback_201(...):
+    # same row but fallback_enabled=True -> 201
+async def test_byo_tts_incapable_language_with_fallback_201(...):
+    # org row: layer="tts", provider="elevenlabs", fallback_enabled=True
+    # POST language="th" -> 201 (was 422 before this task)
+```
+
+Keep the existing `fallback_enabled=False` TTS 422 test passing (seed must set the flag explicitly if the column default differs).
+
+- [ ] **Step 2: Write the failing voicebot tests**:
+
+```python
+def test_build_tts_org_incapable_with_fallback_uses_house_only(...):
+    # org elevenlabs row fallback_enabled=True, language="th" ->
+    # result contains ONLY cartesia instance(s), no elevenlabs
+def test_build_tts_org_incapable_without_fallback_raises(...):
+    # same but fallback_enabled=False -> ProviderKeyError
+def test_session_org_stt_incapable_without_fallback_raises(...):
+    # org speechmatics row fallback_enabled=False, language="gu" -> ProviderKeyError
+def test_session_org_stt_incapable_with_fallback_degrades(...):
+    # fallback_enabled=True -> deepgram STT, warning logged (existing behavior)
+```
+
+- [ ] **Step 3: Run all four files' new tests, verify failures**
+- [ ] **Step 4: Implement** — API gate: both checks become `row is not None and row.provider not in caps.<layer> and not row.fallback_enabled`. Voicebot `build_session`: in the degrade branch, when the incapable provider came from the org row and `not org_stt.fallback_enabled`, raise `ProviderKeyError` naming provider+language. Voicebot `build_tts`: before building the BYO instance, if `language is not None and org.provider not in tts_providers_for(language)`: with consent → log + return the house chain (reuse the existing house-instances path incl. its empty-chain ProviderKeyError); without → raise `ProviderKeyError`. Update the gate's asymmetry comment (both layers now share the consent rule).
+- [ ] **Step 5: Full api + voicebot suites green; lint; commit** (`feat: consent-gated rerouting for BYO stt/tts capability mismatches`).
+
+### Task C2: voicebot startup capability warning
+
+**Files:**
+
+- Modify: `voicebot/hailhq/voicebot/main.py` (log before `cli.run_app`), helper in `voicebot/hailhq/voicebot/pipeline.py`
+- Test: `voicebot/tests/test_pipeline.py`
+
+**Interfaces:**
+
+- Produces: `startup_capability_warnings() -> list[str]` in pipeline.py — pure function of `settings`: (a) when `cartesia_api_key` empty: one message listing the supported languages with no usable house TTS given configured keys; (b) when `speechmatics_api_key` empty: one message that the 22 speechmatics-routed languages fall back to Deepgram + VAD turn detection. `main()` logs each at WARNING.
+
+- [ ] **Step 1: failing tests** — monkeypatch settings combos (both keys set → `[]`; cartesia empty + eleven set → message lists exactly the 7 Cartesia-only codes; speechmatics empty → the 22-language message).
+- [ ] **Step 2: implement helper + wire into `main()`** (import cost: pipeline already imported transitively by agent; keep `main.py` lean — import the helper only).
+- [ ] **Step 3: voicebot suite green; lint; commit** (`feat(voicebot): startup warning for unservable languages`).

--- a/docs/superpowers/plans/2026-08-07-console-speechmatics-byo.md
+++ b/docs/superpowers/plans/2026-08-07-console-speechmatics-byo.md
@@ -1,0 +1,236 @@
+# Console Speechmatics BYO STT (PR 2a + 2b) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an org select Speechmatics as its BYO STT provider in the console, including the `operating_point` (enhanced/standard) parameter.
+
+**Architecture:** Two PRs. PR 2a (hail repo): `STTParams` accepts `operating_point` and the voicebot honors it for BYO Speechmatics rows. PR 2b (hail-website): the Providers page STT layer gains a provider select (currently gated off entirely), a Speechmatics option, and an operating-point select, mirroring the existing TTS/llm drawer patterns.
+
+**Tech Stack:** hail: Python/pydantic v2/LiveKit plugin. hail-website: Next.js server actions + pure-helper modules, vitest.
+
+**Design basis:** spec §7 + amendment in `docs/superpowers/specs/2026-07-29-multi-language-voicebot-design.md` (console is now the ONLY STT selector); file-level scout of `~/hail-website/app/console/calls/providers/` (2026-08-07).
+
+## Global Constraints
+
+- hail work on branch `feat/stt-operating-point` off `main` (repo `/Users/r/playground/hail`).
+- hail-website work in a **git worktree** off `master` (repo `/Users/r/hail-website` has uncommitted unrelated work on `feat/competitive-pricing-page` — do not touch the main checkout). Branch `feat/console-speechmatics-stt`. Create via `git -C /Users/r/hail-website worktree add /Users/r/hail-website-wt-speechmatics -b feat/console-speechmatics-stt origin/master`.
+- Conventional Commits. NEVER any Co-Authored-By / AI-attribution trailer.
+- hail: `uv run pytest <pkg>/tests -q` from repo root; `uv run ruff check --fix` + `uvx black` before commits. hail-website: `pnpm test` (vitest), `pnpm lint` if present (check package.json scripts).
+- Ship PR 2a before merging PR 2b's operating-point UI (a console PUT carrying `operating_point` 422s against today's backend). PR 2b's provider-select-only parts work against today's backend but ship together with the field for one review cycle.
+
+---
+
+### Task A1: hail — STTParams.operating_point + voicebot honors it
+
+**Files:**
+
+- Modify: `core/hailhq/core/provider_config.py` (STTParams, ~line 87)
+- Modify: `voicebot/hailhq/voicebot/pipeline.py` (`build_stt` speechmatics branch)
+- Test: `core/tests/schemas/test_voice_config_language.py` (STTParams cases live here from the earlier feature — check; else the file that tests STTParams), `voicebot/tests/test_pipeline_byo.py`
+
+**Interfaces:**
+
+- Produces: `STTParams.operating_point: Literal["enhanced", "standard"] | None = None`; BYO speechmatics rows with `params.operating_point == "standard"` build `speechmatics_plugin.STT` with `OperatingPoint.STANDARD`; default stays ENHANCED everywhere else (house instances included).
+
+- [ ] **Step 1: Write the failing tests**
+
+Core (put beside the existing `test_stt_params_accept_speechmatics`):
+
+```python
+def test_stt_params_operating_point() -> None:
+    assert STTParams(provider="speechmatics").operating_point is None
+    assert (
+        STTParams(provider="speechmatics", operating_point="standard").operating_point
+        == "standard"
+    )
+    with pytest.raises(ValidationError):
+        STTParams(provider="speechmatics", operating_point="turbo")
+```
+
+Voicebot (`voicebot/tests/test_pipeline_byo.py`, beside `test_stt_org_speechmatics_key_used`; the file's `ResolvedLayer` idiom):
+
+```python
+def test_stt_org_speechmatics_operating_point_standard(captured_plugins) -> None:
+    from livekit.plugins import speechmatics as speechmatics_plugin
+
+    from hailhq.voicebot.pipeline import ResolvedLayer, build_stt
+
+    org = ResolvedLayer(
+        provider="speechmatics",
+        api_key="sm-org-key",
+        params={"operating_point": "standard"},
+        fallback_enabled=False,
+    )
+    stt = build_stt(org=org, language="sv", provider="speechmatics")
+    assert stt._stt_options.operating_point == speechmatics_plugin.OperatingPoint.STANDARD
+
+
+def test_stt_org_speechmatics_operating_point_defaults_enhanced(
+    captured_plugins,
+) -> None:
+    from livekit.plugins import speechmatics as speechmatics_plugin
+
+    from hailhq.voicebot.pipeline import ResolvedLayer, build_stt
+
+    org = ResolvedLayer(
+        provider="speechmatics", api_key="sm-org-key", params={}, fallback_enabled=False
+    )
+    stt = build_stt(org=org, language="sv", provider="speechmatics")
+    assert stt._stt_options.operating_point == speechmatics_plugin.OperatingPoint.ENHANCED
+```
+
+First verify `OperatingPoint.STANDARD` exists in the installed plugin
+(`uv run python -c "from livekit.plugins.speechmatics import OperatingPoint; print(list(OperatingPoint))"`)
+and that `_stt_options.operating_point` stores the enum (it stored the enum after the
+2026-07-30 fix commit `9423faf` — re-verify). Adjust assertions to the installed reality.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest core/tests -q -k operating_point && uv run pytest voicebot/tests/test_pipeline_byo.py -q -k operating_point`
+Expected: core FAILS (extra=forbid rejects the field); voicebot FAILS (standard not honored).
+
+- [ ] **Step 3: Implement**
+
+`core/hailhq/core/provider_config.py`:
+
+```python
+class STTParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider: Literal["deepgram", "speechmatics"]
+    model: str | None = None
+    # Speechmatics transcription tier. None -> enhanced. Ignored on deepgram
+    # rows (accepted-but-unused would violate "no hidden behavior", so the
+    # validator below rejects it there).
+    operating_point: Literal["enhanced", "standard"] | None = None
+
+    @model_validator(mode="after")
+    def _operating_point_is_speechmatics_only(self) -> STTParams:
+        if self.provider != "speechmatics" and self.operating_point is not None:
+            raise ValueError("operating_point only applies to speechmatics")
+        return self
+```
+
+(`model_validator` is already imported in this module for `LLMParams`.)
+
+`voicebot/hailhq/voicebot/pipeline.py`, speechmatics branch of `build_stt` — replace the hardcoded operating point:
+
+```python
+        operating_point = speechmatics_plugin.OperatingPoint.ENHANCED
+        if org_matches and org.params.get("operating_point") == "standard":
+            operating_point = speechmatics_plugin.OperatingPoint.STANDARD
+        kwargs: dict[str, Any] = {
+            "language": language or "en",
+            "operating_point": operating_point,
+        }
+```
+
+The house-fallback instance built from `house_kwargs` keeps whatever this sets minus
+`api_key` — that is correct (a failover keeps the org's chosen tier only if the house
+copy uses the same kwargs; keep the existing `house_kwargs = dict(kwargs)` behavior).
+
+- [ ] **Step 4: Run the full core + voicebot suites**
+
+Run: `uv run pytest core/tests -q` (6 pre-existing env failures in test_ses_email/test_twilio_sms are expected) and `uv run pytest voicebot/tests -q`
+Expected: green apart from the known 6.
+
+- [ ] **Step 5: Check whether the internal provider-config routes appear in openapi.yaml**
+
+Run: `grep -n "operating_point\|providers/{layer}" openapi/openapi.yaml | head`
+If the internal provider routes are in the public spec, regen it per `docs/contributing.md` (live-app dump) in this commit. If absent (internal-only routes), no regen.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+uv run ruff check --fix core/hailhq/core/provider_config.py voicebot/hailhq/voicebot/pipeline.py core/tests voicebot/tests
+uvx black core/hailhq/core/provider_config.py voicebot/hailhq/voicebot/pipeline.py
+git add -A core/ voicebot/ openapi/ && git commit -m "feat(voicebot): honor speechmatics operating_point from BYO stt params"
+```
+
+---
+
+### Task B1: hail-website — provider list + drawer UI
+
+**Files (all under the worktree `/Users/r/hail-website-wt-speechmatics/app/console/calls/providers/`):**
+
+- Modify: `drawer-state.ts:6-10`, `params.ts:24-26`, `ProvidersClient.tsx` (lines below)
+- Test: `__tests__/drawer-state.test.ts`, `__tests__/params.test.ts`
+
+**Interfaces:**
+
+- Consumes: backend accepts `provider: "speechmatics"` today; `operating_point` after Task A1.
+- Produces: STT drawer with provider select (deepgram default, speechmatics option) and an enhanced/standard select shown only for speechmatics.
+
+- [ ] **Step 1: Write the failing tests**
+
+`__tests__/drawer-state.test.ts:22` — change to:
+
+```ts
+expect(providersFor("stt")).toEqual(["deepgram", "speechmatics"]);
+```
+
+`__tests__/params.test.ts` — extend the stt case (mirror its existing style at lines 27-31):
+
+```ts
+it("stt speechmatics keeps operating_point; deepgram drops it", () => {
+  expect(
+    buildParams("stt", {
+      provider: "speechmatics",
+      model: "",
+      operating_point: "standard",
+    }),
+  ).toEqual({ operating_point: "standard" });
+  expect(
+    buildParams("stt", {
+      provider: "deepgram",
+      model: "nova-3",
+      operating_point: "standard",
+    }),
+  ).toEqual({ model: "nova-3" });
+});
+```
+
+(Adapt the form-object shape to `buildParams`' actual signature — read `params.ts` first; the scout says the stt branch currently only reads `form.model`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/r/hail-website-wt-speechmatics && pnpm install && pnpm test`
+Expected: the two edited specs FAIL; rest green.
+
+- [ ] **Step 3: Implement**
+
+- `drawer-state.ts:9`: stt returns `["deepgram", "speechmatics"]` — **deepgram stays first** (`initDraft` defaults to `providersFor(layer)[0]`; ordering preserves existing orgs' default).
+- `params.ts` stt branch: keep `put("model", form.model)`; add `operating_point` only when `form.provider === "speechmatics"` (mirror the llm `base_url` guard pattern at ~line 19).
+- `ProvidersClient.tsx`:
+  - Line ~392: change the gate `{layer !== "stt" && (` to `{providersFor(layer).length > 1 && (` so STT now renders the provider select.
+  - Line ~13 `LAYERS` meta: `providerLabel: "Deepgram"` → `"Deepgram / Speechmatics"`.
+  - `Draft` type (~18-32): add `operating_point: string;`.
+  - `initDraft` (~39-56): initialize from `row?.params?.operating_point ?? "enhanced"`.
+  - New field after the tts `voice_id` block (~449), gated `{layer === "stt" && draft.provider === "speechmatics" && (…)}`: a `div.c-fld` (mirror the voice_id markup) containing a `<select>` (mirror the provider select markup) with options `enhanced` / `standard`, bound to `draft.operating_point`.
+  - `onSave` (~137) and `onTest` (~189) inline params objects: add `operating_point: draft.operating_point`.
+  - `TEST_AFFECTING_KEYS` (~382): add `"operating_point"` (else a stale test-✓ survives a tier change).
+  - `formatParams` whitelist (~328): add `"operating_point"` so the ledger shows it.
+  - `providerOptionLabel` (~548-556): add `if (p === "speechmatics") return "Speechmatics";`.
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `pnpm test` and the repo's typecheck/lint scripts (check `package.json` — likely `pnpm lint` / `tsc --noEmit` via a script). All green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/console/calls/providers/ && git commit -m "feat(console): speechmatics BYO stt provider with operating point"
+```
+
+---
+
+### Task B2: manual smoke against local hail backend (verification only)
+
+- [ ] **Step 1:** From the hail repo (branch with Task A1 merged or checked out): start Postgres + API per CLAUDE.md dev commands. From the worktree: `pnpm dev`. In the console Providers page: STT layer now shows the provider select; choose Speechmatics, paste a test key (or a dummy — expect the validation endpoint to return invalid, which still proves the wire-through), pick `standard`, Save. Confirm: no 422 from the PUT, ledger row shows `speechmatics` + `operating_point`.
+- [ ] **Step 2:** Record findings in the task report. If local stack cannot boot (missing env), record exactly what blocked and mark this task deferred for the user — do NOT fake the smoke.
+
+---
+
+### Final: whole-branch reviews
+
+One review per repo diff (hail: `main..feat/stt-operating-point`; website worktree: `master..feat/console-speechmatics-stt`), then hand both branches to the user for push/PR (never push or create PRs).

--- a/voicebot/hailhq/voicebot/main.py
+++ b/voicebot/hailhq/voicebot/main.py
@@ -13,6 +13,7 @@ service's ``LiveKitClient.dispatch_agent`` matches on this name.
 from __future__ import annotations
 
 import logging
+import sys
 
 from hailhq.voicebot.agent import entrypoint, prewarm
 from hailhq.voicebot.pipeline import startup_capability_warnings
@@ -22,9 +23,11 @@ logger = logging.getLogger("hailhq.voicebot")
 
 
 def main() -> None:
-    # Log startup capability warnings before running the app
-    for warning in startup_capability_warnings():
-        logger.warning(warning)
+    # Log startup capability warnings before running the app, but skip for
+    # download-files (which runs in Docker builder stage with no secrets).
+    if sys.argv[1:2] != ["download-files"]:
+        for warning in startup_capability_warnings():
+            logger.warning(warning)
 
     cli.run_app(
         WorkerOptions(

--- a/voicebot/hailhq/voicebot/main.py
+++ b/voicebot/hailhq/voicebot/main.py
@@ -12,11 +12,20 @@ service's ``LiveKitClient.dispatch_agent`` matches on this name.
 
 from __future__ import annotations
 
+import logging
+
 from hailhq.voicebot.agent import entrypoint, prewarm
+from hailhq.voicebot.pipeline import startup_capability_warnings
 from livekit.agents import WorkerOptions, cli
+
+logger = logging.getLogger("hailhq.voicebot")
 
 
 def main() -> None:
+    # Log startup capability warnings before running the app
+    for warning in startup_capability_warnings():
+        logger.warning(warning)
+
     cli.run_app(
         WorkerOptions(
             entrypoint_fnc=entrypoint,

--- a/voicebot/hailhq/voicebot/pipeline.py
+++ b/voicebot/hailhq/voicebot/pipeline.py
@@ -351,8 +351,32 @@ def build_tts(
     applied to every instance built here — BYO and house fallbacks alike —
     so a provider failover never silently switches the call's language back
     to English. ``None`` keeps each plugin's default (English).
+
+    ``fallback_enabled`` on the org row is consent to house-provider
+    rerouting: if the org's BYO provider can't speak ``language`` at all,
+    consent means skip the incapable BYO instance and build the house
+    chain only (this recurses into the ``org is None`` branch below, so it
+    shares that branch's single-instance/adapter shape and its
+    empty-chain ``ProviderKeyError``). Without consent it's a hard error —
+    the API gate (``routes/calls.py``) is meant to catch this before the
+    voicebot ever sees it; this is defense-in-depth for direct LiveKit
+    dispatches that bypass the API.
     """
     if org is not None:
+        if language is not None and org.provider not in tts_providers_for(language):
+            if not org.fallback_enabled:
+                raise ProviderKeyError(
+                    f"org tts provider '{org.provider}' does not support "
+                    f"language '{language}' and fallback is disabled"
+                )
+            logger.warning(
+                "org tts provider %r does not support language %r; "
+                "skipping the BYO instance and using the house chain only "
+                "(fallback consented)",
+                org.provider,
+                language,
+            )
+            return build_tts(None, voice_id_override, language)
         byo = _org_tts(org, voice_id_override, language)
         if org.fallback_enabled:
             house = _house_tts(voice_id_override, language)
@@ -496,8 +520,18 @@ def build_session(
     provider = resolve_stt_provider(org_stt.provider if org_stt else None, language)
     if language is not None and provider not in SUPPORTED_LANGUAGES[language].stt:
         # An org BYO STT row can name a provider that doesn't cover this
-        # language; deepgram covers every supported language, so degrade
-        # rather than fail the call.
+        # language. ``fallback_enabled`` on that row is consent to
+        # house-provider rerouting: with consent, degrade to deepgram
+        # (which covers every supported language); without it, this is a
+        # hard error naming the provider and language — the API gate
+        # (routes/calls.py) is meant to catch this before the voicebot ever
+        # sees it, so this is defense-in-depth for direct LiveKit dispatches
+        # that bypass the API.
+        if org_stt is not None and not org_stt.fallback_enabled:
+            raise ProviderKeyError(
+                f"org stt provider '{provider}' does not support language "
+                f"'{language}' and fallback is disabled"
+            )
         logger.warning(
             "language %r resolved to stt provider %r, which does not "
             "support it; dropping %r and falling back to deepgram (turn "

--- a/voicebot/hailhq/voicebot/pipeline.py
+++ b/voicebot/hailhq/voicebot/pipeline.py
@@ -407,12 +407,15 @@ def build_stt(
 
     org_matches = org is not None and org.provider == provider
     if provider == "speechmatics":
+        # Must be the enum, not the string "enhanced"/"standard": the plugin
+        # stores it unconverted and its .model property does `op.value`,
+        # which raises AttributeError on a plain str at session start.
+        operating_point = speechmatics_plugin.OperatingPoint.ENHANCED
+        if org_matches and org.params.get("operating_point") == "standard":
+            operating_point = speechmatics_plugin.OperatingPoint.STANDARD
         kwargs: dict[str, Any] = {
             "language": language or "en",
-            # Must be the enum, not the string "enhanced": the plugin stores
-            # it unconverted and its .model property does `op.value`, which
-            # raises AttributeError on a plain str at session start.
-            "operating_point": speechmatics_plugin.OperatingPoint.ENHANCED,
+            "operating_point": operating_point,
         }
         if stt_drives_turns:
             kwargs["turn_detection_mode"] = (

--- a/voicebot/hailhq/voicebot/pipeline.py
+++ b/voicebot/hailhq/voicebot/pipeline.py
@@ -68,6 +68,7 @@ from hailhq.core.config import settings
 from hailhq.core.db import session_scope
 from hailhq.core.languages import (
     SUPPORTED_LANGUAGES,
+    default_stt_for,
     resolve_stt_provider,
     tts_providers_for,
     turn_mode_for,
@@ -113,6 +114,7 @@ __all__ = [
     "build_tts",
     "decrypt_llm_metadata",
     "resolve_org_configs",
+    "startup_capability_warnings",
 ]
 
 
@@ -476,6 +478,55 @@ def build_stt(
             )
         return byo
     return deepgram_plugin.STT(**house_kwargs)
+
+
+def startup_capability_warnings() -> list[str]:
+    """Voicebot startup capability warnings based on configured provider keys.
+
+    Checks for missing TTS and STT provider keys and returns warning messages
+    for languages that will have degraded capability as a result.
+
+    Returns:
+        List of warning messages. Empty when all keys are configured.
+    """
+    warnings: list[str] = []
+
+    # Check for unservable TTS languages when cartesia is not configured
+    if not settings.cartesia_api_key:
+        # Determine which TTS providers are available
+        available_tts_providers = set()
+        if settings.eleven_api_key:
+            available_tts_providers.add("elevenlabs")
+
+        # Find languages that have no available TTS provider
+        unservable_langs = []
+        for code in sorted(SUPPORTED_LANGUAGES.keys()):
+            lang_tts_providers = SUPPORTED_LANGUAGES[code].tts
+            if not (lang_tts_providers & available_tts_providers):
+                unservable_langs.append(code)
+
+        if unservable_langs:
+            warnings.append(
+                f"No Cartesia key configured; the following languages have no "
+                f"usable TTS provider: {', '.join(unservable_langs)}"
+            )
+
+    # Check for speechmatics-routed languages when speechmatics is not configured
+    if not settings.speechmatics_api_key:
+        # Identify languages that route to speechmatics by default
+        speechmatics_routed = []
+        for code in sorted(SUPPORTED_LANGUAGES.keys()):
+            if default_stt_for(code) == "speechmatics":
+                speechmatics_routed.append(code)
+
+        if speechmatics_routed:
+            warnings.append(
+                f"No Speechmatics key configured; the following languages will "
+                f"fall back to Deepgram with VAD turn detection: "
+                f"{', '.join(speechmatics_routed)}"
+            )
+
+    return warnings
 
 
 def build_session(

--- a/voicebot/hailhq/voicebot/pipeline.py
+++ b/voicebot/hailhq/voicebot/pipeline.py
@@ -545,7 +545,16 @@ def build_session(
         provider == "speechmatics"
         and not settings.speechmatics_api_key
         and not (org_stt and org_stt.provider == "speechmatics" and org_stt.api_key)
+        and (org_stt is None or org_stt.fallback_enabled)
     ):
+        # No speechmatics key anywhere (house or org BYO). With no org row,
+        # or an org row that consented via fallback_enabled, degrade to
+        # deepgram + VAD turn detection (tenet 4: a deepgram-only self-host
+        # keeps working). An org row with fallback_enabled=False has NOT
+        # consented to this reroute — leave provider="speechmatics" so this
+        # falls through to build_stt(), which raises ProviderKeyError
+        # ("no org or house speechmatics key available") instead of
+        # silently substituting deepgram.
         logger.warning(
             "auto-routing picked speechmatics for language %r but no "
             "SPEECHMATICS_API_KEY is configured (house or org BYO); "

--- a/voicebot/tests/test_pipeline.py
+++ b/voicebot/tests/test_pipeline.py
@@ -471,3 +471,149 @@ def test_build_tts_only_elevenlabs_key_with_cartesia_only_language_raises(
 
     with pytest.raises(ProviderKeyError, match="cannot speak language"):
         build_tts(language="th")
+
+
+def test_startup_capability_warnings_both_keys_returns_empty_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both TTS keys configured → no warnings."""
+    from hailhq.core.config import settings
+    from hailhq.voicebot.pipeline import startup_capability_warnings
+
+    monkeypatch.setattr(settings, "cartesia_api_key", "ct-key")
+    monkeypatch.setattr(settings, "eleven_api_key", "el-key")
+    monkeypatch.setattr(settings, "speechmatics_api_key", "sm-key")
+
+    warnings = startup_capability_warnings()
+    assert warnings == []
+
+
+def test_startup_capability_warnings_cartesia_empty_eleven_set_lists_cartesia_only_languages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cartesia empty + ElevenLabs set → message listing exactly the 7
+    Cartesia-only languages (those in _NO_ELEVENLABS)."""
+    from hailhq.core.config import settings
+    from hailhq.voicebot.pipeline import startup_capability_warnings
+
+    monkeypatch.setattr(settings, "cartesia_api_key", "")
+    monkeypatch.setattr(settings, "eleven_api_key", "el-key")
+    monkeypatch.setattr(settings, "speechmatics_api_key", "sm-key")
+
+    warnings = startup_capability_warnings()
+    assert len(warnings) == 1
+    msg = warnings[0]
+
+    # Should list the 7 Cartesia-only languages
+    expected_langs = {"bn", "gu", "he", "kn", "te", "th", "mr"}
+    for lang in expected_langs:
+        assert lang in msg, f"Language {lang} should be in warning message"
+
+
+def test_startup_capability_warnings_cartesia_empty_eleven_empty_lists_all_tts_languages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cartesia empty + ElevenLabs empty → message listing all TTS-requiring
+    languages (all 40 supported languages)."""
+    from hailhq.core.config import settings
+    from hailhq.core.languages import SUPPORTED_LANGUAGES
+    from hailhq.voicebot.pipeline import startup_capability_warnings
+
+    monkeypatch.setattr(settings, "cartesia_api_key", "")
+    monkeypatch.setattr(settings, "eleven_api_key", "")
+    monkeypatch.setattr(settings, "speechmatics_api_key", "sm-key")
+
+    warnings = startup_capability_warnings()
+    assert len(warnings) == 1
+    msg = warnings[0]
+
+    # Should list all supported languages
+    for lang_code in SUPPORTED_LANGUAGES:
+        assert lang_code in msg, f"Language {lang_code} should be in warning message"
+
+
+def test_startup_capability_warnings_speechmatics_empty_lists_22_languages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Speechmatics empty → message about 22 speechmatics-routed languages
+    falling back to Deepgram + VAD turn detection."""
+    from hailhq.core.config import settings
+    from hailhq.core.languages import default_stt_for
+    from hailhq.voicebot.pipeline import startup_capability_warnings
+
+    monkeypatch.setattr(settings, "cartesia_api_key", "ct-key")
+    monkeypatch.setattr(settings, "eleven_api_key", "el-key")
+    monkeypatch.setattr(settings, "speechmatics_api_key", "")
+
+    warnings = startup_capability_warnings()
+    assert len(warnings) == 1
+    msg = warnings[0]
+
+    # Should mention Deepgram and VAD
+    assert "Deepgram" in msg
+    assert "VAD" in msg or "silence" in msg.lower()
+
+    # Should list exactly the 22 speechmatics-routed languages
+    speechmatics_routed = {
+        code
+        for code in [
+            "ar",
+            "bg",
+            "bn",
+            "cs",
+            "da",
+            "de",
+            "el",
+            "en",
+            "es",
+            "fi",
+            "fr",
+            "gu",
+            "he",
+            "hi",
+            "hr",
+            "hu",
+            "id",
+            "it",
+            "ja",
+            "kn",
+            "ko",
+            "mr",
+            "ms",
+            "nl",
+            "no",
+            "pl",
+            "pt",
+            "ro",
+            "ru",
+            "sk",
+            "sv",
+            "ta",
+            "te",
+            "th",
+            "tl",
+            "tr",
+            "uk",
+            "vi",
+            "zh",
+        ]
+        if default_stt_for(code) == "speechmatics"
+    }
+
+    for lang in speechmatics_routed:
+        assert lang in msg, f"Speechmatics language {lang} should be in message"
+
+
+def test_startup_capability_warnings_both_keys_empty_returns_both_messages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both TTS and Speechmatics keys empty → two warnings."""
+    from hailhq.core.config import settings
+    from hailhq.voicebot.pipeline import startup_capability_warnings
+
+    monkeypatch.setattr(settings, "cartesia_api_key", "")
+    monkeypatch.setattr(settings, "eleven_api_key", "")
+    monkeypatch.setattr(settings, "speechmatics_api_key", "")
+
+    warnings = startup_capability_warnings()
+    assert len(warnings) == 2

--- a/voicebot/tests/test_pipeline.py
+++ b/voicebot/tests/test_pipeline.py
@@ -493,6 +493,8 @@ def test_startup_capability_warnings_cartesia_empty_eleven_set_lists_cartesia_on
 ) -> None:
     """Cartesia empty + ElevenLabs set → message listing exactly the 7
     Cartesia-only languages (those in _NO_ELEVENLABS)."""
+    import re
+
     from hailhq.core.config import settings
     from hailhq.voicebot.pipeline import startup_capability_warnings
 
@@ -504,17 +506,28 @@ def test_startup_capability_warnings_cartesia_empty_eleven_set_lists_cartesia_on
     assert len(warnings) == 1
     msg = warnings[0]
 
-    # Should list the 7 Cartesia-only languages
+    # Extract language codes from the comma-separated list
+    # Format: "...: bn, gu, he, ..." (codes after colon, comma-space separated)
+    match = re.search(r":\s*(.+)$", msg)
+    assert match, f"Could not extract language list from message: {msg}"
+    langs_str = match.group(1)
+    extracted_langs = {code.strip() for code in langs_str.split(", ")}
+
+    # Should list exactly the 7 Cartesia-only languages
     expected_langs = {"bn", "gu", "he", "kn", "te", "th", "mr"}
-    for lang in expected_langs:
-        assert lang in msg, f"Language {lang} should be in warning message"
+    assert (
+        extracted_langs == expected_langs
+    ), f"Expected {expected_langs}, got {extracted_langs}"
+    assert len(extracted_langs) == 7
 
 
 def test_startup_capability_warnings_cartesia_empty_eleven_empty_lists_all_tts_languages(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Cartesia empty + ElevenLabs empty → message listing all TTS-requiring
-    languages (all 40 supported languages)."""
+    languages (all 39 supported languages)."""
+    import re
+
     from hailhq.core.config import settings
     from hailhq.core.languages import SUPPORTED_LANGUAGES
     from hailhq.voicebot.pipeline import startup_capability_warnings
@@ -527,9 +540,18 @@ def test_startup_capability_warnings_cartesia_empty_eleven_empty_lists_all_tts_l
     assert len(warnings) == 1
     msg = warnings[0]
 
-    # Should list all supported languages
-    for lang_code in SUPPORTED_LANGUAGES:
-        assert lang_code in msg, f"Language {lang_code} should be in warning message"
+    # Extract language codes from the comma-separated list
+    match = re.search(r":\s*(.+)$", msg)
+    assert match, f"Could not extract language list from message: {msg}"
+    langs_str = match.group(1)
+    extracted_langs = {code.strip() for code in langs_str.split(", ")}
+
+    # Should list all 39 supported languages
+    expected_langs = set(SUPPORTED_LANGUAGES.keys())
+    assert (
+        extracted_langs == expected_langs
+    ), f"Expected {expected_langs}, got {extracted_langs}"
+    assert len(extracted_langs) == 39
 
 
 def test_startup_capability_warnings_speechmatics_empty_lists_22_languages(
@@ -537,8 +559,10 @@ def test_startup_capability_warnings_speechmatics_empty_lists_22_languages(
 ) -> None:
     """Speechmatics empty → message about 22 speechmatics-routed languages
     falling back to Deepgram + VAD turn detection."""
+    import re
+
     from hailhq.core.config import settings
-    from hailhq.core.languages import default_stt_for
+    from hailhq.core.languages import SUPPORTED_LANGUAGES, default_stt_for
     from hailhq.voicebot.pipeline import startup_capability_warnings
 
     monkeypatch.setattr(settings, "cartesia_api_key", "ct-key")
@@ -553,55 +577,21 @@ def test_startup_capability_warnings_speechmatics_empty_lists_22_languages(
     assert "Deepgram" in msg
     assert "VAD" in msg or "silence" in msg.lower()
 
-    # Should list exactly the 22 speechmatics-routed languages
-    speechmatics_routed = {
-        code
-        for code in [
-            "ar",
-            "bg",
-            "bn",
-            "cs",
-            "da",
-            "de",
-            "el",
-            "en",
-            "es",
-            "fi",
-            "fr",
-            "gu",
-            "he",
-            "hi",
-            "hr",
-            "hu",
-            "id",
-            "it",
-            "ja",
-            "kn",
-            "ko",
-            "mr",
-            "ms",
-            "nl",
-            "no",
-            "pl",
-            "pt",
-            "ro",
-            "ru",
-            "sk",
-            "sv",
-            "ta",
-            "te",
-            "th",
-            "tl",
-            "tr",
-            "uk",
-            "vi",
-            "zh",
-        ]
-        if default_stt_for(code) == "speechmatics"
+    # Extract language codes from the comma-separated list
+    match = re.search(r":\s*(.+)$", msg)
+    assert match, f"Could not extract language list from message: {msg}"
+    langs_str = match.group(1)
+    extracted_langs = {code.strip() for code in langs_str.split(", ")}
+
+    # Compute expected speechmatics-routed languages
+    expected_langs = {
+        code for code in SUPPORTED_LANGUAGES if default_stt_for(code) == "speechmatics"
     }
 
-    for lang in speechmatics_routed:
-        assert lang in msg, f"Speechmatics language {lang} should be in message"
+    assert (
+        extracted_langs == expected_langs
+    ), f"Expected {expected_langs}, got {extracted_langs}"
+    assert len(extracted_langs) == 22
 
 
 def test_startup_capability_warnings_both_keys_empty_returns_both_messages(

--- a/voicebot/tests/test_pipeline.py
+++ b/voicebot/tests/test_pipeline.py
@@ -290,6 +290,61 @@ def test_session_auto_falls_back_to_deepgram_without_speechmatics_key(
     )
 
 
+def test_session_org_speechmatics_row_no_key_without_fallback_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An org speechmatics row with no stored key and no house key is a
+    key-absence failure, not a capability mismatch — but it must still
+    respect the consent flag: fallback_enabled=False means the org has NOT
+    consented to a silent deepgram reroute, so this must raise
+    ProviderKeyError (from build_stt's own fail-fast) rather than degrade."""
+    from hailhq.core.config import settings
+    from hailhq.voicebot.pipeline import ProviderKeyError, ResolvedLayer
+
+    monkeypatch.setattr(settings, "speechmatics_api_key", "")
+    org_cfgs = {
+        "stt": ResolvedLayer(
+            provider="speechmatics",
+            api_key=None,
+            params={},
+            fallback_enabled=False,
+        )
+    }
+    with pytest.raises(ProviderKeyError, match="speechmatics"):
+        _make_session("da", org_cfgs=org_cfgs)
+
+
+def test_session_org_speechmatics_row_no_key_with_fallback_degrades(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Same no-key org row, but fallback_enabled=True: consent to reroute,
+    so this degrades to deepgram + VAD turns with the existing warning."""
+    import logging
+
+    from hailhq.core.config import settings
+    from hailhq.voicebot.pipeline import ResolvedLayer
+    from livekit.plugins import deepgram as deepgram_plugin
+
+    monkeypatch.setattr(settings, "speechmatics_api_key", "")
+    org_cfgs = {
+        "stt": ResolvedLayer(
+            provider="speechmatics",
+            api_key=None,
+            params={},
+            fallback_enabled=True,
+        )
+    }
+    with caplog.at_level(logging.WARNING, logger="hailhq.voicebot"):
+        session = _make_session("da", org_cfgs=org_cfgs)
+    assert isinstance(session.stt, deepgram_plugin.STT)
+    assert session.turn_detection == "vad"
+    assert any(
+        "da" in record.message and "speechmatics" in record.message
+        for record in caplog.records
+    )
+
+
 def test_session_org_stt_incapable_with_fallback_degrades(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/voicebot/tests/test_pipeline.py
+++ b/voicebot/tests/test_pipeline.py
@@ -290,13 +290,14 @@ def test_session_auto_falls_back_to_deepgram_without_speechmatics_key(
     )
 
 
-def test_session_org_row_unsupported_by_language_degrades_to_deepgram(
+def test_session_org_stt_incapable_with_fallback_degrades(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """'gu' (Gujarati) has no Speechmatics coverage (``_NO_SPEECHMATICS``).
     An org's console BYO STT row can still name speechmatics generally
-    (it's not language-scoped), so ``build_session`` must degrade to
-    deepgram rather than construct an incompatible provider — and warn."""
+    (it's not language-scoped); with ``fallback_enabled=True`` (consent to
+    house-provider rerouting) ``build_session`` degrades to deepgram rather
+    than construct an incompatible provider — and warns."""
     import logging
 
     from hailhq.voicebot.pipeline import ResolvedLayer
@@ -307,7 +308,7 @@ def test_session_org_row_unsupported_by_language_degrades_to_deepgram(
             provider="speechmatics",
             api_key="org-sm-key",
             params={},
-            fallback_enabled=False,
+            fallback_enabled=True,
         )
     }
     with caplog.at_level(logging.WARNING, logger="hailhq.voicebot"):
@@ -317,6 +318,25 @@ def test_session_org_row_unsupported_by_language_degrades_to_deepgram(
         "gu" in record.message and "speechmatics" in record.message
         for record in caplog.records
     )
+
+
+def test_session_org_stt_incapable_without_fallback_raises() -> None:
+    """Same incapable org row as above, but ``fallback_enabled=False``: no
+    consent to reroute to deepgram, so this is a hard ``ProviderKeyError``
+    naming the provider and language, never a silent degrade."""
+    from hailhq.voicebot.pipeline import ProviderKeyError, ResolvedLayer
+
+    org_cfgs = {
+        "stt": ResolvedLayer(
+            provider="speechmatics",
+            api_key="org-sm-key",
+            params={},
+            fallback_enabled=False,
+        )
+    }
+    with pytest.raises(ProviderKeyError, match="speechmatics") as exc_info:
+        _make_session("gu", org_cfgs=org_cfgs)
+    assert "gu" in str(exc_info.value)
 
 
 def test_session_unknown_language_degrades_to_defaults(

--- a/voicebot/tests/test_pipeline_byo.py
+++ b/voicebot/tests/test_pipeline_byo.py
@@ -229,6 +229,34 @@ def test_stt_org_row_ignored_when_pinned_to_other_provider(
     assert isinstance(stt, deepgram_plugin.STT)
 
 
+def test_build_tts_org_incapable_with_fallback_uses_house_only(
+    captured_plugins,
+) -> None:
+    """Org elevenlabs row can't speak 'th' (Cartesia-only); fallback_enabled
+    is consent to reroute — the BYO instance is skipped entirely and the
+    house chain (Cartesia only, for 'th') is returned."""
+    org = ResolvedLayer(
+        provider="elevenlabs", api_key="org-key", params={}, fallback_enabled=True
+    )
+    tts = build_tts(org, language="th")
+    assert "elevenlabs" not in captured_plugins
+    assert len(captured_plugins["cartesia"]) == 1
+    assert "api_key" not in captured_plugins["cartesia"][0].kwargs
+    assert tts is not None
+
+
+def test_build_tts_org_incapable_without_fallback_raises(captured_plugins) -> None:
+    """Same incapable org row, but fallback_enabled=False: no consent to
+    reroute, so this is a hard error naming the provider and language."""
+    org = ResolvedLayer(
+        provider="elevenlabs", api_key="org-key", params={}, fallback_enabled=False
+    )
+    with pytest.raises(ProviderKeyError, match="elevenlabs") as exc_info:
+        build_tts(org, language="th")
+    assert "th" in str(exc_info.value)
+    assert "elevenlabs" not in captured_plugins
+
+
 def test_fallback_enabled_wraps_house_after_byo(captured_plugins) -> None:
     org = ResolvedLayer(
         provider="cartesia", api_key="org-key", params={}, fallback_enabled=True

--- a/voicebot/tests/test_pipeline_byo.py
+++ b/voicebot/tests/test_pipeline_byo.py
@@ -181,6 +181,37 @@ def test_stt_org_speechmatics_key_used(captured_plugins) -> None:
     assert stt._api_key == "sm-org-key"
 
 
+def test_stt_org_speechmatics_operating_point_standard(captured_plugins) -> None:
+    from hailhq.voicebot.pipeline import ResolvedLayer, build_stt
+    from livekit.plugins import speechmatics as speechmatics_plugin
+
+    org = ResolvedLayer(
+        provider="speechmatics",
+        api_key="sm-org-key",
+        params={"operating_point": "standard"},
+        fallback_enabled=False,
+    )
+    stt = build_stt(org=org, language="sv", provider="speechmatics")
+    assert (
+        stt._stt_options.operating_point == speechmatics_plugin.OperatingPoint.STANDARD
+    )
+
+
+def test_stt_org_speechmatics_operating_point_defaults_enhanced(
+    captured_plugins,
+) -> None:
+    from hailhq.voicebot.pipeline import ResolvedLayer, build_stt
+    from livekit.plugins import speechmatics as speechmatics_plugin
+
+    org = ResolvedLayer(
+        provider="speechmatics", api_key="sm-org-key", params={}, fallback_enabled=False
+    )
+    stt = build_stt(org=org, language="sv", provider="speechmatics")
+    assert (
+        stt._stt_options.operating_point == speechmatics_plugin.OperatingPoint.ENHANCED
+    )
+
+
 def test_stt_org_row_ignored_when_pinned_to_other_provider(
     captured_plugins,
 ) -> None:


### PR DESCRIPTION
Backend half of the console Speechmatics BYO feature (merge this BEFORE hail-website's feat/console-speechmatics-stt — the console always sends operating_point for speechmatics saves, which 422s against a backend without this PR).

- STTParams accepts operating_point (enhanced/standard, speechmatics-only, model_validator-enforced); the voicebot honors it for BYO speechmatics rows, house fallback inherits the tier.
- Consent rule: fallback_enabled on a BYO row is consent to house-provider rerouting. Without it, a capability mismatch 422s at call creation (STT and TTS symmetric) and key gaps fail fast in the voicebot instead of silently rerouting.
- With consent: STT degrades to house Deepgram (warned); TTS skips the incapable BYO instance and serves via the house chain.
- Voicebot startup warnings list unservable languages given configured keys (skipped for download-files so image builds stay quiet).
- Route-level tests cover the console's exact payloads (speechmatics+operating_point accepted; deepgram+operating_point 422; validate passthrough).

Suites: api 493, voicebot 170, core 597 (+6 pre-existing env-dependent failures unrelated to this change).
Plan: docs/superpowers/plans/2026-08-07-console-speechmatics-byo.md