### PR TITLE
feat(email): from_name display name + raise attachment cap to 25MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Hail are documented here. The format is based on [Keep a 
 
 ## [Unreleased]
 
+### Email
+
+- `POST /emails` accepts an optional `from_name` — a display name rendered
+  on the `From:` header (`"Acme Billing" <billing@acme.com>`, RFC-2047-encoded
+  for non-ASCII). Exposed on the SDK (`from_name=`), MCP `send_email`
+  (`from_name`), and CLI (`--from-name`); persisted and returned on email
+  reads. Control characters are rejected (422).
+- The per-send attachment cap (body + all attachments, pre-encoding) rose
+  from 10MB to 25MB — SESv2 allows 40MB post-base64, and 25MB raw ≈ 34MB
+  encoded leaves headroom. Same cap applies to `POST /email-attachments`
+  single-file uploads.
+
 ## [0.19.0] — 2026-07-27
 
 The voice agent never speaks tool-call syntax again, and call events say

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Hail are documented here. The format is based on [Keep a 
 
 ## [Unreleased]
 
+## [0.20.0] — 2026-08-10
+
+Sender display names on outbound email, and a 25MB attachment cap.
+
+Component versions cut alongside this release:
+**`sdk-v0.14.0`** (PyPI: `hail-sdk==0.14.0`), **`cli-v0.19.0`** (Homebrew + GitHub Releases).
+
 ### Email
 
 - `POST /emails` accepts an optional `from_name` — a display name rendered

--- a/api/hailhq/api/routes/emails.py
+++ b/api/hailhq/api/routes/emails.py
@@ -17,6 +17,7 @@ from a tenant who hasn't registered a domain still goes out.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Literal
@@ -327,16 +328,22 @@ async def deliver_email(
             # explicit Idempotency-Key, that key stuck at the in-flight
             # sentinel for its full TTL.
             s3 = get_s3_mail()
+            # Independent objects — fetch concurrently so caller latency
+            # is max(fetch) instead of sum(fetch) across attachments.
+            payloads = await asyncio.gather(
+                *(s3.fetch_raw(row.s3_key) for row in attachment_rows)
+            )
             provider_attachments = [
                 ProviderAttachment(
                     filename=row.filename,
                     content_type=row.content_type,
-                    payload=await s3.fetch_raw(row.s3_key),
+                    payload=payload,
                 )
-                for row in attachment_rows
+                for row, payload in zip(attachment_rows, payloads)
             ]
         result = await email_provider.send_email(
             from_address=email.from_address,
+            from_name=email.from_name,
             to_addresses=email.to_addresses,
             subject=email.subject,
             body_text=wire_text,
@@ -522,17 +529,20 @@ async def create_email(
                     detail=f"attachment(s) not found: {', '.join(missing)}",
                 ),
             )
-        total_bytes = sum(row.size_bytes for row in attachment_rows)
-        total_bytes += len((body.body_text or "").encode("utf-8"))
-        total_bytes += len((body.body_html or "").encode("utf-8"))
-        if total_bytes > MAX_EMAIL_ATTACHMENT_BYTES:
-            raise await cache_failure(
-                idem,
-                HTTPException(
-                    status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    detail=ATTACHMENT_TOO_LARGE_DETAIL,
-                ),
-            )
+    # Aggregate per-send cap — body counts even with no attachments
+    # (empty attachment_rows sums to 0), matching the documented
+    # "body + all attachments combined, per send" behavior.
+    total_bytes = sum(row.size_bytes for row in attachment_rows)
+    total_bytes += len((body.body_text or "").encode("utf-8"))
+    total_bytes += len((body.body_html or "").encode("utf-8"))
+    if total_bytes > MAX_EMAIL_ATTACHMENT_BYTES:
+        raise await cache_failure(
+            idem,
+            HTTPException(
+                status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=ATTACHMENT_TOO_LARGE_DETAIL,
+            ),
+        )
 
     try:
         sd = await resolve_sender(db, principal.organization_id, body.from_)
@@ -545,6 +555,7 @@ async def create_email(
         conversation_id=body.conversation_id,
         email_domain_id=sd.id,
         from_address=from_address,
+        from_name=body.from_name,
         to_addresses=list(body.to),
         cc_addresses=list(body.cc) if body.cc else None,
         bcc_addresses=list(body.bcc) if body.bcc else None,
@@ -568,6 +579,9 @@ async def create_email(
         resource_id=email.id,
         payload={
             "from": email.from_address,
+            # What the recipient sees in the From header — audit must be
+            # able to reconstruct it (display-name impersonation reviews).
+            "from_name": email.from_name,
             "to": email.to_addresses,
             "cc": email.cc_addresses,
             "bcc": email.bcc_addresses,

--- a/api/migrations/versions/0040_emails_from_name.py
+++ b/api/migrations/versions/0040_emails_from_name.py
@@ -1,0 +1,25 @@
+"""Add emails.from_name — optional display name for the From: header.
+
+Rendered as "Name <addr>" via email.utils.formataddr at send time.
+NULL on inbound rows and on every send that predates the column.
+
+Revision ID: 0040
+Revises: 0039
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "0040"
+down_revision: str | None = "0039"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE emails ADD COLUMN IF NOT EXISTS from_name TEXT")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE emails DROP COLUMN IF EXISTS from_name")

--- a/api/migrations/versions/0042_emails_from_name.py
+++ b/api/migrations/versions/0042_emails_from_name.py
@@ -3,16 +3,16 @@
 Rendered as "Name <addr>" via email.utils.formataddr at send time.
 NULL on inbound rows and on every send that predates the column.
 
-Revision ID: 0040
-Revises: 0039
+Revision ID: 0042
+Revises: 0041
 """
 
 from __future__ import annotations
 
 from alembic import op
 
-revision: str = "0040"
-down_revision: str | None = "0039"
+revision: str = "0042"
+down_revision: str | None = "0041"
 branch_labels = None
 depends_on = None
 

--- a/api/tests/test_email_attachments_api.py
+++ b/api/tests/test_email_attachments_api.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 from hailhq.api.deps import get_s3_mail
 from hailhq.api.main import app
+from hailhq.core.email_attachment_limits import MAX_EMAIL_ATTACHMENT_BYTES
 
 from .conftest import insert_org_and_key  # noqa: F401
 
@@ -47,7 +48,7 @@ async def test_upload_rejects_oversize_file(
 ) -> None:
     _, _, plain = org_and_key
     headers = {"Authorization": f"Bearer {plain}"}
-    oversize = b"x" * (10 * 1024 * 1024 + 1)
+    oversize = b"x" * (MAX_EMAIL_ATTACHMENT_BYTES + 1)
 
     resp = await client.post(
         "/email-attachments",

--- a/api/tests/test_emails_api.py
+++ b/api/tests/test_emails_api.py
@@ -11,6 +11,7 @@ from hailhq.api.deps import get_s3_mail
 from hailhq.api.main import app
 from hailhq.api.routes import emails as emails_routes
 from hailhq.core.config import settings
+from hailhq.core.email_attachment_limits import MAX_EMAIL_ATTACHMENT_BYTES
 from hailhq.core.email_footer import SENT_FOOTER_TEXT
 from hailhq.core.hail_mail import org_prefix_from_id
 from hailhq.core.models import (
@@ -132,6 +133,123 @@ async def test_post_emails_with_attachment_ids_attaches_and_lists(
     assert attachments[0]["filename"] == "invoice.pdf"
 
 
+async def test_post_emails_from_name_persisted_and_passed_to_provider(
+    client: httpx.AsyncClient,
+    org_and_key: tuple,
+    email_mock: AsyncMock,
+) -> None:
+    _, _, plain = org_and_key
+    headers = {"Authorization": f"Bearer {plain}"}
+    await _register_custom_verified(client, headers, domain="acme.com")
+
+    resp = await client.post(
+        "/emails",
+        json={
+            "from": "billing@acme.com",
+            "from_name": "Acme Billing",
+            "to": ["alice@example.com"],
+            "subject": "hi",
+            "body_text": "hello",
+            "recipient_consent": True,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["from_name"] == "Acme Billing"
+
+    call_kwargs = email_mock.send_email.call_args.kwargs
+    assert call_kwargs["from_address"] == "billing@acme.com"
+    assert call_kwargs["from_name"] == "Acme Billing"
+
+    get_resp = await client.get(f"/emails/{resp.json()['id']}", headers=headers)
+    assert get_resp.status_code == 200
+    assert get_resp.json()["from_name"] == "Acme Billing"
+
+
+async def test_post_emails_rejects_header_injection_in_from_name(
+    client: httpx.AsyncClient,
+    org_and_key: tuple,
+    email_mock: AsyncMock,
+) -> None:
+    _, _, plain = org_and_key
+    headers = {"Authorization": f"Bearer {plain}"}
+    await _register_custom_verified(client, headers, domain="acme.com")
+
+    resp = await client.post(
+        "/emails",
+        json={
+            "from_name": "Acme\r\nBcc: evil@example.com",
+            "to": ["alice@example.com"],
+            "subject": "hi",
+            "body_text": "hello",
+            "recipient_consent": True,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    email_mock.send_email.assert_not_awaited()
+
+
+async def test_post_emails_partial_attachment_fetch_failure_fails_send_cleanly(
+    client: httpx.AsyncClient,
+    org_and_key: tuple,
+    email_mock: AsyncMock,
+    async_session: AsyncSession,
+    s3_mail_mock: AsyncMock,
+) -> None:
+    """With concurrent payload fetches (asyncio.gather), one failed fetch
+    among several must still fail the send cleanly — 502, row 'failed',
+    provider never called."""
+    _, _, plain = org_and_key
+    headers = {"Authorization": f"Bearer {plain}"}
+    await _register_custom_verified(client, headers, domain="acme.com")
+    att_a = await _upload_attachment(client, headers)
+    att_b = await _upload_attachment(client, headers, content=b"other bytes")
+    s3_mail_mock.fetch_raw.side_effect = [b"ok bytes", Exception("NoSuchKey")]
+
+    resp = await client.post(
+        "/emails",
+        json={
+            "to": ["alice@example.com"],
+            "subject": "hi",
+            "body_text": "body",
+            "recipient_consent": True,
+            "attachment_ids": [att_a, att_b],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 502, resp.text
+    email_mock.send_email.assert_not_awaited()
+
+    stmt = select(Email).where(Email.organization_id == org_and_key[0])
+    email = (await async_session.execute(stmt)).scalar_one()
+    assert email.status == "failed"
+
+
+async def test_post_emails_rejects_oversize_body_without_attachments(
+    client: httpx.AsyncClient,
+    org_and_key: tuple,
+    email_mock: AsyncMock,
+) -> None:
+    """The per-send cap covers the body even when no attachments ride along."""
+    _, _, plain = org_and_key
+    headers = {"Authorization": f"Bearer {plain}"}
+    await _register_custom_verified(client, headers, domain="acme.com")
+
+    resp = await client.post(
+        "/emails",
+        json={
+            "to": ["alice@example.com"],
+            "subject": "hi",
+            "body_text": "x" * (MAX_EMAIL_ATTACHMENT_BYTES + 1),
+            "recipient_consent": True,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    email_mock.send_email.assert_not_awaited()
+
+
 async def test_post_emails_rejects_oversize_aggregate_attachments(
     client: httpx.AsyncClient,
     org_and_key: tuple,
@@ -141,7 +259,7 @@ async def test_post_emails_rejects_oversize_aggregate_attachments(
     _, _, plain = org_and_key
     headers = {"Authorization": f"Bearer {plain}"}
     await _register_custom_verified(client, headers, domain="acme.com")
-    big = b"x" * (10 * 1024 * 1024)
+    big = b"x" * MAX_EMAIL_ATTACHMENT_BYTES
     att_id = await _upload_attachment(client, headers, content=big)
 
     resp = await client.post(
@@ -149,7 +267,7 @@ async def test_post_emails_rejects_oversize_aggregate_attachments(
         json={
             "to": ["alice@example.com"],
             "subject": "hi",
-            "body_text": "this pushes it over the 10MB cap",
+            "body_text": "this pushes it over the aggregate cap",
             "recipient_consent": True,
             "attachment_ids": [att_id],
         },

--- a/cli/internal/client/client.gen.go
+++ b/cli/internal/client/client.gen.go
@@ -1159,6 +1159,7 @@ type EmailCreate struct {
 	ConsentSource  *string             `json:"consent_source,omitempty"`
 	ConversationId *openapi_types.UUID `json:"conversation_id,omitempty"`
 	From           *string             `json:"from,omitempty"`
+	FromName       *string             `json:"from_name,omitempty"`
 
 	// MessageType 'marketing' additionally requires a non-empty consent_source. Use 'informational' for transactional/service communications.
 	MessageType *EmailCreateMessageType `json:"message_type,omitempty"`
@@ -1295,6 +1296,7 @@ type EmailResponse struct {
 	EndReason          *string                    `json:"end_reason"`
 	FailedAt           *time.Time                 `json:"failed_at"`
 	FromAddress        string                     `json:"from_address"`
+	FromName           *string                    `json:"from_name,omitempty"`
 	Id                 openapi_types.UUID         `json:"id"`
 	InReplyTo          *string                    `json:"in_reply_to,omitempty"`
 	LastEventAt        *time.Time                 `json:"last_event_at,omitempty"`
@@ -1391,6 +1393,7 @@ type EmailSummary struct {
 	EndReason         *string                 `json:"end_reason"`
 	FailedAt          *time.Time              `json:"failed_at"`
 	FromAddress       string                  `json:"from_address"`
+	FromName          *string                 `json:"from_name,omitempty"`
 	Id                openapi_types.UUID      `json:"id"`
 	Metadata          *map[string]interface{} `json:"metadata,omitempty"`
 	OrganizationId    openapi_types.UUID      `json:"organization_id"`

--- a/cli/internal/cmd/email.go
+++ b/cli/internal/cmd/email.go
@@ -24,6 +24,7 @@ type emailSendFlags struct {
 	cc             []string
 	bcc            []string
 	from           string
+	fromName       string
 	replyTo        string
 	subject        string
 	body           string
@@ -99,6 +100,7 @@ Example (minimal):
 	cmd.Flags().StringSliceVar(&f.cc, "cc", nil, "CC recipient(s)")
 	cmd.Flags().StringSliceVar(&f.bcc, "bcc", nil, "BCC recipient(s)")
 	cmd.Flags().StringVar(&f.from, "from", "", "Override the from-address (must be a verified sender)")
+	cmd.Flags().StringVar(&f.fromName, "from-name", "", "Display name for the From header (\"Acme Billing <billing@acme.com>\")")
 	cmd.Flags().StringVar(&f.replyTo, "reply-to", "", "Reply-To header")
 	cmd.Flags().StringVar(&f.subject, "subject", "", "Subject line")
 	cmd.Flags().StringVar(&f.body, "body", "", "Plain-text body — one of --body/--body-html required")
@@ -162,6 +164,7 @@ func runEmailSend(ctx context.Context, cmd *cobra.Command, opts *Options, f *ema
 		To:       to,
 		Subject:  f.subject,
 		From:     strPtr(f.from),
+		FromName: strPtr(f.fromName),
 		ReplyTo:  strPtr(f.replyTo),
 		BodyText: strPtr(bodyText),
 		BodyHtml: strPtr(bodyHTML),

--- a/cli/internal/cmd/email_attachment_upload.go
+++ b/cli/internal/cmd/email_attachment_upload.go
@@ -26,7 +26,7 @@ reusable attachment id.
 Pass the returned id to ` + "`hail email send --attach-id <id>`" + ` (or,
 simpler, use ` + "`hail email send --attach <file>`" + ` to upload and send
 in one step). The id can be reused across many sends until Hail
-garbage-collects it (24h if never referenced by a send). Files over 10MB
+garbage-collects it (24h if never referenced by a send). Files over 25MB
 (combined with the message body and any other attachments, per send) are
 rejected — host large files externally and link to them in the body
 instead.`,

--- a/cli/internal/cmd/email_test.go
+++ b/cli/internal/cmd/email_test.go
@@ -94,6 +94,31 @@ func TestEmailSend_HappyPath(t *testing.T) {
 	}
 }
 
+func TestEmailSend_FromName(t *testing.T) {
+	srv := newFakeServer(t, http.StatusCreated, sampleEmailResponse())
+
+	_, _, err := runRoot(t,
+		map[string]string{"HAIL_API_KEY": "sk_test", "HAIL_API_URL": srv.URL},
+		"email", "send",
+		"--to", "x@example.com",
+		"--subject", "hi",
+		"--body", "hello",
+		"--from-name", "Acme Billing",
+		"--recipient-consent",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var body client.EmailCreate
+	if err := json.Unmarshal(srv.lastBody, &body); err != nil {
+		t.Fatalf("body parse: %v; raw=%s", err, srv.lastBody)
+	}
+	if body.FromName == nil || *body.FromName != "Acme Billing" {
+		t.Fatalf("FromName = %v", body.FromName)
+	}
+}
+
 func TestEmailSend_RequiresBody(t *testing.T) {
 	srv := newFakeServer(t, http.StatusCreated, sampleEmailResponse())
 

--- a/core/hailhq/core/email_attachment_limits.py
+++ b/core/hailhq/core/email_attachment_limits.py
@@ -3,10 +3,16 @@
 One constant enforced at two layers — the single-file upload endpoint
 (POST /email-attachments) and the aggregate per-send check (POST
 /emails) — so the error text a caller sees is identical everywhere
-(API, MCP, CLI). Mirrors SES SendRawEmail's default hard limit.
+(API, MCP, CLI).
+
+SESv2 hard-caps the wire message at 40MB *after* base64 encoding
+(not adjustable). This cap is on raw bytes before encoding; base64 plus
+MIME line breaks inflate by ~1.37×, so 25MB raw ≈ 34MB encoded, leaving
+headroom for bodies, the branding footer, and headers. Note SES
+bandwidth-throttles messages over 10MB.
 """
 
-MAX_EMAIL_ATTACHMENT_BYTES = 10 * 1024 * 1024
+MAX_EMAIL_ATTACHMENT_BYTES = 25 * 1024 * 1024
 
 ATTACHMENT_TOO_LARGE_DETAIL = (
     "attachment(s) too large — host the file externally and include a "

--- a/core/hailhq/core/models.py
+++ b/core/hailhq/core/models.py
@@ -882,6 +882,9 @@ class Email(Base):
         nullable=True,
     )
     from_address: Mapped[str] = mapped_column(Text, nullable=False)
+    # Display name for the From: header ("Acme Billing <billing@acme.com>").
+    # NULL on inbound rows and on sends that didn't supply one.
+    from_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     to_addresses: Mapped[list[str]] = mapped_column(ARRAY(Text), nullable=False)
     cc_addresses: Mapped[list[str] | None] = mapped_column(ARRAY(Text), nullable=True)
     bcc_addresses: Mapped[list[str] | None] = mapped_column(ARRAY(Text), nullable=True)

--- a/core/hailhq/core/outbound_worker.py
+++ b/core/hailhq/core/outbound_worker.py
@@ -230,6 +230,10 @@ class OutboundForwardWorker:
         try:
             result = await self._get_provider().send_email(
                 from_address=row.from_address,
+                # NULL on every forward row today, but forward what the row
+                # carries so a stored display name never silently drops off
+                # the wire message.
+                from_name=row.from_name,
                 to_addresses=row.to_addresses,
                 subject=row.subject,
                 body_text=row.body_text,

--- a/core/hailhq/core/providers/email/base.py
+++ b/core/hailhq/core/providers/email/base.py
@@ -97,6 +97,7 @@ class EmailProvider(ABC):
         self,
         *,
         from_address: str,
+        from_name: str | None = None,
         to_addresses: list[str],
         subject: str,
         body_text: str | None,

--- a/core/hailhq/core/providers/email/ses.py
+++ b/core/hailhq/core/providers/email/ses.py
@@ -13,6 +13,7 @@ The SESv2 surface is much cleaner than v1 for identity management:
 from __future__ import annotations
 
 import asyncio
+from email.headerregistry import Address
 from email.message import EmailMessage
 from typing import Any
 
@@ -97,9 +98,29 @@ def _mail_from_records(domain: str) -> list[DkimRecord]:
     ]
 
 
+def _friendly_from(from_name: str | None, from_address: str) -> str:
+    """Render ``"Name <addr>"`` as a single header-safe line.
+
+    ``Address`` handles display-name quoting; folding the header through
+    the default policy RFC-2047-encodes non-ASCII names AND splits them
+    into <=75-char encoded words (RFC 2047 §2 — ``formataddr`` would emit
+    one arbitrarily long word). Unfolding keeps it a single line for the
+    SESv2 ``FromEmailAddress`` parameter. The raw-MIME path gets the same
+    rendering by assigning ``Address`` directly (string round-trips are
+    lossy for adjacent encoded words, so it can't share this output).
+    """
+    if not from_name:
+        return from_address
+    msg = EmailMessage()
+    msg["From"] = Address(display_name=from_name, addr_spec=from_address)
+    folded = msg["From"].fold(policy=msg.policy)  # "From: ...\n ..." folded
+    return "".join(folded.splitlines()).removeprefix("From: ").strip()
+
+
 def _build_raw_mime(
     *,
     from_address: str,
+    from_name: str | None,
     to_addresses: list[str],
     subject: str,
     body_text: str | None,
@@ -115,7 +136,13 @@ def _build_raw_mime(
     goes through this path instead.
     """
     msg = EmailMessage()
-    msg["From"] = from_address
+    # Same rendering as _friendly_from (Address + policy folding); assigned
+    # as an Address object because re-parsing an encoded string is lossy.
+    msg["From"] = (
+        Address(display_name=from_name, addr_spec=from_address)
+        if from_name
+        else from_address
+    )
     msg["To"] = ", ".join(to_addresses)
     if cc:
         msg["Cc"] = ", ".join(cc)
@@ -152,6 +179,7 @@ class SesEmailProvider(EmailProvider):
         self,
         *,
         from_address: str,
+        from_name: str | None = None,
         to_addresses: list[str],
         subject: str,
         body_text: str | None,
@@ -185,8 +213,12 @@ class SesEmailProvider(EmailProvider):
         }
 
         if attachments:
-            raw = _build_raw_mime(
+            # Serialization base64-encodes every attachment (pure-Python
+            # CPU work, up to tens of MB) — keep it off the event loop.
+            raw = await asyncio.to_thread(
+                _build_raw_mime,
                 from_address=from_address,
+                from_name=from_name,
                 to_addresses=to_addresses,
                 subject=subject,
                 body_text=body_text,
@@ -212,7 +244,9 @@ class SesEmailProvider(EmailProvider):
             ]
 
         kwargs = {
-            "FromEmailAddress": from_address,
+            # SESv2 accepts a friendly-from here ("Name <addr>");
+            # _friendly_from quotes specials and RFC-2047-encodes non-ASCII.
+            "FromEmailAddress": _friendly_from(from_name, from_address),
             "Destination": destination,
             "Content": {"Simple": message},
         }

--- a/core/hailhq/core/schemas.py
+++ b/core/hailhq/core/schemas.py
@@ -645,6 +645,11 @@ class EmailCreate(ConsentAttestationMixin):
 
     # ``from`` is reserved; ``from_`` mirrors how CallCreate handles it.
     from_: str | None = Field(default=None, alias="from")
+    # Friendly display name for the From: header ("Acme Billing
+    # <billing@acme.com>"). Rendered by the email provider at send time
+    # (see providers/email/ses.py); ``from_`` stays a bare address
+    # everywhere else (sender resolution, compliance, events).
+    from_name: str | None = Field(default=None, max_length=256)
     to: list[str] = Field(min_length=1)
     cc: list[str] | None = None
     bcc: list[str] | None = None
@@ -655,6 +660,30 @@ class EmailCreate(ConsentAttestationMixin):
     conversation_id: UUID | None = None
     metadata: dict = Field(default_factory=dict)
     attachment_ids: list[UUID] | None = None
+
+    @field_validator("from_name", mode="before")
+    @classmethod
+    def _strip_from_name(cls, v: object) -> object:
+        # Strip BEFORE max_length runs so a padded-but-valid name
+        # ("Acme" + spaces) isn't rejected as too long.
+        if isinstance(v, str):
+            v = v.strip()
+            if not v:
+                return None
+        return v
+
+    @field_validator("from_name")
+    @classmethod
+    def _validate_from_name(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        # The display name lands in the From: header. isprintable() rejects
+        # every C0/C1 control (CR/LF header injection, NEL U+0085, U+2028)
+        # plus zero-width/format characters — strictly wider than a bare
+        # ord(ch) < 32 check.
+        if not v.isprintable():
+            raise ValueError("must contain only printable characters")
+        return v
 
     @field_validator("from_", "reply_to")
     @classmethod
@@ -783,6 +812,9 @@ class EmailSummary(BaseModel):
     email_domain_id: UUID | None
     direction: Literal["outbound", "inbound"] = "outbound"
     from_address: str
+    # Display name used on the From: header, when the sender supplied one.
+    # Always None on inbound rows and pre-existing outbound rows.
+    from_name: str | None = None
     to_addresses: list[str]
     cc_addresses: list[str] | None
     bcc_addresses: list[str] | None

--- a/core/tests/providers/test_ses_email.py
+++ b/core/tests/providers/test_ses_email.py
@@ -190,6 +190,116 @@ async def test_send_email_with_attachments_uses_raw_mime() -> None:
     assert b"base64" in raw  # attachment payload is base64-encoded
 
 
+async def test_send_email_simple_path_with_from_name(ses_client, stub: Stubber) -> None:
+    stub.add_response(
+        "send_email",
+        {"MessageId": "m-name"},
+        {
+            "FromEmailAddress": "Acme Billing <alerts@acme.com>",
+            "Destination": {"ToAddresses": ["alice@example.com"]},
+            "Content": {
+                "Simple": {
+                    "Subject": {"Data": "hi", "Charset": "UTF-8"},
+                    "Body": {"Text": {"Data": "body", "Charset": "UTF-8"}},
+                }
+            },
+        },
+    )
+
+    provider = SesEmailProvider(client=ses_client)
+    result = await provider.send_email(
+        from_address="alerts@acme.com",
+        from_name="Acme Billing",
+        to_addresses=["alice@example.com"],
+        subject="hi",
+        body_text="body",
+        body_html=None,
+    )
+    assert result.provider_message_id == "m-name"
+    stub.assert_no_pending_responses()
+
+
+async def test_send_email_simple_path_splits_long_non_ascii_from_name() -> None:
+    """RFC 2047 caps encoded words at 75 chars — a long non-ASCII name must
+    ride as multiple encoded words, not one oversized token, and the
+    parameter must stay a single line."""
+    fake = FakeClient("m-name-long")
+    provider = SesEmailProvider(client=fake)
+    await provider.send_email(
+        from_address="a@b.co",
+        from_name=(
+            "Café Réservations München Support Team — "
+            "Département Facturation Européenne"
+        ),
+        to_addresses=["ops@example.com"],
+        subject="hi",
+        body_text="body",
+        body_html=None,
+    )
+
+    assert fake.kwargs is not None
+    friendly = fake.kwargs["FromEmailAddress"]
+    assert "\r" not in friendly and "\n" not in friendly
+    assert friendly.endswith("<a@b.co>")
+    encoded_words = [tok for tok in friendly.split() if tok.startswith("=?")]
+    assert encoded_words, friendly
+    assert all(len(tok) <= 75 for tok in encoded_words), friendly
+
+
+async def test_send_email_raw_path_with_from_name() -> None:
+    fake = FakeClient("m-name-raw")
+    provider = SesEmailProvider(client=fake)
+    await provider.send_email(
+        from_address="alerts@acme.com",
+        from_name="Acme Billing",
+        to_addresses=["ops@example.com"],
+        subject="invoice",
+        body_text="see attached",
+        body_html=None,
+        attachments=[
+            ProviderAttachment(
+                filename="invoice.pdf",
+                content_type="application/pdf",
+                payload=b"%PDF-1.4",
+            )
+        ],
+    )
+
+    assert fake.kwargs is not None
+    raw = fake.kwargs["Content"]["Raw"]["Data"]
+    assert b"From: Acme Billing <alerts@acme.com>" in raw
+    # The envelope identity stays the bare address — SES matches the
+    # sending identity against it.
+    assert fake.kwargs["FromEmailAddress"] == "alerts@acme.com"
+
+
+async def test_send_email_raw_path_encodes_non_ascii_from_name() -> None:
+    fake = FakeClient("m-name-utf8")
+    provider = SesEmailProvider(client=fake)
+    await provider.send_email(
+        from_address="alerts@acme.com",
+        from_name="Café Réservations",
+        to_addresses=["ops@example.com"],
+        subject="invoice",
+        body_text="see attached",
+        body_html=None,
+        attachments=[
+            ProviderAttachment(
+                filename="invoice.pdf",
+                content_type="application/pdf",
+                payload=b"%PDF-1.4",
+            )
+        ],
+    )
+
+    assert fake.kwargs is not None
+    raw = fake.kwargs["Content"]["Raw"]["Data"]
+    # Non-ASCII display names must ride as RFC 2047 encoded words, never
+    # raw UTF-8 bytes in the header.
+    assert b"=?utf-8?" in raw
+    assert "Café".encode() not in raw
+
+
 async def test_send_email_requires_recipients(ses_client) -> None:
     provider = SesEmailProvider(client=ses_client)
     with pytest.raises(ValueError, match="at least one recipient"):

--- a/core/tests/test_email_attachment_limits.py
+++ b/core/tests/test_email_attachment_limits.py
@@ -4,8 +4,11 @@ from hailhq.core.email_attachment_limits import (
 )
 
 
-def test_max_attachment_bytes_is_ten_megabytes():
-    assert MAX_EMAIL_ATTACHMENT_BYTES == 10 * 1024 * 1024
+def test_cap_after_base64_inflation_fits_ses_forty_megabyte_limit():
+    # SESv2 rejects messages over 40MB *after* base64 encoding (×4/3 plus
+    # MIME line breaks ≈ ×1.37). The raw-bytes cap must leave headroom for
+    # bodies, footer, and headers on a maxed-out send.
+    assert MAX_EMAIL_ATTACHMENT_BYTES * 1.37 < 40 * 1024 * 1024
 
 
 def test_oversize_detail_mentions_a_link():

--- a/core/tests/test_schemas.py
+++ b/core/tests/test_schemas.py
@@ -5,6 +5,7 @@ from uuid import UUID, uuid4
 import pytest
 from hailhq.core.schemas import (
     CallCreate,
+    EmailCreate,
     EmailResponse,
     EmailSummary,
     LLMConfig,
@@ -225,3 +226,58 @@ def test_email_create_still_requires_consent_after_mixin_refactor() -> None:
         EmailCreate(
             to=["a@example.com"], subject="hi", body_text="hi"
         )  # missing recipient_consent
+
+
+def test_email_create_accepts_from_name() -> None:
+    email = EmailCreate(
+        to=["a@example.com"],
+        subject="hi",
+        body_text="hi",
+        from_name="Acme Billing",
+        recipient_consent=True,
+    )
+    assert email.from_name == "Acme Billing"
+
+
+def test_email_create_rejects_newlines_in_from_name() -> None:
+    """A display name lands in the From: header — CR/LF would allow
+    header injection. U+0085 (NEL) is a C1 control some header parsers
+    treat as a line break."""
+    for bad in (
+        "Acme\r\nBcc: evil@x.com",
+        "Acme\nX",
+        "Acme\rX",
+        "Acme\x00X",
+        "Acme\x85X",
+    ):
+        with pytest.raises(ValidationError):
+            EmailCreate(
+                to=["a@example.com"],
+                subject="hi",
+                body_text="hi",
+                from_name=bad,
+                recipient_consent=True,
+            )
+
+
+def test_email_create_rejects_overlong_from_name() -> None:
+    with pytest.raises(ValidationError):
+        EmailCreate(
+            to=["a@example.com"],
+            subject="hi",
+            body_text="hi",
+            from_name="x" * 257,
+            recipient_consent=True,
+        )
+
+
+def test_email_create_strips_from_name_before_length_check() -> None:
+    """Whitespace padding must not push a valid name over max_length."""
+    email = EmailCreate(
+        to=["a@example.com"],
+        subject="hi",
+        body_text="hi",
+        from_name="Acme" + " " * 260,
+        recipient_consent=True,
+    )
+    assert email.from_name == "Acme"

--- a/docs/public/cli.md
+++ b/docs/public/cli.md
@@ -73,7 +73,7 @@ hail email send --to alice@example.com --subject "Hi" --body "Hello"
 
 `hail email get <id>` prints headers, auth verdicts (SPF/DKIM/DMARC/spam/virus), the raw-MIME URL, and attachment metadata for inbound rows.
 
-`hail email send` flags: `--to` (repeatable / comma-separated), `--cc`, `--bcc`, `--from`, `--reply-to`, `--subject` (required), `--body`, `--body-html`, `--body-file`, `--body-html-file` (`-` reads stdin), `--idempotency-key`.
+`hail email send` flags: `--to` (repeatable / comma-separated), `--cc`, `--bcc`, `--from`, `--from-name`, `--reply-to`, `--subject` (required), `--body`, `--body-html`, `--body-file`, `--body-html-file` (`-` reads stdin), `--idempotency-key`.
 
 More email subcommands: `tail <id>`, `raw <id>`, `events <id>`, `stats`, `attachment`, `attachment-upload`. Run `hail email --help` for the list.
 

--- a/docs/public/self-host/aws-ses.md
+++ b/docs/public/self-host/aws-ses.md
@@ -166,9 +166,11 @@ The `from` field is optional. Resolution order:
 
 If none of these resolve, the call returns `503` with instructions to register a domain.
 
+The optional `from_name` field sets a display name on the `From:` header (`"Acme Billing" <billing@acme.com>`). Non-ASCII names are RFC-2047-encoded automatically; control characters are rejected with `422`.
+
 ## 8a. Attachments
 
-Upload a file once and attach it to as many sends as you want. The file size limit is 10MB per upload. SES caps the total message size (including all attachments) at its 10MB raw-message limit.
+Upload a file once and attach it to as many sends as you want. The limit is 25MB per upload and per send (body + all attachments combined, measured before base64 encoding). SES caps the encoded wire message at 40MB and bandwidth-throttles messages over 10MB.
 
 ### Upload a file
 

--- a/mcp/hailhq/mcp/hail_client.py
+++ b/mcp/hailhq/mcp/hail_client.py
@@ -319,6 +319,7 @@ class HailClient:
         body_text: str | None = None,
         body_html: str | None = None,
         from_: str | None = None,
+        from_name: str | None = None,
         cc: list[str] | None = None,
         bcc: list[str] | None = None,
         reply_to: str | None = None,
@@ -343,6 +344,8 @@ class HailClient:
         }
         if from_ is not None:
             fields["from"] = from_
+        if from_name is not None:
+            fields["from_name"] = from_name
         if body_text is not None:
             fields["body_text"] = body_text
         if body_html is not None:

--- a/mcp/hailhq/mcp/tools.py
+++ b/mcp/hailhq/mcp/tools.py
@@ -161,6 +161,7 @@ async def send_email(
     body_text: str | None = None,
     body_html: str | None = None,
     from_: str | None = None,
+    from_name: str | None = None,
     cc: list[str] | None = None,
     bcc: list[str] | None = None,
     reply_to: str | None = None,
@@ -181,6 +182,7 @@ async def send_email(
             body_text=body_text,
             body_html=body_html,
             from_=from_,
+            from_name=from_name,
             cc=cc,
             bcc=bcc,
             reply_to=reply_to,
@@ -632,6 +634,7 @@ def register_tools(
         body_text: str | None = None,
         body_html: str | None = None,
         from_: str | None = None,
+        from_name: str | None = None,
         cc: list[str] | None = None,
         bcc: list[str] | None = None,
         reply_to: str | None = None,
@@ -670,6 +673,10 @@ def register_tools(
         match a verified row already in ``email_domains`` (register
         one with the website console or ``POST /email-domains``).
 
+        ``from_name`` is an optional display name rendered on the
+        From: header ("Acme Billing <billing@acme.com>"). Control
+        characters are rejected.
+
         ``metadata`` is free-form JSON attached to the email record.
 
         ``idempotency_key`` defaults to a fresh UUID and is returned
@@ -700,6 +707,7 @@ def register_tools(
                     body_text=body_text,
                     body_html=body_html,
                     from_=from_,
+                    from_name=from_name,
                     cc=cc,
                     bcc=bcc,
                     reply_to=reply_to,
@@ -726,7 +734,7 @@ def register_tools(
         Returns ``{"id": ..., "filename": ..., "content_type": ...,
         "size_bytes": ...}`` — pass ``id`` in ``send_email``'s
         ``attachment_ids`` list. The id is reusable across many sends
-        and expires in 24h if never used. Files over 10MB (combined
+        and expires in 24h if never used. Files over 25MB (combined
         with the message body and any other attachments, per send) are
         rejected — host large files externally and link to them in the
         body instead.

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -471,6 +471,28 @@ async def test_send_email_serializes_from_alias(client: HailClient) -> None:
 
 
 @respx.mock
+async def test_send_email_forwards_from_name(client: HailClient) -> None:
+    captured: dict = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = request.read().decode("utf-8")
+        return httpx.Response(201, json=_email_response())
+
+    respx.post(f"{_BASE_URL}/emails").mock(side_effect=_handler)
+
+    await tools.send_email(
+        client=client,
+        recipient_consent=True,
+        to=["x@example.com"],
+        subject="hi",
+        body_text="body",
+        from_name="Acme Billing",
+    )
+    body = httpx.Response(200, content=captured["body"]).json()
+    assert body["from_name"] == "Acme Billing"
+
+
+@respx.mock
 async def test_send_email_returns_idempotency_key_in_response(
     client: HailClient,
 ) -> None:
@@ -611,7 +633,7 @@ async def test_upload_email_attachment_maps_413_to_error_detail(
 ) -> None:
     respx.post(f"{_BASE_URL}/email-attachments").mock(
         return_value=httpx.Response(
-            413, json={"detail": "attachment exceeds 10MB limit"}
+            413, json={"detail": "attachment exceeds 25MB limit"}
         )
     )
     result = await tools.upload_email_attachment(
@@ -620,7 +642,7 @@ async def test_upload_email_attachment_maps_413_to_error_detail(
         filename="invoice.pdf",
         content_type="application/pdf",
     )
-    assert "10MB" in result["error"]
+    assert "25MB" in result["error"]
 
 
 # --------------------------------------------------------------------------- #

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2605,6 +2605,12 @@ components:
             - type: string
             - type: "null"
           title: From
+        from_name:
+          anyOf:
+            - type: string
+              maxLength: 256
+            - type: "null"
+          title: From Name
         to:
           items:
             type: string
@@ -2988,6 +2994,11 @@ components:
         from_address:
           type: string
           title: From Address
+        from_name:
+          anyOf:
+            - type: string
+            - type: "null"
+          title: From Name
         to_addresses:
           items:
             type: string
@@ -3350,6 +3361,11 @@ components:
         from_address:
           type: string
           title: From Address
+        from_name:
+          anyOf:
+            - type: string
+            - type: "null"
+          title: From Name
         to_addresses:
           items:
             type: string

--- a/sdk/hail/__init__.py
+++ b/sdk/hail/__init__.py
@@ -57,7 +57,7 @@ from hail.models import (
     VoiceConfig,
 )
 
-__version__ = "0.8.0"
+__version__ = "0.14.0"
 
 __all__ = [
     # helpers

--- a/sdk/hail/client.py
+++ b/sdk/hail/client.py
@@ -296,6 +296,7 @@ class _EmailsResource:
         body_text: str | None = None,
         body_html: str | None = None,
         from_: str | None = None,
+        from_name: str | None = None,
         cc: list[str] | None = None,
         bcc: list[str] | None = None,
         reply_to: str | None = None,
@@ -328,6 +329,8 @@ class _EmailsResource:
         }
         if from_ is not None:
             body["from"] = from_
+        if from_name is not None:
+            body["from_name"] = from_name
         if body_text is not None:
             body["body_text"] = body_text
         if body_html is not None:

--- a/sdk/hail/models.py
+++ b/sdk/hail/models.py
@@ -331,6 +331,8 @@ class EmailCreate(BaseModel):
     to: list[str] = Field(min_length=1)
     subject: str = Field(min_length=1, max_length=998)
     from_: str | None = Field(default=None, alias="from")
+    # Display name for the From: header ("Acme Billing <billing@acme.com>").
+    from_name: str | None = Field(default=None, max_length=256)
     cc: list[str] | None = None
     bcc: list[str] | None = None
     reply_to: str | None = None
@@ -389,6 +391,7 @@ class EmailSummary(BaseModel):
     email_domain_id: UUID | None = None
     direction: Literal["outbound", "inbound"] = "outbound"
     from_address: str
+    from_name: str | None = None
     to_addresses: list[str]
     cc_addresses: list[str] | None = None
     bcc_addresses: list[str] | None = None

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hail-sdk"
-version = "0.13.0"
+version = "0.14.0"
 description = "Python SDK for Hail — universal communication platform for AI agents."
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/sdk/tests/test_emails.py
+++ b/sdk/tests/test_emails.py
@@ -101,6 +101,24 @@ async def test_emails_create_serializes_from_alias(base_url: str, api_key: str) 
 
 
 @respx.mock
+async def test_emails_create_sends_from_name(base_url: str, api_key: str) -> None:
+    route = respx.post(f"{base_url}/emails").mock(
+        return_value=httpx.Response(201, json=make_email_response())
+    )
+    async with Client(api_key=api_key, base_url=base_url) as c:
+        await c.emails.create(
+            to=["x@example.com"],
+            subject="hi",
+            body_text="body",
+            recipient_consent=True,
+            from_="alerts@acme.com",
+            from_name="Acme Billing",
+        )
+    body = json.loads(route.calls.last.request.content)
+    assert body["from_name"] == "Acme Billing"
+
+
+@respx.mock
 async def test_emails_create_with_cc_bcc_reply_to(base_url: str, api_key: str) -> None:
     route = respx.post(f"{base_url}/emails").mock(
         return_value=httpx.Response(201, json=make_email_response())

--- a/uv.lock
+++ b/uv.lock
@@ -1009,7 +1009,7 @@ wheels = [
 
 [[package]]
 name = "hail-sdk"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "sdk" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes two user tickets: sender display name on outbound email, and the attachment size cap. Cuts release **0.20.0** (`sdk-v0.14.0`, `cli-v0.19.0`).

## from_name (Ticket 1)

- `POST /emails` accepts optional `from_name`, rendered as `"Acme Billing" <billing@acme.com>` on the `From:` header.
- Both SES paths (Simple + raw MIME) share a `_friendly_from()` helper — RFC-2047 encoding for non-ASCII with proper word splitting; control characters (incl. NEL U+0085) rejected with 422 as a header-injection gate.
- Persisted (`emails.from_name`, migration `0042`), returned on reads, recorded in the `email.create` audit payload.
- Surfaces: SDK `from_name=`, MCP `send_email(from_name=...)`, CLI `--from-name`, `openapi.yaml` regenerated + Go client re-codegenned.

## Attachment cap 10MB → 25MB (Ticket 2)

- SESv2 (which we use) allows 40MB **post-base64** by default; 25MB raw ≈ 34MB encoded leaves headroom for bodies/footer/headers. 30MB+ raw would exceed the SES limit, so 25MB is the honest max.
- Cap now also enforced on body-only sends (was skipped without `attachment_ids`).
- MIME serialization moved off the event loop (`asyncio.to_thread`); S3 attachment fetches parallelized.
- Stale 10MB references updated in MCP/CLI/docs; tests derive from the constant.

## Release chores in this PR

- CHANGELOG: `[0.20.0] — 2026-08-10` section (from_name + cap).
- SDK: `sdk/pyproject.toml` 0.13.0 → **0.14.0**; `hail/__init__.py` `__version__` fixed from stale 0.8.0 → 0.14.0.
- CLI has no in-repo version — versioned at tag time.

## After merge — tag to release

```bash
git checkout main && git pull --ff-only origin main
git tag sdk-v0.14.0 && git push origin sdk-v0.14.0   # PyPI hail-sdk==0.14.0
git tag cli-v0.19.0 && git push origin cli-v0.19.0   # GoReleaser + Homebrew
git tag v0.20.0    && git push origin v0.20.0        # umbrella marker
```

## Deploy note

⚠️ Run `alembic upgrade head` (migration `0042_emails_from_name.py`) before the new API image serves traffic.

⚠️ The `gmail-account-connection` branch's `GmailEmailProvider.send_email` lacks the `from_name` kwarg — add it there before/at merge or Gmail sends will TypeError.

## Verification

core 611 / api 498 / mcp 88 / sdk 106 pytest, `go test ./...`, `uvx ruff check .`, `uvx black --check .` all green; `openapi.yaml` verified byte-identical to a fresh regen.
