### PR TITLE
fix(api): gate POST /numbers on the balance check (402 when broke)

### DIFF
--- a/api/hailhq/api/routes/numbers.py
+++ b/api/hailhq/api/routes/numbers.py
@@ -18,6 +18,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi import status as http_status
 from hailhq.api.deps import Principal, get_current_principal
 from hailhq.api.errors import unprocessable
+from hailhq.api.funds import require_funds
 from hailhq.api.idempotency import (
     IdempotencyContext,
     cache_failure,
@@ -95,6 +96,11 @@ async def acquire_number(
     if idem is not None and idem.is_replay:
         _cached_id, cached = replay_cached(idem, response, resource_prefix="/numbers")
         return PhoneNumberResponse.model_validate(cached)
+
+    # Acquiring buys a real number at the carrier and starts a monthly fee —
+    # same balance gate as the other paid create routes (/calls, /sms,
+    # /emails). Must run before the carrier purchase below.
+    await require_funds(db, principal, idem)
 
     caps = telephony_catalog.capabilities(body.country_code, body.number_type)
     if caps is None:

--- a/api/tests/test_numbers_api.py
+++ b/api/tests/test_numbers_api.py
@@ -52,6 +52,26 @@ async def test_acquire_number_requires_auth(client) -> None:
     assert resp.status_code == 401
 
 
+async def test_acquire_number_402_zero_balance(
+    client, async_session, voice_provider_mock
+) -> None:
+    """A zero-balance org must not purchase a number: 402 before the carrier
+    is ever reached — same gate as POST /calls, /sms, /emails."""
+    from .conftest import insert_org_and_key
+
+    _, _, plaintext = await insert_org_and_key(
+        async_session, org_slug="broke-numbers", initial_credit_cents=0
+    )
+    resp = await client.post(
+        "/numbers",
+        json={"country_code": "US", "number_type": "local"},
+        headers={"Authorization": f"Bearer {plaintext}"},
+    )
+    assert resp.status_code == 402, resp.text
+    assert "credits" in resp.json()["detail"].lower()
+    voice_provider_mock.acquire_number.assert_not_awaited()
+
+
 async def test_acquire_number_happy_path(
     client, org_and_key, voice_provider_mock
 ) -> None:


### PR DESCRIPTION
## Problem

`POST /numbers` purchases a real number at the carrier with **no funds gate** — it never had one (`git log -S require_funds` on the route is empty). An org with a zero or never-funded balance could acquire dedicated numbers.

Confirmed in prod: org `191cce22-2127-4363-9f2f-ac4c5b2166a6` (viren@adverix.net) has zero `account_credits` rows ever, yet holds dedicated number `+16693382961` (acquired 2026-08-06).

## Fix

Apply the shared `require_funds` gate (same 402 as `/calls`, `/sms`, `/emails`) in `acquire_number`, after the idempotency replay check and before the carrier purchase. The 402 is cached under the idempotency key, mirroring the other routes.

## Tests

- New: `test_acquire_number_402_zero_balance` — zero-balance org gets 402, provider never awaited. Written first, failed with 201, passes with the gate.
- Full API suite: 488 passed.

## Not in this PR

Acquisition still books no immediate debit (the monthly-fee rater bills from acquisition date). Auto-release of numbers for negative-balance orgs is being designed separately.