### PR TITLE
feat(api): number release — DELETE /numbers/{id}, internal dunning release, number_dunning table

### DIFF
--- a/api/hailhq/api/main.py
+++ b/api/hailhq/api/main.py
@@ -24,6 +24,7 @@ from hailhq.api.routes import unsubscribe as unsubscribe_routes
 from hailhq.api.routes import webhooks as webhooks_routes
 from hailhq.api.routes.internal import agent as internal_agent
 from hailhq.api.routes.internal import dsar as internal_dsar
+from hailhq.api.routes.internal import numbers as internal_numbers
 from hailhq.api.routes.internal import org_closures as internal_org_closures
 from hailhq.api.routes.internal import provider_config as internal_provider_config
 from hailhq.api.routes.internal import ses_events as internal_ses_events
@@ -286,6 +287,7 @@ app.include_router(internal_org_closures.router)
 app.include_router(internal_provider_config.router)
 app.include_router(internal_dsar.router)
 app.include_router(internal_agent.router)
+app.include_router(internal_numbers.router)
 
 
 @app.get("/healthz")

--- a/api/hailhq/api/routes/internal/numbers.py
+++ b/api/hailhq/api/routes/internal/numbers.py
@@ -12,6 +12,7 @@ Shared-secret HMAC auth, same as the rest of ``routes/internal/`` — see
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated
 from uuid import UUID
 
@@ -25,6 +26,8 @@ from hailhq.core.providers.voice import VoiceProvider
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/internal",
@@ -60,6 +63,15 @@ async def release_number_internal(
         raise HTTPException(
             status_code=http_status.HTTP_404_NOT_FOUND, detail="number not found"
         )
+    # `source` is provenance-only; log it so a dunning release and a future
+    # operator release are distinguishable after the fact (`released_at` says
+    # when, this says why).
+    logger.info(
+        "internal release of number %s (org %s, source=%s)",
+        body.number_id,
+        body.organization_id,
+        body.source,
+    )
     number = await release_org_number(db, provider, number)
     return {
         "number_id": str(number.id),

--- a/api/hailhq/api/routes/internal/numbers.py
+++ b/api/hailhq/api/routes/internal/numbers.py
@@ -1,0 +1,69 @@
+"""POST /internal/numbers/release — hail-website → API.
+
+Called by hail-website's dunning job (app/api/internal/billing/dunning)
+when an org has held active dedicated numbers on a zero or negative
+balance past the announced grace deadline. Releases one number at the
+carrier and marks the row released, via the same helper as the public
+DELETE /numbers/{id} so the two paths cannot drift.
+
+Shared-secret HMAC auth, same as the rest of ``routes/internal/`` — see
+``routes/internal/auth.py``. Not in the public OpenAPI spec.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi import status as http_status
+from hailhq.api.routes.internal.auth import verify_internal_request
+from hailhq.api.routes.numbers import get_voice_provider, release_org_number
+from hailhq.core.db import get_session
+from hailhq.core.models import PhoneNumber
+from hailhq.core.providers.voice import VoiceProvider
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+router = APIRouter(
+    prefix="/internal",
+    tags=["internal"],
+    include_in_schema=False,
+    dependencies=[Depends(verify_internal_request)],
+)
+
+
+class NumberReleaseIn(BaseModel):
+    organization_id: UUID
+    number_id: UUID
+    # Free-form provenance, e.g. "dunning".
+    source: str = "hail_website"
+
+
+@router.post("/numbers/release")
+async def release_number_internal(
+    body: NumberReleaseIn,
+    db: Annotated[AsyncSession, Depends(get_session)],
+    provider: Annotated[VoiceProvider, Depends(get_voice_provider)],
+) -> dict:
+    number = (
+        await db.execute(
+            select(PhoneNumber).where(
+                PhoneNumber.id == body.number_id,
+                PhoneNumber.organization_id == body.organization_id,
+                PhoneNumber.is_pool.is_(False),
+            )
+        )
+    ).scalar_one_or_none()
+    if number is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND, detail="number not found"
+        )
+    number = await release_org_number(db, provider, number)
+    return {
+        "number_id": str(number.id),
+        "e164": number.e164,
+        "provisioning_state": number.provisioning_state,
+        "released_at": number.released_at.isoformat() if number.released_at else None,
+    }

--- a/api/hailhq/api/routes/internal/numbers.py
+++ b/api/hailhq/api/routes/internal/numbers.py
@@ -3,7 +3,7 @@
 Called by hail-website's dunning job (app/api/internal/billing/dunning)
 when an org has held active dedicated numbers on a zero or negative
 balance past the announced grace deadline. Releases one number at the
-carrier and marks the row released, via the same helper as the public
+carrier and marks the row released, via the same helpers as the public
 DELETE /numbers/{id} so the two paths cannot drift.
 
 Shared-secret HMAC auth, same as the rest of ``routes/internal/`` — see
@@ -16,15 +16,17 @@ import logging
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
-from fastapi import status as http_status
+from fastapi import APIRouter, Depends
+from hailhq.api.audit import write_audit_log
 from hailhq.api.routes.internal.auth import verify_internal_request
-from hailhq.api.routes.numbers import get_voice_provider, release_org_number
+from hailhq.api.routes.numbers import (
+    _get_org_number_or_404,
+    get_voice_provider,
+    release_org_number,
+)
 from hailhq.core.db import get_session
-from hailhq.core.models import PhoneNumber
 from hailhq.core.providers.voice import VoiceProvider
-from pydantic import BaseModel
-from sqlalchemy import select
+from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
@@ -40,8 +42,9 @@ router = APIRouter(
 class NumberReleaseIn(BaseModel):
     organization_id: UUID
     number_id: UUID
-    # Free-form provenance, e.g. "dunning".
-    source: str = "hail_website"
+    # Free-form provenance, e.g. "dunning". Bounded so a crafted body can't
+    # flood the log line / audit payload it lands in.
+    source: str = Field(default="hail_website", max_length=64)
 
 
 @router.post("/numbers/release")
@@ -50,19 +53,10 @@ async def release_number_internal(
     db: Annotated[AsyncSession, Depends(get_session)],
     provider: Annotated[VoiceProvider, Depends(get_voice_provider)],
 ) -> dict:
-    number = (
-        await db.execute(
-            select(PhoneNumber).where(
-                PhoneNumber.id == body.number_id,
-                PhoneNumber.organization_id == body.organization_id,
-                PhoneNumber.is_pool.is_(False),
-            )
-        )
-    ).scalar_one_or_none()
-    if number is None:
-        raise HTTPException(
-            status_code=http_status.HTTP_404_NOT_FOUND, detail="number not found"
-        )
+    # Same lookup as the public routes (no is_pool filter needed: the
+    # phone_numbers_pool_owner_xor CHECK guarantees a row matching a non-null
+    # organization_id is never a pool row).
+    number = await _get_org_number_or_404(db, body.number_id, body.organization_id)
     # `source` is provenance-only; log it so a dunning release and a future
     # operator release are distinguishable after the fact (`released_at` says
     # when, this says why).
@@ -72,7 +66,19 @@ async def release_number_internal(
         body.organization_id,
         body.source,
     )
+    was_released = number.provisioning_state == "released"
     number = await release_org_number(db, provider, number)
+    if not was_released:
+        # Same audit action as DELETE /numbers/{id}; api_key_id is None
+        # because no API key acts here — `source` says who did.
+        await write_audit_log(
+            organization_id=body.organization_id,
+            api_key_id=None,
+            action="number.release",
+            resource_type="phone_number",
+            resource_id=number.id,
+            payload={"e164": number.e164, "source": body.source},
+        )
     return {
         "number_id": str(number.id),
         "e164": number.e164,

--- a/api/hailhq/api/routes/numbers.py
+++ b/api/hailhq/api/routes/numbers.py
@@ -208,7 +208,18 @@ async def release_org_number(
     await provider.release_number(number.provider_resource_id)
     number.provisioning_state = "released"
     number.released_at = datetime.now(timezone.utc)
-    await db.commit()
+    try:
+        await db.commit()
+    except Exception:
+        # The carrier release already happened; until a retry converges the
+        # row, the monthly-fee rater keeps billing a number that is gone at
+        # Twilio. Loud on purpose.
+        logger.error(
+            "number %s released at carrier but the DB commit failed; "
+            "retry the release to stop billing",
+            number.id,
+        )
+        raise
     return number
 
 
@@ -271,6 +282,14 @@ async def enable_sms(
 ) -> PhoneNumberResponse:
     number = await _get_org_number_or_404(db, number_id, principal.organization_id)
 
+    # A released row is a tombstone: its PN is deleted at Twilio, so
+    # attach_number would 404 into an opaque 500.
+    if number.provisioning_state == "released":
+        raise unprocessable(
+            "this number has been released; acquire a new number instead",
+            loc=["path", "number_id"],
+        )
+
     if "sms" not in number.capabilities:
         raise unprocessable(
             "this number does not support sms (fixed at purchase time by the "
@@ -295,8 +314,14 @@ async def enable_sms(
         {"key": str(principal.organization_id)},
     )
     # Re-read under the lock: a concurrent enable of THIS number may have just
-    # attached it (its SID was NULL when the row was first loaded).
-    await db.refresh(number, ["messaging_service_sid"])
+    # attached it (its SID was NULL when the row was first loaded), and a
+    # concurrent release may have tombstoned it (its PN is gone at Twilio).
+    await db.refresh(number, ["messaging_service_sid", "provisioning_state"])
+    if number.provisioning_state == "released":
+        raise unprocessable(
+            "this number has been released; acquire a new number instead",
+            loc=["path", "number_id"],
+        )
     if number.messaging_service_sid is not None:
         return PhoneNumberResponse.model_validate(number)
 

--- a/api/hailhq/api/routes/numbers.py
+++ b/api/hailhq/api/routes/numbers.py
@@ -11,6 +11,7 @@ stays with the rest of the `/numbers` router rather than splitting onto
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from typing import Annotated
 from uuid import UUID
 
@@ -192,6 +193,39 @@ async def acquire_number(
     return number_response
 
 
+async def release_org_number(
+    db: AsyncSession, provider: VoiceProvider, number: PhoneNumber
+) -> PhoneNumber:
+    """Release a dedicated number at the carrier and mark the row released.
+
+    Idempotent: an already-released row is returned unchanged, and the
+    provider tolerates a number that is already gone at the carrier.
+    Shared by DELETE /numbers/{id} and the internal dunning release
+    (routes/internal/numbers.py) so both paths stay identical.
+    """
+    if number.provisioning_state == "released":
+        return number
+    await provider.release_number(number.provider_resource_id)
+    number.provisioning_state = "released"
+    number.released_at = datetime.now(timezone.utc)
+    await db.commit()
+    return number
+
+
+@router.delete("/{number_id}", status_code=http_status.HTTP_204_NO_CONTENT)
+async def release_number(
+    number_id: UUID,
+    principal: Annotated[Principal, Depends(get_current_principal)],
+    db: Annotated[AsyncSession, Depends(get_session)],
+    provider: Annotated[VoiceProvider, Depends(get_voice_provider)],
+) -> None:
+    """Release a dedicated number. The monthly fee stops accruing after the
+    release month; months already accrued stay owed (the rater bills late,
+    never forgives)."""
+    number = await _get_org_number_or_404(db, number_id, principal.organization_id)
+    await release_org_number(db, provider, number)
+
+
 @router.get("/{number_id}", response_model=PhoneNumberResponse)
 async def get_number(
     number_id: UUID,
@@ -299,4 +333,4 @@ async def enable_sms(
     return PhoneNumberResponse.model_validate(number)
 
 
-__all__ = ["get_voice_provider", "router"]
+__all__ = ["get_voice_provider", "release_org_number", "router"]

--- a/api/hailhq/api/routes/numbers.py
+++ b/api/hailhq/api/routes/numbers.py
@@ -17,6 +17,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi import status as http_status
+from hailhq.api.audit import write_audit_log
 from hailhq.api.deps import Principal, get_current_principal
 from hailhq.api.errors import unprocessable
 from hailhq.api.funds import require_funds
@@ -193,6 +194,17 @@ async def acquire_number(
     return number_response
 
 
+def _reject_if_released(number: PhoneNumber) -> None:
+    """422 on a released row. A released row is a tombstone: its PN is
+    deleted at Twilio, so any provisioning call against it would 404 into
+    an opaque 500."""
+    if number.provisioning_state == "released":
+        raise unprocessable(
+            "this number has been released; acquire a new number instead",
+            loc=["path", "number_id"],
+        )
+
+
 async def release_org_number(
     db: AsyncSession, provider: VoiceProvider, number: PhoneNumber
 ) -> PhoneNumber:
@@ -203,6 +215,19 @@ async def release_org_number(
     Shared by DELETE /numbers/{id} and the internal dunning release
     (routes/internal/numbers.py) so both paths stay identical.
     """
+    # Serialize against enable_sms: it re-checks provisioning_state under the
+    # org-keyed advisory lock and then talks to Twilio, so a release that does
+    # not contend for the same lock could delete the PN between that re-check
+    # and attach_number (an opaque Twilio 404 → 500, and a Messaging Service
+    # SID committed onto a tombstone). Transaction-scoped: released at the
+    # commit below (or at rollback).
+    await db.execute(
+        text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))"),
+        {"key": str(number.organization_id)},
+    )
+    # Re-read under the lock: a concurrent release may have already
+    # tombstoned the row after our caller loaded it.
+    await db.refresh(number, ["provisioning_state", "released_at"])
     if number.provisioning_state == "released":
         return number
     await provider.release_number(number.provider_resource_id)
@@ -234,7 +259,19 @@ async def release_number(
     release month; months already accrued stay owed (the rater bills late,
     never forgives)."""
     number = await _get_org_number_or_404(db, number_id, principal.organization_id)
+    # Best-effort pre-check so an idempotent re-DELETE doesn't append a
+    # second audit entry (audit is a safety net, not a correctness gate).
+    was_released = number.provisioning_state == "released"
     await release_org_number(db, provider, number)
+    if not was_released:
+        await write_audit_log(
+            organization_id=principal.organization_id,
+            api_key_id=principal.api_key_id,
+            action="number.release",
+            resource_type="phone_number",
+            resource_id=number.id,
+            payload={"e164": number.e164},
+        )
 
 
 @router.get("/{number_id}", response_model=PhoneNumberResponse)
@@ -282,13 +319,7 @@ async def enable_sms(
 ) -> PhoneNumberResponse:
     number = await _get_org_number_or_404(db, number_id, principal.organization_id)
 
-    # A released row is a tombstone: its PN is deleted at Twilio, so
-    # attach_number would 404 into an opaque 500.
-    if number.provisioning_state == "released":
-        raise unprocessable(
-            "this number has been released; acquire a new number instead",
-            loc=["path", "number_id"],
-        )
+    _reject_if_released(number)
 
     if "sms" not in number.capabilities:
         raise unprocessable(
@@ -307,8 +338,10 @@ async def enable_sms(
     # otherwise both observe no existing service and each create one (leaving
     # orphaned duplicates). A transaction-scoped advisory lock keyed on the org
     # (auto-released at commit/rollback) makes any waiter see the first
-    # request's committed result. No other code path takes advisory locks, so
-    # the org-derived key can't collide.
+    # request's committed result. release_org_number takes the same org-keyed
+    # lock on purpose — that is what makes the released re-check below
+    # authoritative rather than a race window; no other code path takes
+    # advisory locks.
     await db.execute(
         text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))"),
         {"key": str(principal.organization_id)},
@@ -317,11 +350,7 @@ async def enable_sms(
     # attached it (its SID was NULL when the row was first loaded), and a
     # concurrent release may have tombstoned it (its PN is gone at Twilio).
     await db.refresh(number, ["messaging_service_sid", "provisioning_state"])
-    if number.provisioning_state == "released":
-        raise unprocessable(
-            "this number has been released; acquire a new number instead",
-            loc=["path", "number_id"],
-        )
+    _reject_if_released(number)
     if number.messaging_service_sid is not None:
         return PhoneNumberResponse.model_validate(number)
 

--- a/api/migrations/versions/0040_number_dunning.py
+++ b/api/migrations/versions/0040_number_dunning.py
@@ -1,0 +1,40 @@
+"""Create number_dunning — per-org warn-then-release state for unfunded numbers.
+
+One row per org that holds active dedicated numbers on a zero/negative
+balance and has been warned by email. Written and cleared by hail-website's
+dunning job; ``release_after`` (warned_at + grace) is fixed at warn time so
+the announced deadline never moves.
+
+Revision ID: 0040
+Revises: 0039
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "0040"
+down_revision: str | None = "0039"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "number_dunning",
+        sa.Column("organization_id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("warned_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("release_after", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("number_dunning")

--- a/api/migrations/versions/0041_e164_release_reuse.py
+++ b/api/migrations/versions/0041_e164_release_reuse.py
@@ -12,6 +12,7 @@ Revises: 0040
 
 from __future__ import annotations
 
+import sqlalchemy as sa
 from alembic import op
 
 revision: str = "0041"
@@ -32,5 +33,26 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # The full UNIQUE cannot be rebuilt once a released tombstone shares an
+    # e164 with a live re-acquired row — the exact state this migration
+    # exists to allow. Fail with an explanation instead of a bare
+    # duplicate-key error halfway through a rollback.
+    dup = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                "SELECT e164 FROM phone_numbers"
+                " GROUP BY e164 HAVING count(*) > 1 LIMIT 1"
+            )
+        )
+        .first()
+    )
+    if dup is not None:
+        raise RuntimeError(
+            "cannot downgrade 0041: multiple phone_numbers rows share e164 "
+            f"{dup[0]!r} (a released tombstone plus a re-acquired live row). "
+            "Delete or re-number the tombstone rows first, then re-run the "
+            "downgrade."
+        )
     op.drop_index("phone_numbers_e164_live_uniq", table_name="phone_numbers")
     op.create_unique_constraint("phone_numbers_e164_key", "phone_numbers", ["e164"])

--- a/api/migrations/versions/0041_e164_release_reuse.py
+++ b/api/migrations/versions/0041_e164_release_reuse.py
@@ -1,0 +1,36 @@
+"""Make phone_numbers.e164 uniqueness partial: released rows are tombstones.
+
+Release (0040's dunning flow, DELETE /numbers/{id}) keeps the row for
+billing history. With the full UNIQUE from 0001, re-acquiring a number
+Twilio later recycles would purchase it at the carrier and then fail the
+INSERT — a 500, an orphaned paid number, and a stuck idempotency key.
+Only non-released rows need to be unique.
+
+Revision ID: 0041
+Revises: 0040
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "0041"
+down_revision: str | None = "0040"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("phone_numbers_e164_key", "phone_numbers", type_="unique")
+    op.create_index(
+        "phone_numbers_e164_live_uniq",
+        "phone_numbers",
+        ["e164"],
+        unique=True,
+        postgresql_where="provisioning_state <> 'released'",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("phone_numbers_e164_live_uniq", table_name="phone_numbers")
+    op.create_unique_constraint("phone_numbers_e164_key", "phone_numbers", ["e164"])

--- a/api/tests/test_internal_numbers.py
+++ b/api/tests/test_internal_numbers.py
@@ -1,0 +1,108 @@
+"""Tests for POST /internal/numbers/release (dunning release path)."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import uuid
+
+import pytest
+from hailhq.core.config import settings
+from hailhq.core.models import PhoneNumber
+from sqlalchemy.ext.asyncio import AsyncSession
+
+HMAC_SECRET = "test-internal-secret"
+
+
+def _signed(body: bytes) -> dict[str, str]:
+    sig = hmac.new(HMAC_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    return {"X-Hail-Signature": f"sha256={sig}", "Content-Type": "application/json"}
+
+
+@pytest.fixture()
+def internal_secret_set(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(settings, "hail_internal_secret", HMAC_SECRET)
+
+
+async def _seed_number(
+    session: AsyncSession, org_id: uuid.UUID, *, state: str = "active"
+) -> PhoneNumber:
+    pn = PhoneNumber(
+        organization_id=org_id,
+        e164=f"+1415555{uuid.uuid4().hex[:4]}",
+        country_code="US",
+        number_type="local",
+        provider="twilio",
+        provider_resource_id=f"PN-{uuid.uuid4()}",
+        provisioning_state=state,
+    )
+    session.add(pn)
+    await session.commit()
+    return pn
+
+
+async def test_internal_release_releases_number(
+    client, async_session, voice_provider_mock, internal_secret_set
+) -> None:
+    org_id = uuid.uuid4()
+    pn = await _seed_number(async_session, org_id)
+
+    body = json.dumps(
+        {"organization_id": str(org_id), "number_id": str(pn.id), "source": "dunning"}
+    ).encode()
+    resp = await client.post(
+        "/internal/numbers/release", content=body, headers=_signed(body)
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["provisioning_state"] == "released"
+    assert payload["released_at"] is not None
+    voice_provider_mock.release_number.assert_awaited_once_with(
+        pn.provider_resource_id
+    )
+
+
+async def test_internal_release_idempotent_when_already_released(
+    client, async_session, voice_provider_mock, internal_secret_set
+) -> None:
+    org_id = uuid.uuid4()
+    pn = await _seed_number(async_session, org_id, state="released")
+
+    body = json.dumps(
+        {"organization_id": str(org_id), "number_id": str(pn.id)}
+    ).encode()
+    resp = await client.post(
+        "/internal/numbers/release", content=body, headers=_signed(body)
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["provisioning_state"] == "released"
+    voice_provider_mock.release_number.assert_not_awaited()
+
+
+async def test_internal_release_404_on_org_mismatch(
+    client, async_session, voice_provider_mock, internal_secret_set
+) -> None:
+    pn = await _seed_number(async_session, uuid.uuid4())
+
+    body = json.dumps(
+        {"organization_id": str(uuid.uuid4()), "number_id": str(pn.id)}
+    ).encode()
+    resp = await client.post(
+        "/internal/numbers/release", content=body, headers=_signed(body)
+    )
+    assert resp.status_code == 404
+    voice_provider_mock.release_number.assert_not_awaited()
+
+
+async def test_internal_release_401_without_signature(
+    client, async_session, voice_provider_mock, internal_secret_set
+) -> None:
+    pn = await _seed_number(async_session, uuid.uuid4())
+
+    resp = await client.post(
+        "/internal/numbers/release",
+        json={"organization_id": str(pn.organization_id), "number_id": str(pn.id)},
+    )
+    assert resp.status_code == 401
+    voice_provider_mock.release_number.assert_not_awaited()

--- a/api/tests/test_internal_numbers.py
+++ b/api/tests/test_internal_numbers.py
@@ -58,9 +58,7 @@ async def test_internal_release_releases_number(
     payload = resp.json()
     assert payload["provisioning_state"] == "released"
     assert payload["released_at"] is not None
-    voice_provider_mock.release_number.assert_awaited_once_with(
-        pn.provider_resource_id
-    )
+    voice_provider_mock.release_number.assert_awaited_once_with(pn.provider_resource_id)
 
 
 async def test_internal_release_idempotent_when_already_released(

--- a/api/tests/test_migrations.py
+++ b/api/tests/test_migrations.py
@@ -671,3 +671,21 @@ def test_0017_custom_domain_global_unique(empty_db: str) -> None:
         ), "email_domains_custom_domain_global_uq missing after round-trip upgrade"
         assert "UNIQUE" in indexdef
         assert "custom" in indexdef
+
+
+def test_0041_e164_unique_is_partial(empty_db: str) -> None:
+    """After 0041 the full UNIQUE on phone_numbers.e164 is replaced by a
+    partial unique index excluding released tombstones — so a number Twilio
+    recycles can be re-acquired while the released row stays for billing
+    history."""
+    _run_alembic(empty_db, ["upgrade", "head"])
+    with psycopg.connect(_to_libpq_url(to_sync_url(empty_db))) as conn:
+        assert not _constraint_exists(
+            conn, "phone_numbers_e164_key"
+        ), "full unique on phone_numbers.e164 still present after 0041"
+        indexdef = _index_def(conn, "phone_numbers_e164_live_uniq")
+        assert (
+            indexdef is not None
+        ), "partial unique index phone_numbers_e164_live_uniq missing"
+        assert "UNIQUE" in indexdef
+        assert "released" in indexdef, "index WHERE clause missing released filter"

--- a/api/tests/test_numbers_api.py
+++ b/api/tests/test_numbers_api.py
@@ -112,6 +112,57 @@ async def test_acquire_number_idempotent_replay(
     voice_provider_mock.acquire_number.assert_awaited_once()
 
 
+async def test_release_number_204_marks_released(
+    client, org_and_key, voice_provider_mock
+) -> None:
+    _, _, plaintext = org_and_key
+    headers = {"Authorization": f"Bearer {plaintext}"}
+    acquired = await client.post(
+        "/numbers",
+        json={"country_code": "US", "number_type": "local"},
+        headers=headers,
+    )
+    assert acquired.status_code == 201, acquired.text
+    number_id = acquired.json()["id"]
+
+    resp = await client.delete(f"/numbers/{number_id}", headers=headers)
+    assert resp.status_code == 204, resp.text
+    voice_provider_mock.release_number.assert_awaited_once_with("PN_test_acquired")
+
+    got = await client.get(f"/numbers/{number_id}", headers=headers)
+    assert got.status_code == 200
+    assert got.json()["provisioning_state"] == "released"
+
+    # Idempotent: a second DELETE is a no-op 204, no second carrier call.
+    again = await client.delete(f"/numbers/{number_id}", headers=headers)
+    assert again.status_code == 204
+    voice_provider_mock.release_number.assert_awaited_once()
+
+
+async def test_release_number_404_other_org(
+    client, async_session, org_and_key, voice_provider_mock
+) -> None:
+    from .conftest import insert_org_and_key
+
+    _, _, owner_key = org_and_key
+    acquired = await client.post(
+        "/numbers",
+        json={"country_code": "US", "number_type": "local"},
+        headers={"Authorization": f"Bearer {owner_key}"},
+    )
+    assert acquired.status_code == 201, acquired.text
+    number_id = acquired.json()["id"]
+
+    _, _, intruder_key = await insert_org_and_key(
+        async_session, org_slug="other-org-release"
+    )
+    resp = await client.delete(
+        f"/numbers/{number_id}", headers={"Authorization": f"Bearer {intruder_key}"}
+    )
+    assert resp.status_code == 404
+    voice_provider_mock.release_number.assert_not_awaited()
+
+
 async def test_acquire_not_provisionable_returns_422_not_500(
     client, org_and_key, voice_provider_mock
 ):

--- a/api/tests/test_numbers_api.py
+++ b/api/tests/test_numbers_api.py
@@ -139,6 +139,51 @@ async def test_release_number_204_marks_released(
     voice_provider_mock.release_number.assert_awaited_once()
 
 
+async def test_reacquire_same_e164_after_release(
+    client, org_and_key, voice_provider_mock
+) -> None:
+    """Twilio recycles released numbers: a released row is a tombstone and
+    must not block re-acquiring the same e164 (partial unique index,
+    migration 0041). Before, the INSERT hit the full UNIQUE after the
+    carrier purchase — a 500 and an orphaned paid number."""
+    _, _, plaintext = org_and_key
+    headers = {"Authorization": f"Bearer {plaintext}"}
+    body = {"country_code": "US", "number_type": "local"}
+
+    first = await client.post("/numbers", json=body, headers=headers)
+    assert first.status_code == 201, first.text
+    resp = await client.delete(f"/numbers/{first.json()['id']}", headers=headers)
+    assert resp.status_code == 204
+
+    # The mock returns the same e164 (+14155550001) again.
+    second = await client.post("/numbers", json=body, headers=headers)
+    assert second.status_code == 201, second.text
+    assert second.json()["e164"] == first.json()["e164"]
+    assert second.json()["id"] != first.json()["id"]
+
+
+async def test_enable_sms_on_released_number_422(
+    client, org_and_key, voice_provider_mock
+) -> None:
+    """A released number's PN is deleted at Twilio — enable-sms must be a
+    clean 422, not a TwilioRestException 500 from attach_number."""
+    _, _, plaintext = org_and_key
+    headers = {"Authorization": f"Bearer {plaintext}"}
+    acquired = await client.post(
+        "/numbers",
+        json={"country_code": "US", "number_type": "local"},
+        headers=headers,
+    )
+    assert acquired.status_code == 201, acquired.text
+    number_id = acquired.json()["id"]
+    resp = await client.delete(f"/numbers/{number_id}", headers=headers)
+    assert resp.status_code == 204
+
+    enable = await client.post(f"/numbers/{number_id}/enable-sms", headers=headers)
+    assert enable.status_code == 422, enable.text
+    assert "released" in enable.json()["detail"][0]["msg"].lower()
+
+
 async def test_release_number_404_other_org(
     client, async_session, org_and_key, voice_provider_mock
 ) -> None:

--- a/core/hailhq/core/models.py
+++ b/core/hailhq/core/models.py
@@ -393,7 +393,11 @@ class PhoneNumber(Base):
     organization_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True
     )
-    e164: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    # Uniqueness is partial (see __table_args__): released rows are tombstones
+    # and must not block re-acquiring a number Twilio later recycles — with a
+    # full UNIQUE, that re-acquire would buy the number at the carrier and
+    # then 500 on the INSERT, orphaning a paid number (migration 0041).
+    e164: Mapped[str] = mapped_column(Text, nullable=False)
     country_code: Mapped[str] = mapped_column(Text, nullable=False)
     number_type: Mapped[str] = mapped_column(Text, nullable=False)
     capabilities: Mapped[list[str]] = mapped_column(
@@ -450,6 +454,12 @@ class PhoneNumber(Base):
             "(is_pool = TRUE AND organization_id IS NULL)"
             " OR (is_pool = FALSE AND organization_id IS NOT NULL)",
             name="phone_numbers_pool_owner_xor",
+        ),
+        Index(
+            "phone_numbers_e164_live_uniq",
+            "e164",
+            unique=True,
+            postgresql_where=text("provisioning_state <> 'released'"),
         ),
     )
 

--- a/core/hailhq/core/models.py
+++ b/core/hailhq/core/models.py
@@ -328,6 +328,32 @@ class OrgClosure(Base):
     )
 
 
+class NumberDunning(Base):
+    """Per-org dunning state for the unfunded-numbers sweep.
+
+    A row exists while an org holds active dedicated numbers on a zero or
+    negative balance and has been warned by email that they will be
+    released. ``release_after`` is fixed at warn time (warned_at + grace)
+    so a later change to the grace setting never retroactively shortens an
+    already-announced deadline. The website's dunning job
+    (app/api/internal/billing/dunning in hail-website) owns the lifecycle:
+    it inserts on first detection, releases the org's numbers via
+    ``POST /internal/numbers/release`` once ``release_after`` passes, and
+    deletes the row when the org tops up or the numbers are gone.
+    """
+
+    __tablename__ = "number_dunning"
+
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True
+    )
+    warned_at: Mapped[datetime] = mapped_column(TS, nullable=False)
+    release_after: Mapped[datetime] = mapped_column(TS, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        TS, server_default=text("now()"), nullable=False
+    )
+
+
 class ApiKey(Base):
     """Read-only mirror of the auth backend's ``api_keys`` table.
 

--- a/core/hailhq/core/providers/voice/twilio.py
+++ b/core/hailhq/core/providers/voice/twilio.py
@@ -11,6 +11,7 @@ test failures rather than silent breakage.
 from __future__ import annotations
 
 import asyncio
+import logging
 
 from hailhq.core.config import settings
 from hailhq.core.providers.voice.base import (
@@ -22,6 +23,8 @@ from hailhq.core.providers.voice.base import (
 )
 from twilio.base.exceptions import TwilioRestException
 from twilio.rest import Client as TwilioClient
+
+logger = logging.getLogger(__name__)
 
 # Maps the Hail-canonical capability strings to Twilio's available-number
 # search kwargs (which take booleans). Anything in `capabilities` that
@@ -120,8 +123,18 @@ class TwilioVoiceProvider(VoiceProvider):
             )
         except TwilioRestException as exc:
             # Already gone at the carrier (released out of band, or a retry of
-            # a half-completed release): the desired end state holds.
+            # a half-completed release): the desired end state holds. Loud,
+            # not silent — a 404 is also what wrong credentials (a different
+            # (sub)account) or a stale/mangled SID produce, and in that case
+            # the number is still live and billed at Twilio while we mark the
+            # row released.
             if exc.status == 404:
+                logger.warning(
+                    "twilio release of %s returned 404; treating as already "
+                    "released — if this number was expected to be live, check "
+                    "the account credentials and the stored SID",
+                    provider_resource_id,
+                )
                 return
             raise
 

--- a/core/hailhq/core/providers/voice/twilio.py
+++ b/core/hailhq/core/providers/voice/twilio.py
@@ -114,9 +114,16 @@ class TwilioVoiceProvider(VoiceProvider):
         )
 
     async def release_number(self, provider_resource_id: str) -> None:
-        await asyncio.to_thread(
-            self._client.incoming_phone_numbers(provider_resource_id).delete
-        )
+        try:
+            await asyncio.to_thread(
+                self._client.incoming_phone_numbers(provider_resource_id).delete
+            )
+        except TwilioRestException as exc:
+            # Already gone at the carrier (released out of band, or a retry of
+            # a half-completed release): the desired end state holds.
+            if exc.status == 404:
+                return
+            raise
 
     async def get_call_status(self, provider_call_sid: str) -> ProviderCallStatus:
         call = await asyncio.to_thread(self._client.calls(provider_call_sid).fetch)

--- a/core/tests/providers/test_twilio_voice.py
+++ b/core/tests/providers/test_twilio_voice.py
@@ -276,6 +276,39 @@ async def test_release_number(provider: TwilioVoiceProvider) -> None:
 
 
 @responses.activate
+async def test_release_number_tolerates_carrier_404(
+    provider: TwilioVoiceProvider,
+) -> None:
+    """A number already gone at Twilio (out-of-band release, or a retry of a
+    half-completed release) is treated as released — no raise."""
+    responses.add(
+        responses.DELETE,
+        f"{API_BASE}/IncomingPhoneNumbers/PN9999999999999999999999999999.json",
+        json={"code": 20404, "message": "not found", "status": 404},
+        status=404,
+    )
+
+    await provider.release_number("PN9999999999999999999999999999")
+
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+async def test_release_number_raises_on_other_errors(
+    provider: TwilioVoiceProvider,
+) -> None:
+    responses.add(
+        responses.DELETE,
+        f"{API_BASE}/IncomingPhoneNumbers/PN9999999999999999999999999999.json",
+        json={"code": 20003, "message": "auth error", "status": 401},
+        status=401,
+    )
+
+    with pytest.raises(TwilioRestException):
+        await provider.release_number("PN9999999999999999999999999999")
+
+
+@responses.activate
 async def test_get_call_status(provider: TwilioVoiceProvider) -> None:
     responses.add(
         responses.GET,

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,54 +1,52 @@
 openapi: 3.1.0
 info:
   title: Hail
-  description:
-    "Universal communication platform for AI agents.\n\nThis file is the\
+  description: "Universal communication platform for AI agents.\n\nThis file is the\
     \ source of truth for the Go CLI. Regenerate it after\nchanging API routes \u2014\
     \ see docs/public/contributing.md.\n"
   version: 0.1.0
 servers:
-  - url: https://api.hail.so
-    description: Hail Cloud
+- url: https://api.hail.so
+  description: Hail Cloud
 paths:
   /calls:
     post:
       tags:
-        - calls
+      - calls
       summary: Create Call
       operationId: create_call_calls_post
       parameters:
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
-        - name: Idempotency-Key
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Idempotency-Key
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
+      - name: Idempotency-Key
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Idempotency-Key
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CallCreate"
+              $ref: '#/components/schemas/CallCreate'
       responses:
-        "201":
+        '201':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CallResponse"
-        "429":
-          description:
-            Rate limited. The agent-origin workspace exceeded a per-channel
+                $ref: '#/components/schemas/CallResponse'
+        '429':
+          description: Rate limited. The agent-origin workspace exceeded a per-channel
             velocity cap, or the platform kill switch is on. Retry after the Retry-After
             header (seconds).
           headers:
@@ -56,190 +54,189 @@ paths:
               description: Seconds to wait before retrying.
               schema:
                 type: integer
-        "422":
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
     get:
       tags:
-        - calls
+      - calls
       summary: List Calls
       operationId: list_calls_calls_get
       parameters:
-        - name: cursor
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Cursor
-        - name: limit
-          in: query
-          required: false
-          schema:
-            type: integer
-            maximum: 200
-            minimum: 1
-            default: 50
-            title: Limit
-        - name: status
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - enum:
-                  - queued
-                  - dialing
-                  - ringing
-                  - in_progress
-                  - completed
-                  - failed
-                  - busy
-                  - no_answer
-                  - canceled
-                type: string
-              - type: "null"
-            title: Status
-        - name: to
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: To
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: cursor
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 200
+          minimum: 1
+          default: 50
+          title: Limit
+      - name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - enum:
+            - queued
+            - dialing
+            - ringing
+            - in_progress
+            - completed
+            - failed
+            - busy
+            - no_answer
+            - canceled
+            type: string
+          - type: 'null'
+          title: Status
+      - name: to
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: To
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CallListResponse"
-        "422":
+                $ref: '#/components/schemas/CallListResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /calls/{call_id}:
     get:
       tags:
-        - calls
+      - calls
       summary: Get Call
       operationId: get_call_calls__call_id__get
       parameters:
-        - name: call_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Call Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: call_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Call Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CallResponse"
-        "422":
+                $ref: '#/components/schemas/CallResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /email-attachments:
     post:
       tags:
-        - email-attachments
+      - email-attachments
       summary: Create Email Attachment
       operationId: upload_email_attachment
       parameters:
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       requestBody:
         required: true
         content:
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/Body_upload_email_attachment"
+              $ref: '#/components/schemas/Body_upload_email_attachment'
       responses:
-        "201":
+        '201':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EmailAttachmentUploadResponse"
-        "422":
+                $ref: '#/components/schemas/EmailAttachmentUploadResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /emails:
     post:
       tags:
-        - emails
+      - emails
       summary: Create Email
       operationId: create_email_emails_post
       parameters:
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
-        - name: Idempotency-Key
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Idempotency-Key
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
+      - name: Idempotency-Key
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Idempotency-Key
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EmailCreate"
+              $ref: '#/components/schemas/EmailCreate'
       responses:
-        "201":
+        '201':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EmailResponse"
-        "429":
-          description:
-            Rate limited. The agent-origin workspace exceeded a per-channel
+                $ref: '#/components/schemas/EmailResponse'
+        '429':
+          description: Rate limited. The agent-origin workspace exceeded a per-channel
             velocity cap, or the platform kill switch is on. Retry after the Retry-After
             header (seconds).
           headers:
@@ -247,526 +244,524 @@ paths:
               description: Seconds to wait before retrying.
               schema:
                 type: integer
-        "422":
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
     get:
       tags:
-        - emails
+      - emails
       summary: List Emails
       operationId: list_emails_emails_get
       parameters:
-        - name: cursor
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Cursor
-        - name: limit
-          in: query
-          required: false
-          schema:
-            type: integer
-            maximum: 200
-            minimum: 1
-            default: 50
-            title: Limit
-        - name: status
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - enum:
-                  - queued
-                  - sent
-                  - delivered
-                  - failed
-                  - bounced
-                  - complained
-                  - received
-                type: string
-              - type: "null"
-            title: Status
-        - name: direction
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - enum:
-                  - outbound
-                  - inbound
-                type: string
-              - type: "null"
-            title: Direction
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: cursor
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 200
+          minimum: 1
+          default: 50
+          title: Limit
+      - name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - enum:
+            - queued
+            - sent
+            - delivered
+            - failed
+            - bounced
+            - complained
+            - received
+            type: string
+          - type: 'null'
+          title: Status
+      - name: direction
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - enum:
+            - outbound
+            - inbound
+            type: string
+          - type: 'null'
+          title: Direction
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EmailListResponse"
-        "422":
+                $ref: '#/components/schemas/EmailListResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /emails/{email_id}/events:
     get:
       tags:
-        - emails
+      - emails
       summary: List Email Events
-      description: "Chronological lifecycle events for one email (org-scoped).
+      description: 'Chronological lifecycle events for one email (org-scoped).
 
 
         Cursor-paginated with the same forward-walk shape as ``GET /events``:
 
-        strictly-greater on ``(occurred_at, id)``, ascending."
+        strictly-greater on ``(occurred_at, id)``, ascending.'
       operationId: list_email_events_emails__email_id__events_get
       parameters:
-        - name: email_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Email Id
-        - name: cursor
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Cursor
-        - name: limit
-          in: query
-          required: false
-          schema:
-            type: integer
-            maximum: 1000
-            minimum: 1
-            default: 100
-            title: Limit
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: email_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Email Id
+      - name: cursor
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 1000
+          minimum: 1
+          default: 100
+          title: Limit
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EmailEventListResponse"
-        "422":
+                $ref: '#/components/schemas/EmailEventListResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /emails/stats:
     get:
       tags:
-        - emails
+      - emails
       summary: Get Email Stats
       operationId: get_email_stats_emails_stats_get
       parameters:
-        - name: from
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-                format: date-time
-              - type: "null"
-            title: From
-        - name: to
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-                format: date-time
-              - type: "null"
-            title: To
-        - name: bucket
-          in: query
-          required: false
-          schema:
-            enum:
-              - hour
-              - day
-            type: string
-            default: day
-            title: Bucket
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: from
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: From
+      - name: to
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: To
+      - name: bucket
+        in: query
+        required: false
+        schema:
+          enum:
+          - hour
+          - day
+          type: string
+          default: day
+          title: Bucket
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EmailStatsResponse"
-        "422":
+                $ref: '#/components/schemas/EmailStatsResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /emails/{email_id}:
     get:
       tags:
-        - emails
+      - emails
       summary: Get Email
       operationId: get_email_emails__email_id__get
       parameters:
-        - name: email_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Email Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: email_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Email Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EmailResponse"
-        "422":
+                $ref: '#/components/schemas/EmailResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /emails/{email_id}/raw:
     get:
       tags:
-        - emails
+      - emails
       summary: Get Email Raw
-      description:
-        "302 \u2192 presigned S3 URL for the raw inbound MIME (404 for\
+      description: "302 \u2192 presigned S3 URL for the raw inbound MIME (404 for\
         \ outbound)."
       operationId: get_email_raw_emails__email_id__raw_get
       parameters:
-        - name: email_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Email Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: email_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Email Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema: {}
-        "422":
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /emails/{email_id}/attachments/{attachment_id}:
     get:
       tags:
-        - emails
+      - emails
       summary: Get Email Attachment
       description: "302 \u2192 presigned S3 URL for one attachment."
       operationId: get_email_attachment_emails__email_id__attachments__attachment_id__get
       parameters:
-        - name: email_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Email Id
-        - name: attachment_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Attachment Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: email_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Email Id
+      - name: attachment_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Attachment Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema: {}
-        "422":
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /events:
     get:
       tags:
-        - events
+      - events
       summary: List Events
       operationId: list_events_events_get
       parameters:
-        - name: cursor
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Cursor
-        - name: limit
-          in: query
-          required: false
-          schema:
-            type: integer
-            maximum: 1000
-            minimum: 1
-            default: 100
-            title: Limit
-        - name: id
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Id
-        - name: kind
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Kind
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: cursor
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 1000
+          minimum: 1
+          default: 100
+          title: Limit
+      - name: id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Id
+      - name: kind
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Kind
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EventStreamResponse"
-        "422":
+                $ref: '#/components/schemas/EventStreamResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /email-domains:
     post:
       tags:
-        - email-domains
+      - email-domains
       summary: Create Email Domain
       operationId: create_email_domain_email_domains_post
       parameters:
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EmailDomainCreate"
+              $ref: '#/components/schemas/EmailDomainCreate'
       responses:
-        "201":
+        '201':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EmailDomainResponse"
-        "422":
+                $ref: '#/components/schemas/EmailDomainResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
     get:
       tags:
-        - email-domains
+      - email-domains
       summary: List Email Domains
       operationId: list_email_domains_email_domains_get
       parameters:
-        - name: cursor
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Cursor
-        - name: limit
-          in: query
-          required: false
-          schema:
-            type: integer
-            maximum: 200
-            minimum: 1
-            default: 50
-            title: Limit
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: cursor
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 200
+          minimum: 1
+          default: 50
+          title: Limit
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EmailDomainListResponse"
-        "422":
+                $ref: '#/components/schemas/EmailDomainListResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /email-domains/check-domain:
     get:
       tags:
-        - email-domains
+      - email-domains
       summary: Check Domain
       description: Does this domain already receive mail? Drives apex-vs-prefix onboarding.
       operationId: check_domain_email_domains_check_domain_get
       parameters:
-        - name: domain
-          in: query
-          required: true
-          schema:
-            type: string
-            title: Domain
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: domain
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Domain
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DomainCheckResponse"
-        "422":
+                $ref: '#/components/schemas/DomainCheckResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /email-domains/{domain_id}:
     get:
       tags:
-        - email-domains
+      - email-domains
       summary: Get Email Domain
       operationId: get_email_domain_email_domains__domain_id__get
       parameters:
-        - name: domain_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Domain Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: domain_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Domain Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EmailDomainResponse"
-        "422":
+                $ref: '#/components/schemas/EmailDomainResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
     patch:
       tags:
-        - email-domains
+      - email-domains
       summary: Patch Email Domain
-      description:
-        "Edit hail-mail prefixes and/or inbound action settings.\n\nTwo\
+      description: "Edit hail-mail prefixes and/or inbound action settings.\n\nTwo\
         \ modes, mutually compatible:\n\n* **Prefix edit** (``local_prefix_user``\
         \ / ``local_prefix_org``):\n  hail_mail rows only. The managed-cloud console\
         \ writes here when\n  an org admin changes the visible hail-mail address.\n\
@@ -774,643 +769,677 @@ paths:
         \ any row kind."
       operationId: patch_email_domain_email_domains__domain_id__patch
       parameters:
-        - name: domain_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Domain Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: domain_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Domain Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EmailDomainPatch"
+              $ref: '#/components/schemas/EmailDomainPatch'
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EmailDomainResponse"
-        "422":
+                $ref: '#/components/schemas/EmailDomainResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
     delete:
       tags:
-        - email-domains
+      - email-domains
       summary: Delete Email Domain
       operationId: delete_email_domain_email_domains__domain_id__delete
       parameters:
-        - name: domain_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Domain Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: domain_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Domain Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "204":
+        '204':
           description: Successful Response
-        "422":
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /email-domains/{domain_id}/verify:
     post:
       tags:
-        - email-domains
+      - email-domains
       summary: Verify Email Domain
-      description:
-        "Re-poll the email provider for the current verification status.\n\
+      description: "Re-poll the email provider for the current verification status.\n\
         \nOn-demand only \u2014 there is no background poller in v1. Operators /\n\
         tenants hit this after publishing DNS to flip the row to ``verified``.\nHail-mail\
         \ rows are no-ops (they're already verified by construction)."
       operationId: verify_email_domain_email_domains__domain_id__verify_post
       parameters:
-        - name: domain_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Domain Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: domain_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Domain Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EmailDomainResponse"
-        "422":
+                $ref: '#/components/schemas/EmailDomainResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /numbers:
     post:
       tags:
-        - numbers
+      - numbers
       summary: Acquire Number
       operationId: acquire_number_numbers_post
       parameters:
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
-        - name: Idempotency-Key
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Idempotency-Key
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
+      - name: Idempotency-Key
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Idempotency-Key
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/NumberAcquireRequest"
+              $ref: '#/components/schemas/NumberAcquireRequest'
       responses:
-        "201":
+        '201':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PhoneNumberResponse"
-        "422":
+                $ref: '#/components/schemas/PhoneNumberResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
     get:
       tags:
-        - numbers
+      - numbers
       summary: List Numbers
       operationId: list_numbers_numbers_get
       parameters:
-        - name: cursor
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Cursor
-        - name: limit
-          in: query
-          required: false
-          schema:
-            type: integer
-            maximum: 200
-            minimum: 1
-            default: 50
-            title: Limit
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: cursor
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 200
+          minimum: 1
+          default: 50
+          title: Limit
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PhoneNumberListResponse"
-        "422":
+                $ref: '#/components/schemas/PhoneNumberListResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /numbers/{number_id}:
+    delete:
+      tags:
+      - numbers
+      summary: Release Number
+      description: 'Release a dedicated number. The monthly fee stops accruing after
+        the
+
+        release month; months already accrued stay owed (the rater bills late,
+
+        never forgives).'
+      operationId: release_number_numbers__number_id__delete
+      parameters:
+      - name: number_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Number Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
     get:
       tags:
-        - numbers
+      - numbers
       summary: Get Number
       operationId: get_number_numbers__number_id__get
       parameters:
-        - name: number_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Number Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: number_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Number Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PhoneNumberResponse"
-        "422":
+                $ref: '#/components/schemas/PhoneNumberResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /numbers/{number_id}/enable-sms:
     post:
       tags:
-        - numbers
+      - numbers
       summary: Enable Sms
       operationId: enable_sms_numbers__number_id__enable_sms_post
       parameters:
-        - name: number_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Number Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: number_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Number Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PhoneNumberResponse"
-        "422":
+                $ref: '#/components/schemas/PhoneNumberResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /webhooks:
     post:
       tags:
-        - webhooks
+      - webhooks
       summary: Create Subscription
       operationId: create_subscription_webhooks_post
       parameters:
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/WebhookSubscriptionCreate"
+              $ref: '#/components/schemas/WebhookSubscriptionCreate'
       responses:
-        "201":
+        '201':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/WebhookSubscriptionResponse"
-        "422":
+                $ref: '#/components/schemas/WebhookSubscriptionResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
     get:
       tags:
-        - webhooks
+      - webhooks
       summary: List Subscriptions
       operationId: list_subscriptions_webhooks_get
       parameters:
-        - name: cursor
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Cursor
-        - name: limit
-          in: query
-          required: false
-          schema:
-            type: integer
-            maximum: 200
-            minimum: 1
-            default: 50
-            title: Limit
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: cursor
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 200
+          minimum: 1
+          default: 50
+          title: Limit
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/WebhookSubscriptionListResponse"
-        "422":
+                $ref: '#/components/schemas/WebhookSubscriptionListResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /webhooks/{sub_id}:
     get:
       tags:
-        - webhooks
+      - webhooks
       summary: Get Subscription
       operationId: get_subscription_webhooks__sub_id__get
       parameters:
-        - name: sub_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Sub Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: sub_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Sub Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/WebhookSubscriptionResponse"
-        "422":
+                $ref: '#/components/schemas/WebhookSubscriptionResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
     patch:
       tags:
-        - webhooks
+      - webhooks
       summary: Patch Subscription
       operationId: patch_subscription_webhooks__sub_id__patch
       parameters:
-        - name: sub_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Sub Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: sub_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Sub Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/WebhookSubscriptionPatch"
+              $ref: '#/components/schemas/WebhookSubscriptionPatch'
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/WebhookSubscriptionResponse"
-        "422":
+                $ref: '#/components/schemas/WebhookSubscriptionResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
     delete:
       tags:
-        - webhooks
+      - webhooks
       summary: Delete Subscription
       operationId: delete_subscription_webhooks__sub_id__delete
       parameters:
-        - name: sub_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Sub Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: sub_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Sub Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "204":
+        '204':
           description: Successful Response
-        "422":
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /webhooks/{sub_id}/rotate-secret:
     post:
       tags:
-        - webhooks
+      - webhooks
       summary: Rotate Secret
       operationId: rotate_secret_webhooks__sub_id__rotate_secret_post
       parameters:
-        - name: sub_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Sub Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: sub_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Sub Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/WebhookSubscriptionResponse"
-        "422":
+                $ref: '#/components/schemas/WebhookSubscriptionResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /webhooks/{sub_id}/deliveries:
     get:
       tags:
-        - webhooks
+      - webhooks
       summary: List Deliveries
       operationId: list_deliveries_webhooks__sub_id__deliveries_get
       parameters:
-        - name: sub_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Sub Id
-        - name: cursor
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Cursor
-        - name: limit
-          in: query
-          required: false
-          schema:
-            type: integer
-            maximum: 200
-            minimum: 1
-            default: 50
-            title: Limit
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: sub_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Sub Id
+      - name: cursor
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 200
+          minimum: 1
+          default: 50
+          title: Limit
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/WebhookDeliveryListResponse"
-        "422":
+                $ref: '#/components/schemas/WebhookDeliveryListResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /webhooks/{sub_id}/deliveries/{delivery_id}/redeliver:
     post:
       tags:
-        - webhooks
+      - webhooks
       summary: Redeliver
       operationId: redeliver_webhooks__sub_id__deliveries__delivery_id__redeliver_post
       parameters:
-        - name: sub_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Sub Id
-        - name: delivery_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Delivery Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: sub_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Sub Id
+      - name: delivery_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Delivery Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/WebhookDeliveryResponse"
-        "422":
+                $ref: '#/components/schemas/WebhookDeliveryResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /unsubscribe:
     get:
       tags:
-        - unsubscribe
+      - unsubscribe
       summary: Unsubscribe
       operationId: unsubscribe_unsubscribe_get
       parameters:
-        - name: token
-          in: query
-          required: true
-          schema:
-            type: string
-            title: Token
+      - name: token
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Token
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             text/html:
               schema:
                 type: string
-        "422":
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /sms:
     post:
       tags:
-        - sms
+      - sms
       summary: Create Sms
       operationId: create_sms_sms_post
       parameters:
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
-        - name: Idempotency-Key
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Idempotency-Key
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
+      - name: Idempotency-Key
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Idempotency-Key
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SmsCreate"
+              $ref: '#/components/schemas/SmsCreate'
       responses:
-        "201":
+        '201':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SmsResponse"
-        "429":
-          description:
-            Rate limited. The agent-origin workspace exceeded a per-channel
+                $ref: '#/components/schemas/SmsResponse'
+        '429':
+          description: Rate limited. The agent-origin workspace exceeded a per-channel
             velocity cap, or the platform kill switch is on. Retry after the Retry-After
             header (seconds).
           headers:
@@ -1418,434 +1447,434 @@ paths:
               description: Seconds to wait before retrying.
               schema:
                 type: integer
-        "422":
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
     get:
       tags:
-        - sms
+      - sms
       summary: List Sms
       operationId: list_sms_sms_get
       parameters:
-        - name: cursor
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Cursor
-        - name: limit
-          in: query
-          required: false
-          schema:
-            type: integer
-            maximum: 200
-            minimum: 1
-            default: 50
-            title: Limit
-        - name: status
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - enum:
-                  - queued
-                  - sent
-                  - delivered
-                  - failed
-                  - undelivered
-                  - received
-                type: string
-              - type: "null"
-            title: Status
-        - name: to
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: To
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: cursor
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 200
+          minimum: 1
+          default: 50
+          title: Limit
+      - name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - enum:
+            - queued
+            - sent
+            - delivered
+            - failed
+            - undelivered
+            - received
+            type: string
+          - type: 'null'
+          title: Status
+      - name: to
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: To
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SmsListResponse"
-        "422":
+                $ref: '#/components/schemas/SmsListResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /sms/suppressions:
     get:
       tags:
-        - sms
+      - sms
       summary: List Sms Suppressions
       operationId: list_sms_suppressions_sms_suppressions_get
       parameters:
-        - name: cursor
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Cursor
-        - name: limit
-          in: query
-          required: false
-          schema:
-            type: integer
-            maximum: 200
-            minimum: 1
-            default: 50
-            title: Limit
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: cursor
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 200
+          minimum: 1
+          default: 50
+          title: Limit
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SuppressionListResponse"
-        "422":
+                $ref: '#/components/schemas/SuppressionListResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /sms/suppressions/{number}:
     delete:
       tags:
-        - sms
+      - sms
       summary: Delete Sms Suppression
       operationId: delete_sms_suppression_sms_suppressions__number__delete
       parameters:
-        - name: number
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Number
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: number
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Number
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "204":
+        '204':
           description: Successful Response
-        "422":
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /sms/sender-id:
     get:
       tags:
-        - sms
+      - sms
       summary: Get Sender Id
       operationId: get_sender_id_sms_sender_id_get
       parameters:
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SenderIdResponse"
-        "422":
+                $ref: '#/components/schemas/SenderIdResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
     patch:
       tags:
-        - sms
+      - sms
       summary: Patch Sender Id
       operationId: patch_sender_id_sms_sender_id_patch
       parameters:
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SenderIdPatch"
+              $ref: '#/components/schemas/SenderIdPatch'
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SenderIdResponse"
-        "422":
+                $ref: '#/components/schemas/SenderIdResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /sms/{sms_id}:
     get:
       tags:
-        - sms
+      - sms
       summary: Get Sms
       operationId: get_sms_sms__sms_id__get
       parameters:
-        - name: sms_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Sms Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: sms_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Sms Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SmsResponse"
-        "422":
+                $ref: '#/components/schemas/SmsResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /contacts:
     get:
       tags:
-        - contacts
+      - contacts
       summary: List Contacts
       operationId: list_contacts_contacts_get
       parameters:
-        - name: q
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Q
-        - name: cursor
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Cursor
-        - name: limit
-          in: query
-          required: false
-          schema:
-            type: integer
-            maximum: 500
-            minimum: 1
-            default: 100
-            title: Limit
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: q
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Q
+      - name: cursor
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 500
+          minimum: 1
+          default: 100
+          title: Limit
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContactListResponse"
-        "422":
+                $ref: '#/components/schemas/ContactListResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
     post:
       tags:
-        - contacts
+      - contacts
       summary: Create Contact
       operationId: create_contact_contacts_post
       parameters:
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ContactCreate"
+              $ref: '#/components/schemas/ContactCreate'
       responses:
-        "201":
+        '201':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContactEntry"
-        "422":
+                $ref: '#/components/schemas/ContactEntry'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /contacts/{contact_id}:
     patch:
       tags:
-        - contacts
+      - contacts
       summary: Patch Contact
       operationId: patch_contact_contacts__contact_id__patch
       parameters:
-        - name: contact_id
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Contact Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: contact_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Contact Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ContactPatch"
+              $ref: '#/components/schemas/ContactPatch'
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContactEntry"
-        "422":
+                $ref: '#/components/schemas/ContactEntry'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
     delete:
       tags:
-        - contacts
+      - contacts
       summary: Delete Contact
       operationId: delete_contact_contacts__contact_id__delete
       parameters:
-        - name: contact_id
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Contact Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: contact_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Contact Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "204":
+        '204':
           description: Successful Response
-        "422":
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /members/{user_id}/phone:
     put:
       tags:
-        - contacts
+      - contacts
       summary: Put Member Phone
       operationId: put_member_phone_members__user_id__phone_put
       parameters:
-        - name: user_id
-          in: path
-          required: true
-          schema:
-            type: string
-            title: User Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: user_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: User Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/MemberPhonePut"
+              $ref: '#/components/schemas/MemberPhonePut'
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
@@ -1854,77 +1883,76 @@ paths:
                 additionalProperties:
                   type: string
                 title: Response Put Member Phone Members  User Id  Phone Put
-        "422":
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
     delete:
       tags:
-        - contacts
+      - contacts
       summary: Delete Member Phone
       operationId: delete_member_phone_members__user_id__phone_delete
       parameters:
-        - name: user_id
-          in: path
-          required: true
-          schema:
-            type: string
-            title: User Id
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: user_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: User Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "204":
+        '204':
           description: Successful Response
-        "422":
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /providers:
     get:
       tags:
-        - providers
+      - providers
       summary: List Providers
       description: Every saved provider row for the caller's organization, all layers.
       operationId: list_providers
       parameters:
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProviderConfigListResponse"
-        "422":
+                $ref: '#/components/schemas/ProviderConfigListResponse'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /providers/{layer}:
     put:
       tags:
-        - providers
+      - providers
       summary: Upsert Provider
-      description:
-        "Save a provider for ``layer`` and make it the active one.\n\n\
+      description: "Save a provider for ``layer`` and make it the active one.\n\n\
         A partial write: anything you omit keeps its saved value. Omitting\n``api_key``\
         \ keeps the stored key, ``params`` keys you don't send are\npreserved, and\
         \ omitting ``fallback_enabled`` leaves the flag alone\n(``false`` on a new\
@@ -1932,180 +1960,178 @@ paths:
         \ against the layer's schema (422 on a mismatch). 404 on an\nunknown layer."
       operationId: upsert_provider
       parameters:
-        - name: layer
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Layer
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: layer
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Layer
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProviderConfigUpsert"
+              $ref: '#/components/schemas/ProviderConfigUpsert'
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProviderConfigEntry"
-        "422":
+                $ref: '#/components/schemas/ProviderConfigEntry'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /providers/{layer}/{provider}:
     delete:
       tags:
-        - providers
+      - providers
       summary: Delete Provider
-      description:
-        "Delete one provider row. Deleting the active row promotes the
+      description: 'Delete one provider row. Deleting the active row promotes the
 
-        most-recently-updated sibling. Idempotent: deleting a row that isn't
+        most-recently-updated sibling. Idempotent: deleting a row that isn''t
 
-        there is a 204 too. 404 on an unknown layer."
+        there is a 204 too. 404 on an unknown layer.'
       operationId: delete_provider
       parameters:
-        - name: layer
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Layer
-        - name: provider
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Provider
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: layer
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Layer
+      - name: provider
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Provider
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       responses:
-        "204":
+        '204':
           description: Successful Response
-        "422":
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /providers/{layer}/activate:
     post:
       tags:
-        - providers
+      - providers
       summary: Activate Provider
-      description:
-        "Switch which saved provider is active for ``layer``. 404 when
+      description: 'Switch which saved provider is active for ``layer``. 404 when
         that
 
-        provider has no saved config."
+        provider has no saved config.'
       operationId: activate_provider
       parameters:
-        - name: layer
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Layer
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: layer
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Layer
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProviderActivateRequest"
+              $ref: '#/components/schemas/ProviderActivateRequest'
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProviderConfigEntry"
-        "422":
+                $ref: '#/components/schemas/ProviderConfigEntry'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /providers/{layer}/validate:
     post:
       tags:
-        - providers
+      - providers
       summary: Validate Provider
-      description: "Probe a provider key against the real provider.
+      description: 'Probe a provider key against the real provider.
 
 
-        Empty body tests the layer's active provider with its stored key; send
+        Empty body tests the layer''s active provider with its stored key; send
 
         ``provider`` to test a specific saved row, or ``api_key`` (plus
 
-        ``provider``/``params``) to test a key before saving it."
+        ``provider``/``params``) to test a key before saving it.'
       operationId: validate_provider
       parameters:
-        - name: layer
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Layer
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: "null"
-            title: Authorization
+      - name: layer
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Layer
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProviderValidateRequest"
+              $ref: '#/components/schemas/ProviderValidateRequest'
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProviderValidateResult"
-        "422":
+                $ref: '#/components/schemas/ProviderValidateResult'
+        '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HTTPValidationError"
+                $ref: '#/components/schemas/HTTPValidationError'
   /healthz:
     get:
       summary: Healthz
       operationId: healthz_healthz_get
       responses:
-        "200":
+        '200':
           description: Successful Response
           content:
             application/json:
@@ -2124,70 +2150,66 @@ components:
           title: File
       type: object
       required:
-        - file
+      - file
       title: Body_upload_email_attachment
     CallCreate:
       properties:
         recipient_consent:
           type: boolean
           title: Recipient Consent
-          description:
-            "Attestation that you have obtained the lawful consent required\
+          description: "Attestation that you have obtained the lawful consent required\
             \ to contact this recipient. Hail does not verify consent itself \u2014\
             \ you are responsible for a lawful basis under TCPA/ePrivacy/PECR/CAN-SPAM/GDPR\
             \ as applicable. Rejected (422) if not true."
         consent_source:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Consent Source
-          description:
-            Where/how consent was obtained (e.g. 'signup form', 'prior
+          description: Where/how consent was obtained (e.g. 'signup form', 'prior
             customer relationship'). Required (non-empty) when message_type is 'marketing'.
         consent_obtained_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Consent Obtained At
           description: When consent was obtained, if known.
         message_type:
           type: string
           enum:
-            - marketing
-            - informational
+          - marketing
+          - informational
           title: Message Type
-          description:
-            "'marketing' additionally requires a non-empty consent_source.
-            Use 'informational' for transactional/service communications."
+          description: '''marketing'' additionally requires a non-empty consent_source.
+            Use ''informational'' for transactional/service communications.'
           default: informational
         to:
           type: string
           title: To
         from:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: From
         system_prompt:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: System Prompt
         llm:
           anyOf:
-            - $ref: "#/components/schemas/LLMConfig"
-            - type: "null"
+          - $ref: '#/components/schemas/LLMConfig'
+          - type: 'null'
         first_message:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: First Message
         ai_disclosure:
           type: boolean
           title: Ai Disclosure
-          description:
-            "Speak the AI self-disclosure line ('Hi, this is an AI assistant\
+          description: "Speak the AI self-disclosure line ('Hi, this is an AI assistant\
             \ calling on behalf of ...') as the first thing on the call. Enabled by\
             \ default. Disable only if you have verified the disclosure is not required\
             \ for this call \u2014 47 CFR 64.1200(b)(1) requires identifying the initiating\
@@ -2196,12 +2218,12 @@ components:
             \ for you. The agent still identifies itself as an AI if asked."
           default: true
         voice_config:
-          $ref: "#/components/schemas/VoiceConfig"
+          $ref: '#/components/schemas/VoiceConfig'
         conversation_id:
           anyOf:
-            - type: string
-              format: uuid
-            - type: "null"
+          - type: string
+            format: uuid
+          - type: 'null'
           title: Conversation Id
         metadata:
           additionalProperties: true
@@ -2209,36 +2231,35 @@ components:
           title: Metadata
         tools:
           anyOf:
-            - items:
-                type: string
-              type: array
-            - type: "null"
+          - items:
+              type: string
+            type: array
+          - type: 'null'
           title: Tools
-          description:
-            "Agent tools to allow on this call. Omitted: every tool the
-            organization's configured channels support (new channels appear automatically).
-            Empty list: no tools. Tool names are validated against the server's registry."
+          description: 'Agent tools to allow on this call. Omitted: every tool the
+            organization''s configured channels support (new channels appear automatically).
+            Empty list: no tools. Tool names are validated against the server''s registry.'
       additionalProperties: false
       type: object
       required:
-        - recipient_consent
-        - to
+      - recipient_consent
+      - to
       title: CallCreate
     CallListResponse:
       properties:
         items:
           items:
-            $ref: "#/components/schemas/CallResponse"
+            $ref: '#/components/schemas/CallResponse'
           type: array
           title: Items
         next_cursor:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Next Cursor
       type: object
       required:
-        - items
+      - items
       title: CallListResponse
     CallResponse:
       properties:
@@ -2252,9 +2273,9 @@ components:
           title: Organization Id
         conversation_id:
           anyOf:
-            - type: string
-              format: uuid
-            - type: "null"
+          - type: string
+            format: uuid
+          - type: 'null'
           title: Conversation Id
         from_e164:
           type: string
@@ -2265,46 +2286,46 @@ components:
         direction:
           type: string
           enum:
-            - outbound
-            - inbound
+          - outbound
+          - inbound
           title: Direction
         status:
           type: string
           enum:
-            - queued
-            - dialing
-            - ringing
-            - in_progress
-            - completed
-            - failed
-            - busy
-            - no_answer
-            - canceled
+          - queued
+          - dialing
+          - ringing
+          - in_progress
+          - completed
+          - failed
+          - busy
+          - no_answer
+          - canceled
           title: Status
         end_reason:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: End Reason
         provider_call_sid:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Provider Call Sid
         livekit_room:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Livekit Room
         initial_prompt:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Initial Prompt
         recording_s3_key:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Recording S3 Key
         requested_at:
           type: string
@@ -2312,40 +2333,40 @@ components:
           title: Requested At
         started_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Started At
         answered_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Answered At
         ended_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Ended At
       type: object
       required:
-        - id
-        - organization_id
-        - conversation_id
-        - from_e164
-        - to_e164
-        - direction
-        - status
-        - end_reason
-        - provider_call_sid
-        - livekit_room
-        - initial_prompt
-        - recording_s3_key
-        - requested_at
-        - started_at
-        - answered_at
-        - ended_at
+      - id
+      - organization_id
+      - conversation_id
+      - from_e164
+      - to_e164
+      - direction
+      - status
+      - end_reason
+      - provider_call_sid
+      - livekit_room
+      - initial_prompt
+      - recording_s3_key
+      - requested_at
+      - started_at
+      - answered_at
+      - ended_at
       title: CallResponse
     ContactCreate:
       properties:
@@ -2356,18 +2377,18 @@ components:
           title: Name
         phone_e164:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Phone E164
         email:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Email
       additionalProperties: false
       type: object
       required:
-        - name
+      - name
       title: ContactCreate
     ContactEntry:
       properties:
@@ -2377,71 +2398,70 @@ components:
         kind:
           type: string
           enum:
-            - member
-            - manual
+          - member
+          - manual
           title: Kind
         name:
           type: string
           title: Name
         phone_e164:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Phone E164
         email:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Email
         role:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Role
       type: object
       required:
-        - id
-        - kind
-        - name
+      - id
+      - kind
+      - name
       title: ContactEntry
-      description:
-        "One row in the computed contacts union \u2014 an org member or\
+      description: "One row in the computed contacts union \u2014 an org member or\
         \ a manual\ncontact. ``id`` is ``member:<user_id>`` for members, the contact\
         \ row's\nUUID (as str) for manual rows."
     ContactListResponse:
       properties:
         items:
           items:
-            $ref: "#/components/schemas/ContactEntry"
+            $ref: '#/components/schemas/ContactEntry'
           type: array
           title: Items
         next_cursor:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Next Cursor
       type: object
       required:
-        - items
+      - items
       title: ContactListResponse
     ContactPatch:
       properties:
         name:
           anyOf:
-            - type: string
-              maxLength: 200
-              minLength: 1
-            - type: "null"
+          - type: string
+            maxLength: 200
+            minLength: 1
+          - type: 'null'
           title: Name
         phone_e164:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Phone E164
         email:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Email
       additionalProperties: false
       type: object
@@ -2457,26 +2477,26 @@ components:
         type:
           type: string
           enum:
-            - CNAME
-            - MX
-            - TXT
+          - CNAME
+          - MX
+          - TXT
           title: Type
           default: CNAME
         priority:
           anyOf:
-            - type: integer
-            - type: "null"
+          - type: integer
+          - type: 'null'
           title: Priority
       additionalProperties: true
       type: object
       required:
-        - name
-        - value
+      - name
+      - value
       title: DnsRecordSchema
-      description: "One DNS record the tenant must publish for a sending domain.
+      description: 'One DNS record the tenant must publish for a sending domain.
 
 
-        Covers DKIM CNAMEs, MAIL FROM MX, and SPF TXT records."
+        Covers DKIM CNAMEs, MAIL FROM MX, and SPF TXT records.'
     DomainCheckResponse:
       properties:
         domain:
@@ -2495,10 +2515,10 @@ components:
           title: Suggested Domain
       type: object
       required:
-        - domain
-        - in_use
-        - existing_mx
-        - suggested_domain
+      - domain
+      - in_use
+      - existing_mx
+      - suggested_domain
       title: DomainCheckResponse
     EmailAttachmentResponse:
       properties:
@@ -2517,22 +2537,21 @@ components:
           title: Size Bytes
         content_id:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Content Id
         url:
           type: string
           title: Url
       type: object
       required:
-        - id
-        - filename
-        - content_type
-        - size_bytes
-        - url
+      - id
+      - filename
+      - content_type
+      - size_bytes
+      - url
       title: EmailAttachmentResponse
-      description:
-        "One inbound MIME attachment as exposed to API consumers.\n\n``url``\
+      description: "One inbound MIME attachment as exposed to API consumers.\n\n``url``\
         \ is the stable Hail API endpoint that 302-redirects to a\npresigned S3 URL\
         \ on access \u2014 see GET /emails/{id}/attachments/{aid}."
     EmailAttachmentUploadResponse:
@@ -2552,58 +2571,55 @@ components:
           title: Size Bytes
       type: object
       required:
-        - id
-        - filename
-        - content_type
-        - size_bytes
+      - id
+      - filename
+      - content_type
+      - size_bytes
       title: EmailAttachmentUploadResponse
-      description: "Returned by POST /email-attachments.
+      description: 'Returned by POST /email-attachments.
 
 
         ``id`` is reusable across many ``POST /emails`` calls via
 
         ``EmailCreate.attachment_ids`` until Hail garbage-collects it (24h
 
-        if never referenced by a send)."
+        if never referenced by a send).'
     EmailCreate:
       properties:
         recipient_consent:
           type: boolean
           title: Recipient Consent
-          description:
-            "Attestation that you have obtained the lawful consent required\
+          description: "Attestation that you have obtained the lawful consent required\
             \ to contact this recipient. Hail does not verify consent itself \u2014\
             \ you are responsible for a lawful basis under TCPA/ePrivacy/PECR/CAN-SPAM/GDPR\
             \ as applicable. Rejected (422) if not true."
         consent_source:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Consent Source
-          description:
-            Where/how consent was obtained (e.g. 'signup form', 'prior
+          description: Where/how consent was obtained (e.g. 'signup form', 'prior
             customer relationship'). Required (non-empty) when message_type is 'marketing'.
         consent_obtained_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Consent Obtained At
           description: When consent was obtained, if known.
         message_type:
           type: string
           enum:
-            - marketing
-            - informational
+          - marketing
+          - informational
           title: Message Type
-          description:
-            "'marketing' additionally requires a non-empty consent_source.
-            Use 'informational' for transactional/service communications."
+          description: '''marketing'' additionally requires a non-empty consent_source.
+            Use ''informational'' for transactional/service communications.'
           default: informational
         from:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: From
         to:
           items:
@@ -2613,22 +2629,22 @@ components:
           title: To
         cc:
           anyOf:
-            - items:
-                type: string
-              type: array
-            - type: "null"
+          - items:
+              type: string
+            type: array
+          - type: 'null'
           title: Cc
         bcc:
           anyOf:
-            - items:
-                type: string
-              type: array
-            - type: "null"
+          - items:
+              type: string
+            type: array
+          - type: 'null'
           title: Bcc
         reply_to:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Reply To
         subject:
           type: string
@@ -2637,19 +2653,19 @@ components:
           title: Subject
         body_text:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Body Text
         body_html:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Body Html
         conversation_id:
           anyOf:
-            - type: string
-              format: uuid
-            - type: "null"
+          - type: string
+            format: uuid
+          - type: 'null'
           title: Conversation Id
         metadata:
           additionalProperties: true
@@ -2657,51 +2673,51 @@ components:
           title: Metadata
         attachment_ids:
           anyOf:
-            - items:
-                type: string
-                format: uuid
-              type: array
-            - type: "null"
+          - items:
+              type: string
+              format: uuid
+            type: array
+          - type: 'null'
           title: Attachment Ids
       additionalProperties: false
       type: object
       required:
-        - recipient_consent
-        - to
-        - subject
+      - recipient_consent
+      - to
+      - subject
       title: EmailCreate
     EmailDomainCreate:
       properties:
         kind:
           type: string
           enum:
-            - hail_mail
-            - custom
+          - hail_mail
+          - custom
           title: Kind
         domain:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Domain
         local_prefix_user:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Local Prefix User
         local_prefix_org:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Local Prefix Org
       additionalProperties: false
       type: object
       required:
-        - kind
+      - kind
       title: EmailDomainCreate
-      description: "Request body for POST /email-domains.
+      description: 'Request body for POST /email-domains.
 
 
-        For ``kind='hail_mail'`` ``domain`` is omitted; the server composes
+        For ``kind=''hail_mail''`` ``domain`` is omitted; the server composes
 
         the full address as ``<local_prefix_user>+<local_prefix_org>@<base>``.
 
@@ -2709,59 +2725,58 @@ components:
 
         ``HAIL_MAIL_DEFAULT_*_PREFIX`` env vars; the server returns 503 if
 
-        neither is supplied. For ``kind='custom'`` ``domain`` is required and
+        neither is supplied. For ``kind=''custom''`` ``domain`` is required and
 
-        the prefix fields must be omitted."
+        the prefix fields must be omitted.'
     EmailDomainListResponse:
       properties:
         items:
           items:
-            $ref: "#/components/schemas/EmailDomainResponse"
+            $ref: '#/components/schemas/EmailDomainResponse'
           type: array
           title: Items
         next_cursor:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Next Cursor
       type: object
       required:
-        - items
+      - items
       title: EmailDomainListResponse
     EmailDomainPatch:
       properties:
         local_prefix_user:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Local Prefix User
         local_prefix_org:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Local Prefix Org
         inbound_enabled:
           anyOf:
-            - type: boolean
-            - type: "null"
+          - type: boolean
+          - type: 'null'
           title: Inbound Enabled
         forward_to:
           anyOf:
-            - items:
-                type: string
-              type: array
-            - type: "null"
+          - items:
+              type: string
+            type: array
+          - type: 'null'
           title: Forward To
         forward_rate_per_hour:
           anyOf:
-            - type: integer
-            - type: "null"
+          - type: integer
+          - type: 'null'
           title: Forward Rate Per Hour
       additionalProperties: false
       type: object
       title: EmailDomainPatch
-      description:
-        "Body for PATCH /email-domains/{id}.\n\nTwo clusters of mutable\
+      description: "Body for PATCH /email-domains/{id}.\n\nTwo clusters of mutable\
         \ fields:\n\n* Hail-mail addressing \u2014 the user/org prefix pair (only\
         \ valid on\n  ``kind='hail_mail'`` rows; the handler returns 422 if a tenant\
         \ tries\n  to PATCH these on a custom row).\n* Inbound action \u2014 ``inbound_enabled``\
@@ -2786,52 +2801,52 @@ components:
         kind:
           type: string
           enum:
-            - hail_mail
-            - custom
+          - hail_mail
+          - custom
           title: Kind
         domain:
           type: string
           title: Domain
         local_prefix_user:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Local Prefix User
         local_prefix_org:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Local Prefix Org
         verification_status:
           type: string
           enum:
-            - pending
-            - verified
-            - failed
+          - pending
+          - verified
+          - failed
           title: Verification Status
         dns_records:
           items:
-            $ref: "#/components/schemas/DnsRecordSchema"
+            $ref: '#/components/schemas/DnsRecordSchema'
           type: array
           title: Dns Records
         mail_from_domain:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Mail From Domain
         mail_from_status:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Mail From Status
         provider:
           type: string
           title: Provider
         verified_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Verified At
         inbound_enabled:
           type: boolean
@@ -2839,15 +2854,15 @@ components:
           default: false
         forward_to:
           anyOf:
-            - items:
-                type: string
-              type: array
-            - type: "null"
+          - items:
+              type: string
+            type: array
+          - type: 'null'
           title: Forward To
         forward_rate_per_hour:
           anyOf:
-            - type: integer
-            - type: "null"
+          - type: integer
+          - type: 'null'
           title: Forward Rate Per Hour
         created_at:
           type: string
@@ -2859,48 +2874,48 @@ components:
           title: Updated At
         receive_ready:
           anyOf:
-            - type: boolean
-            - type: "null"
+          - type: boolean
+          - type: 'null'
           title: Receive Ready
       type: object
       required:
-        - id
-        - organization_id
-        - kind
-        - domain
-        - local_prefix_user
-        - local_prefix_org
-        - verification_status
-        - dns_records
-        - mail_from_domain
-        - provider
-        - verified_at
-        - created_at
-        - updated_at
+      - id
+      - organization_id
+      - kind
+      - domain
+      - local_prefix_user
+      - local_prefix_org
+      - verification_status
+      - dns_records
+      - mail_from_domain
+      - provider
+      - verified_at
+      - created_at
+      - updated_at
       title: EmailDomainResponse
-      description: "Read view for an email domain.
+      description: 'Read view for an email domain.
 
 
         The inbound-action fields (``inbound_enabled``, ``forward_to``,
 
         ``forward_rate_per_hour``) surface what the row has configured for
 
-        incoming mail."
+        incoming mail.'
     EmailEventListResponse:
       properties:
         items:
           items:
-            $ref: "#/components/schemas/EmailEventResponse"
+            $ref: '#/components/schemas/EmailEventResponse'
           type: array
           title: Items
         next_cursor:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Next Cursor
       type: object
       required:
-        - items
+      - items
       title: EmailEventListResponse
     EmailEventResponse:
       properties:
@@ -2915,14 +2930,14 @@ components:
         kind:
           type: string
           enum:
-            - sent
-            - delivered
-            - delivery_delayed
-            - bounced
-            - complained
-            - rejected
-            - opened
-            - clicked
+          - sent
+          - delivered
+          - delivery_delayed
+          - bounced
+          - complained
+          - rejected
+          - opened
+          - clicked
           title: Kind
         payload:
           additionalProperties: true
@@ -2934,27 +2949,27 @@ components:
           title: Occurred At
       type: object
       required:
-        - id
-        - email_id
-        - kind
-        - payload
-        - occurred_at
+      - id
+      - email_id
+      - kind
+      - payload
+      - occurred_at
       title: EmailEventResponse
     EmailListResponse:
       properties:
         items:
           items:
-            $ref: "#/components/schemas/EmailSummary"
+            $ref: '#/components/schemas/EmailSummary'
           type: array
           title: Items
         next_cursor:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Next Cursor
       type: object
       required:
-        - items
+      - items
       title: EmailListResponse
     EmailResponse:
       properties:
@@ -2968,21 +2983,21 @@ components:
           title: Organization Id
         conversation_id:
           anyOf:
-            - type: string
-              format: uuid
-            - type: "null"
+          - type: string
+            format: uuid
+          - type: 'null'
           title: Conversation Id
         email_domain_id:
           anyOf:
-            - type: string
-              format: uuid
-            - type: "null"
+          - type: string
+            format: uuid
+          - type: 'null'
           title: Email Domain Id
         direction:
           type: string
           enum:
-            - outbound
-            - inbound
+          - outbound
+          - inbound
           title: Direction
           default: outbound
         from_address:
@@ -2995,22 +3010,22 @@ components:
           title: To Addresses
         cc_addresses:
           anyOf:
-            - items:
-                type: string
-              type: array
-            - type: "null"
+          - items:
+              type: string
+            type: array
+          - type: 'null'
           title: Cc Addresses
         bcc_addresses:
           anyOf:
-            - items:
-                type: string
-              type: array
-            - type: "null"
+          - items:
+              type: string
+            type: array
+          - type: 'null'
           title: Bcc Addresses
         reply_to:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Reply To
         subject:
           type: string
@@ -3018,23 +3033,23 @@ components:
         status:
           type: string
           enum:
-            - queued
-            - sent
-            - delivered
-            - failed
-            - bounced
-            - complained
-            - received
+          - queued
+          - sent
+          - delivered
+          - failed
+          - bounced
+          - complained
+          - received
           title: Status
         end_reason:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: End Reason
         provider_message_id:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Provider Message Id
         requested_at:
           type: string
@@ -3042,15 +3057,15 @@ components:
           title: Requested At
         sent_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Sent At
         failed_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Failed At
         metadata:
           additionalProperties: true
@@ -3058,99 +3073,99 @@ components:
           title: Metadata
         body_text:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Body Text
         body_html:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Body Html
         message_id:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Message Id
         in_reply_to:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: In Reply To
         references_ids:
           anyOf:
-            - items:
-                type: string
-              type: array
-            - type: "null"
+          - items:
+              type: string
+            type: array
+          - type: 'null'
           title: References Ids
         spam_verdict:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Spam Verdict
         virus_verdict:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Virus Verdict
         dkim_verdict:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Dkim Verdict
         spf_verdict:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Spf Verdict
         dmarc_verdict:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Dmarc Verdict
         provider_received_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Provider Received At
         raw_url:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Raw Url
         attachments:
           items:
-            $ref: "#/components/schemas/EmailAttachmentResponse"
+            $ref: '#/components/schemas/EmailAttachmentResponse'
           type: array
           title: Attachments
           default: []
         last_event_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Last Event At
       type: object
       required:
-        - id
-        - organization_id
-        - conversation_id
-        - email_domain_id
-        - from_address
-        - to_addresses
-        - cc_addresses
-        - bcc_addresses
-        - reply_to
-        - subject
-        - status
-        - end_reason
-        - provider_message_id
-        - requested_at
-        - sent_at
-        - failed_at
-        - body_text
-        - body_html
+      - id
+      - organization_id
+      - conversation_id
+      - email_domain_id
+      - from_address
+      - to_addresses
+      - cc_addresses
+      - bcc_addresses
+      - reply_to
+      - subject
+      - status
+      - end_reason
+      - provider_message_id
+      - requested_at
+      - sent_at
+      - failed_at
+      - body_text
+      - body_html
       title: EmailResponse
     EmailStatsBucket:
       properties:
@@ -3204,7 +3219,7 @@ components:
           title: Bucket Start
       type: object
       required:
-        - bucket_start
+      - bucket_start
       title: EmailStatsBucket
     EmailStatsCounts:
       properties:
@@ -3258,28 +3273,28 @@ components:
       properties:
         delivery:
           anyOf:
-            - type: number
-            - type: "null"
+          - type: number
+          - type: 'null'
           title: Delivery
         bounce:
           anyOf:
-            - type: number
-            - type: "null"
+          - type: number
+          - type: 'null'
           title: Bounce
         complaint:
           anyOf:
-            - type: number
-            - type: "null"
+          - type: number
+          - type: 'null'
           title: Complaint
         open:
           anyOf:
-            - type: number
-            - type: "null"
+          - type: number
+          - type: 'null'
           title: Open
         click:
           anyOf:
-            - type: number
-            - type: "null"
+          - type: number
+          - type: 'null'
           title: Click
       type: object
       title: EmailStatsRates
@@ -3297,26 +3312,26 @@ components:
         bucket:
           type: string
           enum:
-            - hour
-            - day
+          - hour
+          - day
           title: Bucket
         totals:
-          $ref: "#/components/schemas/EmailStatsCounts"
+          $ref: '#/components/schemas/EmailStatsCounts'
         rates:
-          $ref: "#/components/schemas/EmailStatsRates"
+          $ref: '#/components/schemas/EmailStatsRates'
         series:
           items:
-            $ref: "#/components/schemas/EmailStatsBucket"
+            $ref: '#/components/schemas/EmailStatsBucket'
           type: array
           title: Series
       type: object
       required:
-        - from
-        - to
-        - bucket
-        - totals
-        - rates
-        - series
+      - from
+      - to
+      - bucket
+      - totals
+      - rates
+      - series
       title: EmailStatsResponse
     EmailSummary:
       properties:
@@ -3330,21 +3345,21 @@ components:
           title: Organization Id
         conversation_id:
           anyOf:
-            - type: string
-              format: uuid
-            - type: "null"
+          - type: string
+            format: uuid
+          - type: 'null'
           title: Conversation Id
         email_domain_id:
           anyOf:
-            - type: string
-              format: uuid
-            - type: "null"
+          - type: string
+            format: uuid
+          - type: 'null'
           title: Email Domain Id
         direction:
           type: string
           enum:
-            - outbound
-            - inbound
+          - outbound
+          - inbound
           title: Direction
           default: outbound
         from_address:
@@ -3357,22 +3372,22 @@ components:
           title: To Addresses
         cc_addresses:
           anyOf:
-            - items:
-                type: string
-              type: array
-            - type: "null"
+          - items:
+              type: string
+            type: array
+          - type: 'null'
           title: Cc Addresses
         bcc_addresses:
           anyOf:
-            - items:
-                type: string
-              type: array
-            - type: "null"
+          - items:
+              type: string
+            type: array
+          - type: 'null'
           title: Bcc Addresses
         reply_to:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Reply To
         subject:
           type: string
@@ -3380,23 +3395,23 @@ components:
         status:
           type: string
           enum:
-            - queued
-            - sent
-            - delivered
-            - failed
-            - bounced
-            - complained
-            - received
+          - queued
+          - sent
+          - delivered
+          - failed
+          - bounced
+          - complained
+          - received
           title: Status
         end_reason:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: End Reason
         provider_message_id:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Provider Message Id
         requested_at:
           type: string
@@ -3404,15 +3419,15 @@ components:
           title: Requested At
         sent_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Sent At
         failed_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Failed At
         metadata:
           additionalProperties: true
@@ -3420,25 +3435,24 @@ components:
           title: Metadata
       type: object
       required:
-        - id
-        - organization_id
-        - conversation_id
-        - email_domain_id
-        - from_address
-        - to_addresses
-        - cc_addresses
-        - bcc_addresses
-        - reply_to
-        - subject
-        - status
-        - end_reason
-        - provider_message_id
-        - requested_at
-        - sent_at
-        - failed_at
+      - id
+      - organization_id
+      - conversation_id
+      - email_domain_id
+      - from_address
+      - to_addresses
+      - cc_addresses
+      - bcc_addresses
+      - reply_to
+      - subject
+      - status
+      - end_reason
+      - provider_message_id
+      - requested_at
+      - sent_at
+      - failed_at
       title: EmailSummary
-      description:
-        "Trimmed view for list endpoints \u2014 drops the message bodies.\n\
+      description: "Trimmed view for list endpoints \u2014 drops the message bodies.\n\
         \nBodies can be large and contain PII; paging through a year of mail\nshouldn't\
         \ return every byte of every message just to render a list.\nUse ``EmailResponse``\
         \ (via ``GET /emails/{id}``) for the full row."
@@ -3451,27 +3465,27 @@ components:
         source:
           type: string
           enum:
-            - call
-            - email
-            - sms
+          - call
+          - email
+          - sms
           title: Source
         call_id:
           anyOf:
-            - type: string
-              format: uuid
-            - type: "null"
+          - type: string
+            format: uuid
+          - type: 'null'
           title: Call Id
         email_id:
           anyOf:
-            - type: string
-              format: uuid
-            - type: "null"
+          - type: string
+            format: uuid
+          - type: 'null'
           title: Email Id
         sms_id:
           anyOf:
-            - type: string
-              format: uuid
-            - type: "null"
+          - type: string
+            format: uuid
+          - type: 'null'
           title: Sms Id
         kind:
           type: string
@@ -3486,49 +3500,49 @@ components:
           title: Occurred At
       type: object
       required:
-        - id
-        - source
-        - kind
-        - payload
-        - occurred_at
+      - id
+      - source
+      - kind
+      - payload
+      - occurred_at
       title: EventResponse
       description: One event on the unified GET /events stream (call, email, or SMS).
     EventStreamResponse:
       properties:
         items:
           items:
-            $ref: "#/components/schemas/EventResponse"
+            $ref: '#/components/schemas/EventResponse'
           type: array
           title: Items
         next_cursor:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Next Cursor
         call_status:
           anyOf:
-            - type: string
-              enum:
-                - queued
-                - dialing
-                - ringing
-                - in_progress
-                - completed
-                - failed
-                - busy
-                - no_answer
-                - canceled
-            - type: "null"
+          - type: string
+            enum:
+            - queued
+            - dialing
+            - ringing
+            - in_progress
+            - completed
+            - failed
+            - busy
+            - no_answer
+            - canceled
+          - type: 'null'
           title: Call Status
       type: object
       required:
-        - items
+      - items
       title: EventStreamResponse
     HTTPValidationError:
       properties:
         detail:
           items:
-            $ref: "#/components/schemas/ValidationError"
+            $ref: '#/components/schemas/ValidationError'
           type: array
           title: Detail
       type: object
@@ -3547,9 +3561,9 @@ components:
       additionalProperties: false
       type: object
       required:
-        - base_url
-        - api_key
-        - model
+      - base_url
+      - api_key
+      - model
       title: LLMConfig
     MemberPhonePut:
       properties:
@@ -3559,7 +3573,7 @@ components:
       additionalProperties: false
       type: object
       required:
-        - phone_e164
+      - phone_e164
       title: MemberPhonePut
     NumberAcquireRequest:
       properties:
@@ -3571,32 +3585,32 @@ components:
         number_type:
           type: string
           enum:
-            - local
-            - mobile
-            - toll_free
-            - national
+          - local
+          - mobile
+          - toll_free
+          - national
           title: Number Type
           default: local
       additionalProperties: false
       type: object
       required:
-        - country_code
+      - country_code
       title: NumberAcquireRequest
     PhoneNumberListResponse:
       properties:
         items:
           items:
-            $ref: "#/components/schemas/PhoneNumberResponse"
+            $ref: '#/components/schemas/PhoneNumberResponse'
           type: array
           title: Items
         next_cursor:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Next Cursor
       type: object
       required:
-        - items
+      - items
       title: PhoneNumberListResponse
     PhoneNumberResponse:
       properties:
@@ -3626,18 +3640,18 @@ components:
           title: Is Dedicated
         messaging_service_sid:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Messaging Service Sid
       type: object
       required:
-        - id
-        - e164
-        - country_code
-        - number_type
-        - capabilities
-        - provisioning_state
-        - is_dedicated
+      - id
+      - e164
+      - country_code
+      - number_type
+      - capabilities
+      - provisioning_state
+      - is_dedicated
       title: PhoneNumberResponse
     ProviderActivateRequest:
       properties:
@@ -3647,7 +3661,7 @@ components:
       additionalProperties: false
       type: object
       required:
-        - provider
+      - provider
       title: ProviderActivateRequest
       description: Body of ``POST /providers/{layer}/activate``.
     ProviderConfigEntry:
@@ -3655,22 +3669,22 @@ components:
         layer:
           type: string
           enum:
-            - llm
-            - tts
-            - stt
+          - llm
+          - tts
+          - stt
           title: Layer
         provider:
           type: string
           title: Provider
         key_last4:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Key Last4
         key_set_at:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Key Set At
         params:
           additionalProperties: true
@@ -3684,15 +3698,15 @@ components:
           title: Is Active
       type: object
       required:
-        - layer
-        - provider
-        - key_last4
-        - key_set_at
-        - params
-        - fallback_enabled
-        - is_active
+      - layer
+      - provider
+      - key_last4
+      - key_set_at
+      - params
+      - fallback_enabled
+      - is_active
       title: ProviderConfigEntry
-      description: "One saved provider row. Write-only key: ``key_last4`` and
+      description: 'One saved provider row. Write-only key: ``key_last4`` and
 
         ``key_set_at`` are the only key-derived fields that leave the API.
 
@@ -3701,17 +3715,17 @@ components:
 
         serializer always emits all of them, and required response fields
 
-        generate plain values instead of pointers in the Go CLI's client."
+        generate plain values instead of pointers in the Go CLI''s client.'
     ProviderConfigListResponse:
       properties:
         providers:
           items:
-            $ref: "#/components/schemas/ProviderConfigEntry"
+            $ref: '#/components/schemas/ProviderConfigEntry'
           type: array
           title: Providers
       type: object
       required:
-        - providers
+      - providers
       title: ProviderConfigListResponse
     ProviderConfigUpsert:
       properties:
@@ -3720,8 +3734,8 @@ components:
           title: Provider
         api_key:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Api Key
         params:
           additionalProperties: true
@@ -3729,16 +3743,15 @@ components:
           title: Params
         fallback_enabled:
           anyOf:
-            - type: boolean
-            - type: "null"
+          - type: boolean
+          - type: 'null'
           title: Fallback Enabled
       additionalProperties: false
       type: object
       required:
-        - provider
+      - provider
       title: ProviderConfigUpsert
-      description:
-        "Body of ``PUT /providers/{layer}`` \u2014 save and activate one\
+      description: "Body of ``PUT /providers/{layer}`` \u2014 save and activate one\
         \ provider.\n\nA partial write. Fields you omit keep the value already saved\
         \ for this\n``(layer, provider)`` pair: omit ``api_key`` to edit params without\n\
         resending the key, send only the ``params`` keys you want to change,\nand\
@@ -3754,13 +3767,13 @@ components:
       properties:
         api_key:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Api Key
         provider:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Provider
         params:
           additionalProperties: true
@@ -3769,8 +3782,7 @@ components:
       additionalProperties: false
       type: object
       title: ProviderValidateRequest
-      description:
-        "Body of ``POST /providers/{layer}/validate`` \u2014 a live key\
+      description: "Body of ``POST /providers/{layer}/validate`` \u2014 a live key\
         \ probe.\n\nAll fields optional: with an empty body the layer's active provider\
         \ and\nits stored key are tested. ``provider`` tests that provider's stored\
         \ key\ninstead. ``api_key`` tests a key that has not been saved yet."
@@ -3781,21 +3793,21 @@ components:
           title: Status
         message:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Message
       type: object
       required:
-        - status
-        - message
+      - status
+      - message
       title: ProviderValidateResult
       description: Outcome of a live provider-key probe.
     SenderIdPatch:
       properties:
         custom_sender_id:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Custom Sender Id
       additionalProperties: false
       type: object
@@ -3804,8 +3816,8 @@ components:
       properties:
         custom_sender_id:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Custom Sender Id
         effective_default:
           type: string
@@ -3813,50 +3825,47 @@ components:
           default: HAIL
       type: object
       required:
-        - custom_sender_id
+      - custom_sender_id
       title: SenderIdResponse
     SmsCreate:
       properties:
         recipient_consent:
           type: boolean
           title: Recipient Consent
-          description:
-            "Attestation that you have obtained the lawful consent required\
+          description: "Attestation that you have obtained the lawful consent required\
             \ to contact this recipient. Hail does not verify consent itself \u2014\
             \ you are responsible for a lawful basis under TCPA/ePrivacy/PECR/CAN-SPAM/GDPR\
             \ as applicable. Rejected (422) if not true."
         consent_source:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Consent Source
-          description:
-            Where/how consent was obtained (e.g. 'signup form', 'prior
+          description: Where/how consent was obtained (e.g. 'signup form', 'prior
             customer relationship'). Required (non-empty) when message_type is 'marketing'.
         consent_obtained_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Consent Obtained At
           description: When consent was obtained, if known.
         message_type:
           type: string
           enum:
-            - marketing
-            - informational
+          - marketing
+          - informational
           title: Message Type
-          description:
-            "'marketing' additionally requires a non-empty consent_source.
-            Use 'informational' for transactional/service communications."
+          description: '''marketing'' additionally requires a non-empty consent_source.
+            Use ''informational'' for transactional/service communications.'
           default: informational
         to:
           type: string
           title: To
         from:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: From
         body:
           type: string
@@ -3870,25 +3879,25 @@ components:
       additionalProperties: false
       type: object
       required:
-        - recipient_consent
-        - to
-        - body
+      - recipient_consent
+      - to
+      - body
       title: SmsCreate
     SmsListResponse:
       properties:
         items:
           items:
-            $ref: "#/components/schemas/SmsResponse"
+            $ref: '#/components/schemas/SmsResponse'
           type: array
           title: Items
         next_cursor:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Next Cursor
       type: object
       required:
-        - items
+      - items
       title: SmsListResponse
     SmsResponse:
       properties:
@@ -3909,34 +3918,34 @@ components:
         direction:
           type: string
           enum:
-            - outbound
-            - inbound
+          - outbound
+          - inbound
           title: Direction
         status:
           type: string
           enum:
-            - queued
-            - sent
-            - delivered
-            - failed
-            - undelivered
-            - received
+          - queued
+          - sent
+          - delivered
+          - failed
+          - undelivered
+          - received
           title: Status
         body:
           type: string
           title: Body
         provider_message_sid:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Provider Message Sid
         segment_count:
           type: integer
           title: Segment Count
         error_code:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Error Code
         requested_at:
           type: string
@@ -3944,40 +3953,40 @@ components:
           title: Requested At
         sent_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Sent At
       type: object
       required:
-        - id
-        - organization_id
-        - from_e164
-        - to_e164
-        - direction
-        - status
-        - body
-        - provider_message_sid
-        - segment_count
-        - error_code
-        - requested_at
-        - sent_at
+      - id
+      - organization_id
+      - from_e164
+      - to_e164
+      - direction
+      - status
+      - body
+      - provider_message_sid
+      - segment_count
+      - error_code
+      - requested_at
+      - sent_at
       title: SmsResponse
     SuppressionListResponse:
       properties:
         items:
           items:
-            $ref: "#/components/schemas/SuppressionResponse"
+            $ref: '#/components/schemas/SuppressionResponse'
           type: array
           title: Items
         next_cursor:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Next Cursor
       type: object
       required:
-        - items
+      - items
       title: SuppressionListResponse
     SuppressionResponse:
       properties:
@@ -4003,20 +4012,20 @@ components:
           title: Created At
       type: object
       required:
-        - id
-        - recipient
-        - channel
-        - reason
-        - source
-        - created_at
+      - id
+      - recipient
+      - channel
+      - reason
+      - source
+      - created_at
       title: SuppressionResponse
     ValidationError:
       properties:
         loc:
           items:
             anyOf:
-              - type: string
-              - type: integer
+            - type: string
+            - type: integer
           type: array
           title: Location
         msg:
@@ -4032,9 +4041,9 @@ components:
           title: Context
       type: object
       required:
-        - loc
-        - msg
-        - type
+      - loc
+      - msg
+      - type
       title: ValidationError
     VoiceConfig:
       properties:
@@ -4055,56 +4064,55 @@ components:
           default: livekit
         voice_id:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Voice Id
         language:
           anyOf:
-            - type: string
-              enum:
-                - ar
-                - bg
-                - bn
-                - cs
-                - da
-                - de
-                - el
-                - en
-                - es
-                - fi
-                - fr
-                - gu
-                - he
-                - hi
-                - hr
-                - hu
-                - id
-                - it
-                - ja
-                - kn
-                - ko
-                - mr
-                - ms
-                - nl
-                - "no"
-                - pl
-                - pt
-                - ro
-                - ru
-                - sk
-                - sv
-                - ta
-                - te
-                - th
-                - tl
-                - tr
-                - uk
-                - vi
-                - zh
-            - type: "null"
+          - type: string
+            enum:
+            - ar
+            - bg
+            - bn
+            - cs
+            - da
+            - de
+            - el
+            - en
+            - es
+            - fi
+            - fr
+            - gu
+            - he
+            - hi
+            - hr
+            - hu
+            - id
+            - it
+            - ja
+            - kn
+            - ko
+            - mr
+            - ms
+            - nl
+            - 'no'
+            - pl
+            - pt
+            - ro
+            - ru
+            - sk
+            - sv
+            - ta
+            - te
+            - th
+            - tl
+            - tr
+            - uk
+            - vi
+            - zh
+          - type: 'null'
           title: Language
-          description:
-            "Spoken language for the call as a lowercase ISO 639-1 code\
+          description: "Spoken language for the call as a lowercase ISO 639-1 code\
             \ (e.g. 'da'). One of the 39 supported codes \u2014 see docs/languages.md.\
             \ Applied to STT, TTS, and turn detection. Omitted: the providers' defaults\
             \ (English)."
@@ -4115,17 +4123,17 @@ components:
       properties:
         items:
           items:
-            $ref: "#/components/schemas/WebhookDeliveryResponse"
+            $ref: '#/components/schemas/WebhookDeliveryResponse'
           type: array
           title: Items
         next_cursor:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Next Cursor
       type: object
       required:
-        - items
+      - items
       title: WebhookDeliveryListResponse
     WebhookDeliveryResponse:
       properties:
@@ -4135,15 +4143,15 @@ components:
           title: Id
         subscription_id:
           anyOf:
-            - type: string
-              format: uuid
-            - type: "null"
+          - type: string
+            format: uuid
+          - type: 'null'
           title: Subscription Id
         email_domain_id:
           anyOf:
-            - type: string
-              format: uuid
-            - type: "null"
+          - type: string
+            format: uuid
+          - type: 'null'
           title: Email Domain Id
         event_type:
           type: string
@@ -4158,20 +4166,20 @@ components:
         status:
           type: string
           enum:
-            - pending
-            - succeeded
-            - failed
-            - dead
+          - pending
+          - succeeded
+          - failed
+          - dead
           title: Status
         response_status:
           anyOf:
-            - type: integer
-            - type: "null"
+          - type: integer
+          - type: 'null'
           title: Response Status
         response_body:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Response Body
         next_attempt_at:
           type: string
@@ -4179,9 +4187,9 @@ components:
           title: Next Attempt At
         succeeded_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Succeeded At
         created_at:
           type: string
@@ -4189,15 +4197,15 @@ components:
           title: Created At
       type: object
       required:
-        - id
-        - subscription_id
-        - email_domain_id
-        - event_type
-        - event_id
-        - attempt
-        - status
-        - next_attempt_at
-        - created_at
+      - id
+      - subscription_id
+      - email_domain_id
+      - event_type
+      - event_id
+      - attempt
+      - status
+      - next_attempt_at
+      - created_at
       title: WebhookDeliveryResponse
     WebhookSubscriptionCreate:
       properties:
@@ -4209,6 +4217,60 @@ components:
           items:
             type: string
             enum:
+            - email.received
+            - email.delivered
+            - email.delivery_delayed
+            - email.bounced
+            - email.complained
+            - email.opened
+            - email.clicked
+            - email.received.suppressed
+            - email.send_failed
+            - sms.received
+            - sms.delivered
+            - sms.undelivered
+            - sms.failed
+            - call.answered
+            - call.completed
+            - call.failed
+            - call.busy
+            - call.no_answer
+          type: array
+          minItems: 1
+          title: Event Types
+      type: object
+      required:
+      - target_url
+      - event_types
+      title: WebhookSubscriptionCreate
+    WebhookSubscriptionListResponse:
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/WebhookSubscriptionResponse'
+          type: array
+          title: Items
+        next_cursor:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Next Cursor
+      type: object
+      required:
+      - items
+      title: WebhookSubscriptionListResponse
+    WebhookSubscriptionPatch:
+      properties:
+        target_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Target Url
+        event_types:
+          anyOf:
+          - items:
+              type: string
+              enum:
               - email.received
               - email.delivered
               - email.delivery_delayed
@@ -4227,70 +4289,16 @@ components:
               - call.failed
               - call.busy
               - call.no_answer
-          type: array
-          minItems: 1
-          title: Event Types
-      type: object
-      required:
-        - target_url
-        - event_types
-      title: WebhookSubscriptionCreate
-    WebhookSubscriptionListResponse:
-      properties:
-        items:
-          items:
-            $ref: "#/components/schemas/WebhookSubscriptionResponse"
-          type: array
-          title: Items
-        next_cursor:
-          anyOf:
-            - type: string
-            - type: "null"
-          title: Next Cursor
-      type: object
-      required:
-        - items
-      title: WebhookSubscriptionListResponse
-    WebhookSubscriptionPatch:
-      properties:
-        target_url:
-          anyOf:
-            - type: string
-            - type: "null"
-          title: Target Url
-        event_types:
-          anyOf:
-            - items:
-                type: string
-                enum:
-                  - email.received
-                  - email.delivered
-                  - email.delivery_delayed
-                  - email.bounced
-                  - email.complained
-                  - email.opened
-                  - email.clicked
-                  - email.received.suppressed
-                  - email.send_failed
-                  - sms.received
-                  - sms.delivered
-                  - sms.undelivered
-                  - sms.failed
-                  - call.answered
-                  - call.completed
-                  - call.failed
-                  - call.busy
-                  - call.no_answer
-              type: array
-            - type: "null"
+            type: array
+          - type: 'null'
           title: Event Types
         status:
           anyOf:
-            - type: string
-              enum:
-                - active
-                - disabled
-            - type: "null"
+          - type: string
+            enum:
+            - active
+            - disabled
+          - type: 'null'
           title: Status
       type: object
       title: WebhookSubscriptionPatch
@@ -4315,23 +4323,23 @@ components:
         status:
           type: string
           enum:
-            - active
-            - disabled
+          - active
+          - disabled
           title: Status
         consecutive_failures:
           type: integer
           title: Consecutive Failures
         last_success_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Last Success At
         last_failure_at:
           anyOf:
-            - type: string
-              format: date-time
-            - type: "null"
+          - type: string
+            format: date-time
+          - type: 'null'
           title: Last Failure At
         created_at:
           type: string
@@ -4343,23 +4351,23 @@ components:
           title: Updated At
         secret:
           anyOf:
-            - type: string
-            - type: "null"
+          - type: string
+          - type: 'null'
           title: Secret
       type: object
       required:
-        - id
-        - organization_id
-        - target_url
-        - event_types
-        - status
-        - consecutive_failures
-        - created_at
-        - updated_at
+      - id
+      - organization_id
+      - target_url
+      - event_types
+      - status
+      - consecutive_failures
+      - created_at
+      - updated_at
       title: WebhookSubscriptionResponse
-      description: "Subscription as returned by the API.
+      description: 'Subscription as returned by the API.
 
 
         ``secret`` is populated **only** by create + rotate-secret responses;
 
-        later GETs return ``None`` so the plaintext never round-trips."
+        later GETs return ``None`` so the plaintext never round-trips.'


### PR DESCRIPTION
Part 1 of the unfunded-numbers dunning flow (follow-up to #74). The hail-website part (dunning job, warning email, console release button) is a separate PR in hail-website.

## What

- **`DELETE /numbers/{id}`** — org-scoped release. Releases at the carrier, sets `provisioning_state='released'` + `released_at`. Idempotent: re-deleting a released number is a 204 no-op. The monthly-fee rater then bills the final month and stops — its released branch goes live (it was dead code).
- **`POST /internal/numbers/release`** — HMAC-authed (same scheme as `routes/internal/auth.py`) release for the website's dunning job. Shares the same `release_org_number` helper as the public route.
- **`TwilioVoiceProvider.release_number`** now tolerates a carrier 404 (already gone) so a retried half-completed release converges.
- **Migration 0040**: `number_dunning` table — per-org (organization_id PK) `warned_at` + `release_after`, written/cleared by the website's dunning job. `release_after` is fixed at warn time so an announced deadline never moves.

## Tests

- API: release 204 + idempotency + cross-org 404; internal route 200/404/401 + idempotency. 494 passed.
- Core: Twilio release 404-tolerated, non-404 still raises. 13 passed.

🛑 Deploy note: migration 0040 must be applied (manual psql) before the website dunning PR ships.