### PR TITLE
feat(email): require explicit from on multiple domains, add whoami

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to Hail are documented here. The format is based on [Keep a 
 
 ## [Unreleased]
 
+### Email sender resolution — breaking
+
+- `POST /emails` no longer guesses a sender. An org with **two or more**
+  verified identities and no `from` now gets a `422` listing every address
+  it can send from, instead of silently using the oldest one — that pick
+  changed the sending identity whenever a domain was added or deleted.
+  One verified identity (or none, which auto-mints hail-mail) behaves as
+  before. The voicebot's internal send route keeps the old pick: a voice
+  agent has no way to name a domain mid-call.
+- `GET /email-domains` gained `default_from` — the address a `from`-less
+  send goes out as, `null` when the caller must choose. With no rows at all
+  it shows the hail-mail address a first send would mint, which was
+  previously unknowable until that send happened. Surfaced on the SDK
+  (`.default_from`) and the CLI (`hail email domain list` footer).
+
+### Whoami
+
+- New `GET /whoami` returns the caller's `auth_kind`, `organization_id`,
+  `user_id`, `email`, and `name`. The user fields are `null` for a shared
+  operator key. Exposed as `client.whoami()` (SDK), `hail whoami` (CLI),
+  and the `whoami` MCP tool — an agent reads `email` and passes it as
+  `reply_to` so replies reach the person, not an unattended `noreply@`.
+- New `list_email_domains` MCP tool, so an agent can discover sending
+  identities instead of guessing a domain.
+
 ## [0.20.0] — 2026-08-10
 
 Sender display names on outbound email, and a 25MB attachment cap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Hail are documented here. The format is based on [Keep a 
 
 ## [Unreleased]
 
+## [0.21.0] — 2026-08-13
+
+No more guessing which address your mail goes out as, and a `whoami` on every surface.
+
+Component versions cut alongside this release:
+**`sdk-v0.15.0`** (PyPI: `hail-sdk==0.15.0`), **`cli-v0.20.0`** (Homebrew + GitHub Releases).
+
 ### Email sender resolution — breaking
 
 - `POST /emails` no longer guesses a sender. An org with **two or more**

--- a/api/hailhq/api/main.py
+++ b/api/hailhq/api/main.py
@@ -22,6 +22,7 @@ from hailhq.api.routes import providers as providers_routes
 from hailhq.api.routes import sms as sms_routes
 from hailhq.api.routes import unsubscribe as unsubscribe_routes
 from hailhq.api.routes import webhooks as webhooks_routes
+from hailhq.api.routes import whoami as whoami_routes
 from hailhq.api.routes.internal import agent as internal_agent
 from hailhq.api.routes.internal import dsar as internal_dsar
 from hailhq.api.routes.internal import numbers as internal_numbers
@@ -281,6 +282,7 @@ app.include_router(webhooks_routes.router)
 app.include_router(unsubscribe_routes.router)
 app.include_router(sms_routes.router)
 app.include_router(contacts_routes.router)
+app.include_router(whoami_routes.router)
 app.include_router(providers_routes.router)
 app.include_router(internal_ses_events.router)
 app.include_router(internal_org_closures.router)

--- a/api/hailhq/api/routes/email_domains.py
+++ b/api/hailhq/api/routes/email_domains.py
@@ -39,6 +39,7 @@ from hailhq.api.pagination import fetch_cursor_page
 from hailhq.core.config import settings
 from hailhq.core.db import get_session
 from hailhq.core.dns_lookup import custom_dns_records, resolve_mx, ses_inbound_host
+from hailhq.core.email_sender import from_address_for
 from hailhq.core.hail_mail import org_prefix_from_id
 from hailhq.core.models import Email, EmailDomain
 from hailhq.core.providers.email import EmailProvider, SesEmailProvider
@@ -190,6 +191,74 @@ def compose_hail_mail_address(user_prefix: str, org_prefix: str) -> str:
 
 
 # --------------------------------------------------------------------------- #
+# Sender selection — shared by POST /emails and GET /email-domains.
+# --------------------------------------------------------------------------- #
+
+
+async def verified_senders(
+    db: AsyncSession, organization_id: UUID
+) -> list[EmailDomain]:
+    """Every verified identity the org can send through, oldest first.
+
+    Ordered by ``created_at`` so a single-identity org resolves the same
+    row on every retry.
+    """
+    stmt = (
+        select(EmailDomain)
+        .where(EmailDomain.organization_id == organization_id)
+        .where(EmailDomain.verification_status == "verified")
+        .order_by(EmailDomain.created_at.asc())
+    )
+    return list((await db.execute(stmt)).scalars().all())
+
+
+async def first_pending_custom(db: AsyncSession, organization_id: UUID) -> str | None:
+    """The domain of one custom row still waiting on DKIM, if any."""
+    stmt = (
+        select(EmailDomain.domain)
+        .where(EmailDomain.organization_id == organization_id)
+        .where(EmailDomain.kind == "custom")
+        .where(EmailDomain.verification_status == "pending")
+        .limit(1)
+    )
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def preview_default_from(db: AsyncSession, organization_id: UUID) -> str | None:
+    """The address a ``from``-less send would use right now, or ``None``.
+
+    ``None`` means "a ``from``-less send will not go out": either the org
+    owns several verified identities and must name one (``resolve_sender``
+    raises 422), or it owns none that can send yet. Mirrors
+    ``resolve_sender`` case for case — the two must not drift, which is
+    why both read ``verified_senders`` / ``first_pending_custom``.
+
+    Never raises: hail-mail being unconfigured is a normal deployment
+    posture and must not break ``GET /email-domains``.
+    """
+    verified = await verified_senders(db, organization_id)
+    if len(verified) != 1:
+        return None if verified else await _unminted_hail_mail(db, organization_id)
+    return from_address_for(verified[0])
+
+
+async def _unminted_hail_mail(db: AsyncSession, organization_id: UUID) -> str | None:
+    """The hail-mail address a first send would mint, if it would mint one."""
+    if await first_pending_custom(db, organization_id) is not None:
+        # resolve_sender 422s on this state instead of minting.
+        return None
+    try:
+        user_prefix, org_prefix = resolve_hail_mail_prefixes(
+            None, None, organization_id
+        )
+        return compose_hail_mail_address(user_prefix, org_prefix)
+    except HTTPException:
+        # 503 from either helper — the operator has not configured
+        # hail-mail. Not an error for a read; there simply is no default.
+        return None
+
+
+# --------------------------------------------------------------------------- #
 # POST /email-domains
 # --------------------------------------------------------------------------- #
 
@@ -330,6 +399,9 @@ async def list_email_domains(
     return EmailDomainListResponse(
         items=[EmailDomainResponse.model_validate(r) for r in rows],
         next_cursor=next_cursor,
+        # Whole-org answer, not a property of this page: computed from
+        # every verified row, so it stays correct while paging.
+        default_from=await preview_default_from(db, principal.organization_id),
     )
 
 

--- a/api/hailhq/api/routes/emails.py
+++ b/api/hailhq/api/routes/emails.py
@@ -4,10 +4,14 @@ POST /emails - send an outbound message through SES.
 GET /emails/{id} - read a single email (org-scoped).
 GET /emails - cursor-paginated list (org-scoped).
 
-The from-address resolution mirrors POST /calls:
+From-address resolution:
 
-  explicit ``from`` → first verified org-owned domain →
+  explicit ``from`` → the org's one verified domain →
   freshly minted hail-mail address (if HAIL_MAIL_BASE_DOMAIN is set)
+
+An org with several verified domains has no default: a ``from``-less
+send returns 422 listing the choices. ``GET /email-domains`` exposes the
+same decision up front as ``default_from``.
 
 Unlike the phone-number pool, the hail-mail "pool" is not shared across
 orgs — every org gets its own row under the operator's pre-verified
@@ -44,8 +48,10 @@ from hailhq.api.idempotency import (
 from hailhq.api.pagination import fetch_cursor_page
 from hailhq.api.routes.email_domains import (
     compose_hail_mail_address,
+    first_pending_custom,
     get_email_provider,
     resolve_hail_mail_prefixes,
+    verified_senders,
 )
 from hailhq.api.usage import write_usage_event
 from hailhq.core.compliance_gate import check_email_allowed, normalize_recipient
@@ -56,6 +62,7 @@ from hailhq.core.email_attachment_limits import (
 )
 from hailhq.core.email_delivery_events import record_sent_event
 from hailhq.core.email_footer import append_sent_footer
+from hailhq.core.email_sender import from_address_for
 from hailhq.core.models import (
     Email,
     EmailAttachment,
@@ -107,17 +114,24 @@ async def resolve_sender(
     db: AsyncSession,
     organization_id: UUID,
     explicit_from: str | None,
+    *,
+    allow_ambiguous: bool = False,
 ) -> EmailDomain:
     """Find the EmailDomain row to send through, in priority order.
 
     1. Explicit ``from``: look up by full address (hail-mail row's
        ``domain`` is the full address; custom row's ``domain`` is the
        parent so we match by suffix).
-    2. First verified org-owned domain by ``created_at`` (deterministic
-       across retries — newest-last so the "default sender" stays
-       stable as orgs add more).
-    3. Mint a fresh hail-mail row on the fly if ``HAIL_MAIL_BASE_DOMAIN``
+    2. No ``from``, exactly one verified org-owned domain: that one.
+    3. No ``from``, several verified domains: 422 listing them. Picking
+       one for the caller means the sending identity changes silently
+       when domains are added or deleted, so the caller names it.
+    4. Mint a fresh hail-mail row on the fly if ``HAIL_MAIL_BASE_DOMAIN``
        is configured.
+
+    ``allow_ambiguous`` restores the old "oldest verified wins" pick for
+    callers that have no way to name a sender — the voicebot's internal
+    send route, where the choice is made by a phone conversation.
 
     Raises ``HTTPException`` if nothing resolves.
     """
@@ -156,30 +170,25 @@ async def resolve_sender(
             loc=["body", "from"],
         )
 
-    # No explicit `from` — prefer any verified domain, ordered by created_at.
-    stmt = (
-        select(EmailDomain)
-        .where(EmailDomain.organization_id == organization_id)
-        .where(EmailDomain.verification_status == "verified")
-        .order_by(EmailDomain.created_at.asc())
-        .limit(1)
-    )
-    sd = (await db.execute(stmt)).scalar_one_or_none()
-    if sd is not None:
-        return sd
+    # No explicit `from`. One verified identity is unambiguous; several
+    # are not — see the docstring for why we refuse to guess.
+    verified = await verified_senders(db, organization_id)
+    if len(verified) == 1 or (verified and allow_ambiguous):
+        return verified[0]
+    if verified:
+        choices = ", ".join(from_address_for(sd) for sd in verified)
+        raise unprocessable(
+            f"organization has {len(verified)} verified senders — pass an "
+            f"explicit `from` to choose one of: {choices} (a custom domain "
+            "accepts any local-part)",
+            loc=["body", "from"],
+        )
 
     # No verified row. If the org has *any* pending custom rows, return a
     # targeted 422 pointing at the verify endpoint rather than the generic
     # "set HAIL_MAIL_BASE_DOMAIN" message that would mislead the operator
     # into thinking hail-mail config was the problem.
-    pending_stmt = (
-        select(EmailDomain.domain)
-        .where(EmailDomain.organization_id == organization_id)
-        .where(EmailDomain.kind == "custom")
-        .where(EmailDomain.verification_status == "pending")
-        .limit(1)
-    )
-    pending_domain = (await db.execute(pending_stmt)).scalar_one_or_none()
+    pending_domain = await first_pending_custom(db, organization_id)
     if pending_domain is not None:
         raise unprocessable(
             f"sender domain {pending_domain!r} is pending DKIM verification; "
@@ -247,20 +256,6 @@ async def resolve_sender(
     # in the same request observes the materialized values.
     await db.refresh(sd)
     return sd
-
-
-def from_address_for(sd: EmailDomain, explicit: str | None) -> str:
-    """Resolve the wire ``From:`` for a send.
-
-    Hail-mail: ``sd.domain`` is the full address.
-    Custom:    ``sd.domain`` is just the DNS name; if the caller didn't
-               supply an explicit local-part, default to ``noreply``.
-    """
-    if explicit is not None:
-        return explicit
-    if sd.kind == "hail_mail":
-        return sd.domain
-    return f"noreply@{sd.domain}"
 
 
 # --------------------------------------------------------------------------- #
@@ -945,4 +940,4 @@ async def list_emails(
     )
 
 
-__all__ = ["deliver_email", "from_address_for", "resolve_sender", "router"]
+__all__ = ["deliver_email", "resolve_sender", "router"]

--- a/api/hailhq/api/routes/internal/agent.py
+++ b/api/hailhq/api/routes/internal/agent.py
@@ -25,7 +25,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from hailhq.api.audit import write_audit_log
 from hailhq.api.numbers import resolve_org_number
 from hailhq.api.routes.email_domains import get_email_provider
-from hailhq.api.routes.emails import deliver_email, from_address_for, resolve_sender
+from hailhq.api.routes.emails import deliver_email, resolve_sender
 from hailhq.api.routes.internal.auth import verify_internal_request
 from hailhq.api.routes.sms import deliver_sms, get_sms_provider
 from hailhq.core.agent_caps import check_agent_send_allowed
@@ -45,6 +45,7 @@ from hailhq.core.compliance_gate import (
 )
 from hailhq.core.db import get_session
 from hailhq.core.directory import resolve_member_emails
+from hailhq.core.email_sender import from_address_for
 from hailhq.core.models import Call, Email, Sms
 from hailhq.core.providers.email import EmailProvider
 from hailhq.core.providers.sms import SmsProvider
@@ -415,7 +416,10 @@ async def agent_send_email(
         )
 
     try:
-        sd = await resolve_sender(db, org, None)
+        # A voice agent cannot name a sending domain mid-call, so this path
+        # keeps the old "oldest verified wins" pick that POST /emails now
+        # refuses. Public callers get the 422 and choose for themselves.
+        sd = await resolve_sender(db, org, None, allow_ambiguous=True)
     except HTTPException:
         return AgentSendResponse(ok=False, spoken=_SPOKEN_EMAIL_UNCONFIGURED)
 

--- a/api/hailhq/api/routes/whoami.py
+++ b/api/hailhq/api/routes/whoami.py
@@ -1,0 +1,57 @@
+"""GET /whoami — who the caller is.
+
+Agents need this to address mail as a person: an MCP client that wants
+the human's address in ``Reply-To`` has no other way to learn it, since
+the bearer token carries an organization, not a mailbox.
+
+The identity comes from ``Principal`` (deps.py), so the answer follows
+the auth path: an api-key call resolves the key owner, a JWT call
+resolves its ``sub``, and a shared-key (``HAIL_API_KEY``) call resolves
+nobody — ``user_id``/``email``/``name`` come back ``None``.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from hailhq.api.deps import Principal, get_current_principal
+from hailhq.core.db import get_session
+from hailhq.core.models import User
+from hailhq.core.schemas import WhoamiResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+router = APIRouter(tags=["whoami"])
+
+
+@router.get("/whoami", response_model=WhoamiResponse)
+async def get_whoami(
+    principal: Annotated[Principal, Depends(get_current_principal)],
+    db: Annotated[AsyncSession, Depends(get_session)],
+) -> WhoamiResponse:
+    if principal.user_id is None:
+        return WhoamiResponse(
+            auth_kind=principal.auth_kind,
+            organization_id=principal.organization_id,
+        )
+
+    row = (
+        await db.execute(
+            select(User.email, User.name).where(User.id == principal.user_id)
+        )
+    ).one_or_none()
+
+    return WhoamiResponse(
+        auth_kind=principal.auth_kind,
+        organization_id=principal.organization_id,
+        user_id=principal.user_id,
+        # The website owns ``users``; a JWT ``sub`` with no row there is a
+        # live session for a deleted user. Report the id we have rather
+        # than 404 — the caller asked who it is, not for a user record.
+        email=row.email if row is not None else None,
+        name=row.name if row is not None else None,
+    )
+
+
+__all__ = ["router"]

--- a/api/tests/test_email_domains_api.py
+++ b/api/tests/test_email_domains_api.py
@@ -633,6 +633,115 @@ async def test_list_email_domains_is_org_scoped(
 
 
 # --------------------------------------------------------------------------- #
+# GET /email-domains — default_from
+#
+# The field answers "what does a send with no `from` go out as?", so every
+# case below is paired with the POST /emails behaviour it predicts.
+# --------------------------------------------------------------------------- #
+
+
+async def _verify(client: httpx.AsyncClient, headers: dict, domain: str) -> None:
+    created = await client.post(
+        "/email-domains", json={"kind": "custom", "domain": domain}, headers=headers
+    )
+    assert created.status_code == 201
+    await client.post(f"/email-domains/{created.json()['id']}/verify", headers=headers)
+
+
+async def test_default_from_is_the_single_verified_sender(
+    client: httpx.AsyncClient,
+    org_and_key: tuple,
+) -> None:
+    _, _, plain = org_and_key
+    headers = {"Authorization": f"Bearer {plain}"}
+    await _verify(client, headers, "acme.com")
+
+    resp = await client.get("/email-domains", headers=headers)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["default_from"] == "noreply@acme.com"
+
+
+async def test_default_from_is_null_with_several_verified_senders(
+    client: httpx.AsyncClient,
+    org_and_key: tuple,
+) -> None:
+    """Null mirrors the 422 a ``from``-less POST /emails now returns."""
+    _, _, plain = org_and_key
+    headers = {"Authorization": f"Bearer {plain}"}
+    await _verify(client, headers, "acme.com")
+    await _verify(client, headers, "mail.acme.io")
+
+    resp = await client.get("/email-domains", headers=headers)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["default_from"] is None
+
+
+async def test_default_from_shows_the_unminted_hail_mail_address(
+    client: httpx.AsyncClient,
+    org_and_key: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no rows at all the address exists nowhere else until a send."""
+    monkeypatch.setattr(settings, "hail_mail_base_domain", "mail.hail.so")
+    monkeypatch.setattr(settings, "hail_mail_default_user_prefix", "admin")
+    monkeypatch.setattr(settings, "hail_mail_from", "")
+    org_id, _, plain = org_and_key
+
+    resp = await client.get(
+        "/email-domains", headers={"Authorization": f"Bearer {plain}"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["items"] == []
+    assert body["default_from"] == f"admin+{org_prefix_from_id(org_id)}@mail.hail.so"
+
+
+async def test_default_from_is_null_while_a_custom_domain_is_pending(
+    client: httpx.AsyncClient,
+    org_and_key: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pending row blocks auto-mint, so there is no default to report."""
+    monkeypatch.setattr(settings, "hail_mail_base_domain", "mail.hail.so")
+    monkeypatch.setattr(settings, "hail_mail_default_user_prefix", "admin")
+    _, _, plain = org_and_key
+    headers = {"Authorization": f"Bearer {plain}"}
+    created = await client.post(
+        "/email-domains",
+        json={"kind": "custom", "domain": "pending.com"},
+        headers=headers,
+    )
+    assert created.status_code == 201  # left unverified
+
+    resp = await client.get("/email-domains", headers=headers)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["default_from"] is None
+
+
+async def test_default_from_is_null_when_hail_mail_is_unconfigured(
+    client: httpx.AsyncClient,
+    org_and_key: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unconfigured deployment must not 503 a plain list read."""
+    monkeypatch.setattr(settings, "hail_mail_base_domain", "")
+    monkeypatch.setattr(settings, "hail_mail_default_user_prefix", "")
+    monkeypatch.setattr(settings, "hail_mail_from", "")
+    _, _, plain = org_and_key
+
+    resp = await client.get(
+        "/email-domains", headers={"Authorization": f"Bearer {plain}"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["default_from"] is None
+
+
+# --------------------------------------------------------------------------- #
 # POST /email-domains/{id}/verify
 # --------------------------------------------------------------------------- #
 

--- a/api/tests/test_emails_api.py
+++ b/api/tests/test_emails_api.py
@@ -903,6 +903,81 @@ async def test_post_emails_does_not_send_through_pending_domain(
     assert "verify" in detail
 
 
+async def test_post_emails_without_from_422s_on_several_verified_senders(
+    client: httpx.AsyncClient,
+    org_and_key: tuple,
+    email_mock: AsyncMock,
+) -> None:
+    """Two verified identities and no ``from`` → refuse, don't guess.
+
+    Guessing meant the sending identity silently changed whenever a domain
+    was added or removed. The 422 lists both addresses so the caller can
+    retry with one of them.
+    """
+    _, _, plain = org_and_key
+    headers = {"Authorization": f"Bearer {plain}"}
+    await _register_custom_verified(client, headers, domain="acme.com")
+    await _register_custom_verified(client, headers, domain="mail.acme.io")
+
+    resp = await client.post(
+        "/emails",
+        json={
+            "to": ["x@example.com"],
+            "subject": "hi",
+            "body_text": "body",
+            "recipient_consent": True,
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    detail = resp.json()["detail"][0]["msg"]
+    assert "noreply@acme.com" in detail
+    assert "noreply@mail.acme.io" in detail
+    email_mock.send_email.assert_not_awaited()
+
+
+async def test_post_emails_without_from_sends_on_a_single_verified_sender(
+    client: httpx.AsyncClient,
+    org_and_key: tuple,
+    email_mock: AsyncMock,
+) -> None:
+    """One identity is unambiguous — no ``from`` needed."""
+    _, _, plain = org_and_key
+    headers = {"Authorization": f"Bearer {plain}"}
+    await _register_custom_verified(client, headers, domain="acme.com")
+
+    body = await _send_email(client, plain)
+
+    assert body["from_address"] == "noreply@acme.com"
+
+
+async def test_post_emails_named_from_still_works_with_several_senders(
+    client: httpx.AsyncClient,
+    org_and_key: tuple,
+    email_mock: AsyncMock,
+) -> None:
+    _, _, plain = org_and_key
+    headers = {"Authorization": f"Bearer {plain}"}
+    await _register_custom_verified(client, headers, domain="acme.com")
+    await _register_custom_verified(client, headers, domain="mail.acme.io")
+
+    resp = await client.post(
+        "/emails",
+        json={
+            "from": "sales@mail.acme.io",
+            "to": ["x@example.com"],
+            "subject": "hi",
+            "body_text": "body",
+            "recipient_consent": True,
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["from_address"] == "sales@mail.acme.io"
+
+
 # --------------------------------------------------------------------------- #
 # POST /emails — provider failure
 # --------------------------------------------------------------------------- #

--- a/api/tests/test_internal_agent_send.py
+++ b/api/tests/test_internal_agent_send.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import httpx
 import pytest
@@ -547,3 +547,71 @@ async def test_send_sms_agent_caps_noop_for_human_org(
         "/internal/agent/send-sms", content=body, headers=_signed(body)
     )
     assert resp.json()["ok"] is True
+
+
+async def test_agent_send_email_still_picks_a_sender_with_several_verified(
+    client, async_session, email_mock, add_phone_number
+):
+    """The voicebot keeps the oldest-verified pick POST /emails now refuses.
+
+    A voice agent has no way to name a sending domain mid-call, so the
+    ambiguity that returns 422 on the public route must not silently turn
+    into "email is not configured" here.
+    """
+    org = uuid.uuid4()
+    call = await _insert_live_call(async_session, org, add_phone_number)
+    now = datetime.now(timezone.utc)
+    async_session.add(
+        EmailDomain(
+            organization_id=org,
+            kind="custom",
+            domain="first.test",
+            verification_status="verified",
+            created_at=now - timedelta(days=1),
+        )
+    )
+    async_session.add(
+        EmailDomain(
+            organization_id=org,
+            kind="custom",
+            domain="second.test",
+            verification_status="verified",
+            created_at=now,
+        )
+    )
+    user = User(
+        id=uuid.uuid4(),
+        name="Sarah Chen",
+        email="sarah@a.test",
+        created_at=now,
+    )
+    async_session.add(user)
+    async_session.add(
+        OrganizationMember(
+            id=uuid.uuid4(),
+            user_id=user.id,
+            organization_id=org,
+            role="member",
+            created_at=now,
+        )
+    )
+    await async_session.commit()
+
+    payload = json.dumps(
+        {
+            "call_id": str(call.id),
+            "tool_invocation_id": str(uuid.uuid4()),
+            "recipient_name": "Sarah Chen",
+            "subject": "Call summary",
+            "body_text": "Hello from the call.",
+        }
+    ).encode()
+    resp = await client.post(
+        "/internal/agent/send-email", content=payload, headers=_signed(payload)
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+    rows = (await async_session.execute(select(Email))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].from_address == "noreply@first.test"

--- a/api/tests/test_whoami_api.py
+++ b/api/tests/test_whoami_api.py
@@ -1,0 +1,88 @@
+"""Integration tests for GET /whoami."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+from hailhq.api.deps import SELF_HOSTED_ORG_ID
+from hailhq.core.config import settings
+from hailhq.core.models import User
+from sqlalchemy.ext.asyncio import AsyncSession
+
+SHARED_KEY = "hail-test-shared-secret-do-not-use-in-prod"
+
+
+async def test_whoami_resolves_the_api_key_owner(
+    client: httpx.AsyncClient,
+    org_and_key: tuple,
+    async_session: AsyncSession,
+) -> None:
+    org_id, api_key, plain = org_and_key
+    user_id = uuid.UUID(api_key.reference_id)
+    async_session.add(
+        User(
+            id=user_id,
+            name="Sarah Chen",
+            email="sarah@acme.test",
+            created_at=datetime.now(timezone.utc),
+        )
+    )
+    await async_session.commit()
+
+    resp = await client.get("/whoami", headers={"Authorization": f"Bearer {plain}"})
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body == {
+        "auth_kind": "apikey",
+        "organization_id": str(org_id),
+        "user_id": str(user_id),
+        "email": "sarah@acme.test",
+        "name": "Sarah Chen",
+    }
+
+
+async def test_whoami_without_a_users_row_keeps_the_user_id(
+    client: httpx.AsyncClient,
+    org_and_key: tuple,
+) -> None:
+    """A session for a deleted user still answers — id yes, mailbox no."""
+    org_id, api_key, plain = org_and_key
+
+    resp = await client.get("/whoami", headers={"Authorization": f"Bearer {plain}"})
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["organization_id"] == str(org_id)
+    assert body["user_id"] == api_key.reference_id
+    assert body["email"] is None
+    assert body["name"] is None
+
+
+async def test_whoami_on_the_shared_key_has_no_human(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A self-hosted operator key carries an org, not a person."""
+    monkeypatch.setattr(settings, "hail_api_key", SHARED_KEY)
+
+    resp = await client.get(
+        "/whoami", headers={"Authorization": f"Bearer {SHARED_KEY}"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "auth_kind": "shared",
+        "organization_id": str(SELF_HOSTED_ORG_ID),
+        "user_id": None,
+        "email": None,
+        "name": None,
+    }
+
+
+async def test_whoami_requires_auth(client: httpx.AsyncClient) -> None:
+    resp = await client.get("/whoami")
+    assert resp.status_code == 401

--- a/cli/internal/client/client.gen.go
+++ b/cli/internal/client/client.gen.go
@@ -855,6 +855,27 @@ func (e WebhookSubscriptionResponseStatus) Valid() bool {
 	}
 }
 
+// Defines values for WhoamiResponseAuthKind.
+const (
+	Apikey WhoamiResponseAuthKind = "apikey"
+	Jwt    WhoamiResponseAuthKind = "jwt"
+	Shared WhoamiResponseAuthKind = "shared"
+)
+
+// Valid indicates whether the value is a known member of the WhoamiResponseAuthKind enum.
+func (e WhoamiResponseAuthKind) Valid() bool {
+	switch e {
+	case Apikey:
+		return true
+	case Jwt:
+		return true
+	case Shared:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ListCallsCallsGetParamsStatus.
 const (
 	ListCallsCallsGetParamsStatusBusy       ListCallsCallsGetParamsStatus = "busy"
@@ -1195,8 +1216,9 @@ type EmailDomainCreateKind string
 
 // EmailDomainListResponse defines model for EmailDomainListResponse.
 type EmailDomainListResponse struct {
-	Items      []EmailDomainResponse `json:"items"`
-	NextCursor *string               `json:"next_cursor,omitempty"`
+	DefaultFrom *string               `json:"default_from,omitempty"`
+	Items       []EmailDomainResponse `json:"items"`
+	NextCursor  *string               `json:"next_cursor,omitempty"`
 }
 
 // EmailDomainPatch Body for PATCH /email-domains/{id}.
@@ -1734,6 +1756,23 @@ type WebhookSubscriptionResponse struct {
 // WebhookSubscriptionResponseStatus defines model for WebhookSubscriptionResponse.Status.
 type WebhookSubscriptionResponseStatus string
 
+// WhoamiResponse Who the caller is — the answer “GET /whoami“ gives.
+//
+// “user_id“/“email“/“name“ are “None“ for shared-key
+// (“HAIL_API_KEY“) callers: that key carries no human identity. An
+// agent that wants to put the operator's address in “Reply-To“ reads
+// “email“ and skips the header when it is “None“.
+type WhoamiResponse struct {
+	AuthKind       WhoamiResponseAuthKind `json:"auth_kind"`
+	Email          *string                `json:"email,omitempty"`
+	Name           *string                `json:"name,omitempty"`
+	OrganizationId openapi_types.UUID     `json:"organization_id"`
+	UserId         *openapi_types.UUID    `json:"user_id,omitempty"`
+}
+
+// WhoamiResponseAuthKind defines model for WhoamiResponse.AuthKind.
+type WhoamiResponseAuthKind string
+
 // ListCallsCallsGetParams defines parameters for ListCallsCallsGet.
 type ListCallsCallsGetParams struct {
 	Cursor        *string                        `form:"cursor,omitempty" json:"cursor,omitempty"`
@@ -1909,6 +1948,11 @@ type AcquireNumberNumbersPostParams struct {
 	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
 }
 
+// ReleaseNumberNumbersNumberIdDeleteParams defines parameters for ReleaseNumberNumbersNumberIdDelete.
+type ReleaseNumberNumbersNumberIdDeleteParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // GetNumberNumbersNumberIdGetParams defines parameters for GetNumberNumbersNumberIdGet.
 type GetNumberNumbersNumberIdGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
@@ -2035,6 +2079,11 @@ type RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostParams struct {
 
 // RotateSecretWebhooksSubIdRotateSecretPostParams defines parameters for RotateSecretWebhooksSubIdRotateSecretPost.
 type RotateSecretWebhooksSubIdRotateSecretPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// GetWhoamiWhoamiGetParams defines parameters for GetWhoamiWhoamiGet.
+type GetWhoamiWhoamiGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
@@ -2430,6 +2479,9 @@ type ClientInterface interface {
 
 	AcquireNumberNumbersPost(ctx context.Context, params *AcquireNumberNumbersPostParams, body AcquireNumberNumbersPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ReleaseNumberNumbersNumberIdDelete request
+	ReleaseNumberNumbersNumberIdDelete(ctx context.Context, numberId openapi_types.UUID, params *ReleaseNumberNumbersNumberIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetNumberNumbersNumberIdGet request
 	GetNumberNumbersNumberIdGet(ctx context.Context, numberId openapi_types.UUID, params *GetNumberNumbersNumberIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2512,6 +2564,9 @@ type ClientInterface interface {
 
 	// RotateSecretWebhooksSubIdRotateSecretPost request
 	RotateSecretWebhooksSubIdRotateSecretPost(ctx context.Context, subId openapi_types.UUID, params *RotateSecretWebhooksSubIdRotateSecretPostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetWhoamiWhoamiGet request
+	GetWhoamiWhoamiGet(ctx context.Context, params *GetWhoamiWhoamiGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) ListCallsCallsGet(ctx context.Context, params *ListCallsCallsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -2946,6 +3001,18 @@ func (c *Client) AcquireNumberNumbersPost(ctx context.Context, params *AcquireNu
 	return c.Client.Do(req)
 }
 
+func (c *Client) ReleaseNumberNumbersNumberIdDelete(ctx context.Context, numberId openapi_types.UUID, params *ReleaseNumberNumbersNumberIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewReleaseNumberNumbersNumberIdDeleteRequest(c.Server, numberId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetNumberNumbersNumberIdGet(ctx context.Context, numberId openapi_types.UUID, params *GetNumberNumbersNumberIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetNumberNumbersNumberIdGetRequest(c.Server, numberId, params)
 	if err != nil {
@@ -3296,6 +3363,18 @@ func (c *Client) RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPost(ctx con
 
 func (c *Client) RotateSecretWebhooksSubIdRotateSecretPost(ctx context.Context, subId openapi_types.UUID, params *RotateSecretWebhooksSubIdRotateSecretPostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRotateSecretWebhooksSubIdRotateSecretPostRequest(c.Server, subId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetWhoamiWhoamiGet(ctx context.Context, params *GetWhoamiWhoamiGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetWhoamiWhoamiGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -5154,6 +5233,55 @@ func NewAcquireNumberNumbersPostRequestWithBody(server string, params *AcquireNu
 	return req, nil
 }
 
+// NewReleaseNumberNumbersNumberIdDeleteRequest generates requests for ReleaseNumberNumbersNumberIdDelete
+func NewReleaseNumberNumbersNumberIdDeleteRequest(server string, numberId openapi_types.UUID, params *ReleaseNumberNumbersNumberIdDeleteParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "number_id", numberId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/numbers/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithOptions("simple", false, "authorization", *params.Authorization, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationHeader, Type: "string", Format: ""})
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
 // NewGetNumberNumbersNumberIdGetRequest generates requests for GetNumberNumbersNumberIdGet
 func NewGetNumberNumbersNumberIdGetRequest(server string, numberId openapi_types.UUID, params *GetNumberNumbersNumberIdGetParams) (*http.Request, error) {
 	var err error
@@ -6521,6 +6649,48 @@ func NewRotateSecretWebhooksSubIdRotateSecretPostRequest(server string, subId op
 	return req, nil
 }
 
+// NewGetWhoamiWhoamiGetRequest generates requests for GetWhoamiWhoamiGet
+func NewGetWhoamiWhoamiGetRequest(server string, params *GetWhoamiWhoamiGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/whoami")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithOptions("simple", false, "authorization", *params.Authorization, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationHeader, Type: "string", Format: ""})
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
 func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
 	for _, r := range c.RequestEditors {
 		if err := r(ctx, req); err != nil {
@@ -6664,6 +6834,9 @@ type ClientWithResponsesInterface interface {
 
 	AcquireNumberNumbersPostWithResponse(ctx context.Context, params *AcquireNumberNumbersPostParams, body AcquireNumberNumbersPostJSONRequestBody, reqEditors ...RequestEditorFn) (*AcquireNumberNumbersPostResponse, error)
 
+	// ReleaseNumberNumbersNumberIdDeleteWithResponse request
+	ReleaseNumberNumbersNumberIdDeleteWithResponse(ctx context.Context, numberId openapi_types.UUID, params *ReleaseNumberNumbersNumberIdDeleteParams, reqEditors ...RequestEditorFn) (*ReleaseNumberNumbersNumberIdDeleteResponse, error)
+
 	// GetNumberNumbersNumberIdGetWithResponse request
 	GetNumberNumbersNumberIdGetWithResponse(ctx context.Context, numberId openapi_types.UUID, params *GetNumberNumbersNumberIdGetParams, reqEditors ...RequestEditorFn) (*GetNumberNumbersNumberIdGetResponse, error)
 
@@ -6746,6 +6919,9 @@ type ClientWithResponsesInterface interface {
 
 	// RotateSecretWebhooksSubIdRotateSecretPostWithResponse request
 	RotateSecretWebhooksSubIdRotateSecretPostWithResponse(ctx context.Context, subId openapi_types.UUID, params *RotateSecretWebhooksSubIdRotateSecretPostParams, reqEditors ...RequestEditorFn) (*RotateSecretWebhooksSubIdRotateSecretPostResponse, error)
+
+	// GetWhoamiWhoamiGetWithResponse request
+	GetWhoamiWhoamiGetWithResponse(ctx context.Context, params *GetWhoamiWhoamiGetParams, reqEditors ...RequestEditorFn) (*GetWhoamiWhoamiGetResponse, error)
 }
 
 type ListCallsCallsGetResponse struct {
@@ -7388,6 +7564,28 @@ func (r AcquireNumberNumbersPostResponse) StatusCode() int {
 	return 0
 }
 
+type ReleaseNumberNumbersNumberIdDeleteResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ReleaseNumberNumbersNumberIdDeleteResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ReleaseNumberNumbersNumberIdDeleteResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetNumberNumbersNumberIdGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -7913,6 +8111,29 @@ func (r RotateSecretWebhooksSubIdRotateSecretPostResponse) StatusCode() int {
 	return 0
 }
 
+type GetWhoamiWhoamiGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *WhoamiResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetWhoamiWhoamiGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetWhoamiWhoamiGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 // ListCallsCallsGetWithResponse request returning *ListCallsCallsGetResponse
 func (c *ClientWithResponses) ListCallsCallsGetWithResponse(ctx context.Context, params *ListCallsCallsGetParams, reqEditors ...RequestEditorFn) (*ListCallsCallsGetResponse, error) {
 	rsp, err := c.ListCallsCallsGet(ctx, params, reqEditors...)
@@ -8229,6 +8450,15 @@ func (c *ClientWithResponses) AcquireNumberNumbersPostWithResponse(ctx context.C
 	return ParseAcquireNumberNumbersPostResponse(rsp)
 }
 
+// ReleaseNumberNumbersNumberIdDeleteWithResponse request returning *ReleaseNumberNumbersNumberIdDeleteResponse
+func (c *ClientWithResponses) ReleaseNumberNumbersNumberIdDeleteWithResponse(ctx context.Context, numberId openapi_types.UUID, params *ReleaseNumberNumbersNumberIdDeleteParams, reqEditors ...RequestEditorFn) (*ReleaseNumberNumbersNumberIdDeleteResponse, error) {
+	rsp, err := c.ReleaseNumberNumbersNumberIdDelete(ctx, numberId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseReleaseNumberNumbersNumberIdDeleteResponse(rsp)
+}
+
 // GetNumberNumbersNumberIdGetWithResponse request returning *GetNumberNumbersNumberIdGetResponse
 func (c *ClientWithResponses) GetNumberNumbersNumberIdGetWithResponse(ctx context.Context, numberId openapi_types.UUID, params *GetNumberNumbersNumberIdGetParams, reqEditors ...RequestEditorFn) (*GetNumberNumbersNumberIdGetResponse, error) {
 	rsp, err := c.GetNumberNumbersNumberIdGet(ctx, numberId, params, reqEditors...)
@@ -8490,6 +8720,15 @@ func (c *ClientWithResponses) RotateSecretWebhooksSubIdRotateSecretPostWithRespo
 		return nil, err
 	}
 	return ParseRotateSecretWebhooksSubIdRotateSecretPostResponse(rsp)
+}
+
+// GetWhoamiWhoamiGetWithResponse request returning *GetWhoamiWhoamiGetResponse
+func (c *ClientWithResponses) GetWhoamiWhoamiGetWithResponse(ctx context.Context, params *GetWhoamiWhoamiGetParams, reqEditors ...RequestEditorFn) (*GetWhoamiWhoamiGetResponse, error) {
+	rsp, err := c.GetWhoamiWhoamiGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetWhoamiWhoamiGetResponse(rsp)
 }
 
 // ParseListCallsCallsGetResponse parses an HTTP response from a ListCallsCallsGetWithResponse call
@@ -9388,6 +9627,32 @@ func ParseAcquireNumberNumbersPostResponse(rsp *http.Response) (*AcquireNumberNu
 	return response, nil
 }
 
+// ParseReleaseNumberNumbersNumberIdDeleteResponse parses an HTTP response from a ReleaseNumberNumbersNumberIdDeleteWithResponse call
+func ParseReleaseNumberNumbersNumberIdDeleteResponse(rsp *http.Response) (*ReleaseNumberNumbersNumberIdDeleteResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ReleaseNumberNumbersNumberIdDeleteResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetNumberNumbersNumberIdGetResponse parses an HTTP response from a GetNumberNumbersNumberIdGetWithResponse call
 func ParseGetNumberNumbersNumberIdGetResponse(rsp *http.Response) (*GetNumberNumbersNumberIdGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -10102,6 +10367,39 @@ func ParseRotateSecretWebhooksSubIdRotateSecretPostResponse(rsp *http.Response) 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest WebhookSubscriptionResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetWhoamiWhoamiGetResponse parses an HTTP response from a GetWhoamiWhoamiGetWithResponse call
+func ParseGetWhoamiWhoamiGetResponse(rsp *http.Response) (*GetWhoamiWhoamiGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetWhoamiWhoamiGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest WhoamiResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/cli/internal/cmd/email.go
+++ b/cli/internal/cmd/email.go
@@ -83,9 +83,11 @@ and --body-html-file read content from disk. --attach uploads a local
 file and attaches it (repeatable); --attach-id attaches a file already
 uploaded via ` + "`hail email attachment-upload`" + ` (repeatable).
 
-If --from is omitted, the API picks the first verified sender domain
-on your organization, or auto-mints a hail-mail address if one is
-configured. See docs/public/self-host/aws-ses.md.
+--from is optional only while your org has one verified sender. With
+several, omitting it fails with a 422 listing them — run
+` + "`hail email domain list`" + ` and pass one. With none, the API
+auto-mints a hail-mail address if the operator configured one.
+See docs/public/self-host/aws-ses.md.
 
 Example (minimal):
   hail email send --to alice@example.com --subject "Hi" --body "Hello" --recipient-consent`,

--- a/cli/internal/cmd/email_domain.go
+++ b/cli/internal/cmd/email_domain.go
@@ -345,20 +345,32 @@ func printEmailDomainList(opts *Options, body *client.EmailDomainListResponse) e
 	}
 	if len(body.Items) == 0 {
 		fmt.Fprintln(opts.Stdout, "(no email domains)")
-		return nil
+	} else {
+		w := tabwriter.NewWriter(opts.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "ID\tKIND\tDOMAIN\tSTATUS")
+		for _, sd := range body.Items {
+			fmt.Fprintf(
+				w, "%s\t%s\t%s\t%s\n",
+				sd.Id.String(),
+				string(sd.Kind),
+				sd.Domain,
+				string(sd.VerificationStatus),
+			)
+		}
+		_ = w.Flush()
 	}
-	w := tabwriter.NewWriter(opts.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "ID\tKIND\tDOMAIN\tSTATUS")
-	for _, sd := range body.Items {
-		fmt.Fprintf(
-			w, "%s\t%s\t%s\t%s\n",
-			sd.Id.String(),
-			string(sd.Kind),
-			sd.Domain,
-			string(sd.VerificationStatus),
-		)
+	// Printed even on an empty page: with no domains at all it reveals the
+	// hail-mail address a first send would mint, which exists nowhere else
+	// until that send happens.
+	if body.DefaultFrom != nil && *body.DefaultFrom != "" {
+		fmt.Fprintf(opts.Stdout, "\nSends with no --from go out as: %s\n", *body.DefaultFrom)
+	} else if len(body.Items) > 0 {
+		// Covers both "several verified identities, pick one" and "nothing
+		// verified yet, so no --from is valid either" — the API returns a
+		// null default_from for each, and only the first is fixable by
+		// passing --from.
+		fmt.Fprintln(opts.Stdout, "\nNo default sender — a send without --from is rejected.")
 	}
-	_ = w.Flush()
 	if body.NextCursor != nil && *body.NextCursor != "" {
 		fmt.Fprintf(opts.Stdout, "\nMore: --cursor %s\n", *body.NextCursor)
 	}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -354,6 +354,7 @@ or pass --api-key.`,
 	root.AddCommand(newTailCmd(opts))
 	root.AddCommand(newLoginCmd(opts))
 	root.AddCommand(newAuthCmd(opts))
+	root.AddCommand(newWhoamiCmd(opts))
 	root.AddCommand(newMcpCmd(opts))
 	root.AddCommand(newVersionCmd(opts))
 	root.AddCommand(newCompletionCmd(opts))

--- a/cli/internal/cmd/whoami.go
+++ b/cli/internal/cmd/whoami.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/hail-hq/hail/cli/internal/client"
+)
+
+// newWhoamiCmd builds `hail whoami`.
+//
+// `hail auth token` answers "which key am I using"; this answers "who does
+// that key belong to" — the org it bills to and the human it was issued
+// for. Scripts use the email to address mail as that person, e.g. as the
+// Reply-To on an agent send.
+func newWhoamiCmd(opts *Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "whoami",
+		Short: "Show the org and user behind the current API key",
+		Long: `hail whoami — identify the caller behind the resolved API key.
+
+Prints the organization id, the user the key belongs to, and how the
+request authenticated. A shared operator key (HAIL_API_KEY on a
+self-hosted server) carries no user, so those fields come back empty.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runWhoami(cmd.Context(), opts)
+		},
+	}
+}
+
+func runWhoami(ctx context.Context, opts *Options) error {
+	apiClient, err := opts.newClient()
+	if err != nil {
+		return err
+	}
+	resp, err := apiClient.GetWhoamiWhoamiGetWithResponse(
+		ctx, &client.GetWhoamiWhoamiGetParams{},
+	)
+	if err != nil {
+		return fmt.Errorf("whoami API: %w", err)
+	}
+	if resp.HTTPResponse.StatusCode != http.StatusOK || resp.JSON200 == nil {
+		return apiError(resp.HTTPResponse.StatusCode, resp.Body)
+	}
+	return printWhoami(opts, resp.JSON200)
+}
+
+func printWhoami(opts *Options, body *client.WhoamiResponse) error {
+	if opts.JSON {
+		return printJSON(opts.Stdout, body)
+	}
+	switch {
+	case body.Email != nil && *body.Email != "":
+		fmt.Fprintf(opts.Stdout, "%s\n", *body.Email)
+	case body.AuthKind == client.Shared:
+		fmt.Fprintln(opts.Stdout, "(no user — shared operator key)")
+	default:
+		// An api-key/JWT principal whose users row is gone: the key still
+		// identifies an org and a user id, just no mailbox. Saying "shared
+		// operator key" here would name the wrong auth path.
+		fmt.Fprintln(opts.Stdout, "(no user email on record)")
+	}
+	if body.Name != nil && *body.Name != "" {
+		fmt.Fprintf(opts.Stdout, "  Name:         %s\n", *body.Name)
+	}
+	if body.UserId != nil {
+		fmt.Fprintf(opts.Stdout, "  User:         %s\n", body.UserId.String())
+	}
+	fmt.Fprintf(opts.Stdout, "  Organization: %s\n", body.OrganizationId.String())
+	fmt.Fprintf(opts.Stdout, "  Auth:         %s\n", string(body.AuthKind))
+	return nil
+}

--- a/cli/internal/cmd/whoami_test.go
+++ b/cli/internal/cmd/whoami_test.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestWhoami_PrintsEmailOrgAndAuthKind(t *testing.T) {
+	srv := newFakeServer(t, http.StatusOK, map[string]any{
+		"auth_kind":       "apikey",
+		"organization_id": "22222222-2222-2222-2222-222222222222",
+		"user_id":         "11111111-1111-1111-1111-111111111111",
+		"email":           "sarah@acme.test",
+		"name":            "Sarah Chen",
+	})
+
+	stdout, _, err := runRoot(t,
+		map[string]string{"HAIL_API_KEY": "sk_test", "HAIL_API_URL": srv.URL},
+		"whoami",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(&srv.hits); got != 1 {
+		t.Fatalf("expected 1 request, got %d", got)
+	}
+	if srv.lastReq.Method != http.MethodGet || srv.lastReq.URL.Path != "/whoami" {
+		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
+	}
+	for _, want := range []string{
+		"sarah@acme.test",
+		"Sarah Chen",
+		"22222222-2222-2222-2222-222222222222",
+		"apikey",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestWhoami_SharedKeySaysNoUser(t *testing.T) {
+	srv := newFakeServer(t, http.StatusOK, map[string]any{
+		"auth_kind":       "shared",
+		"organization_id": "22222222-2222-2222-2222-222222222222",
+		"user_id":         nil,
+		"email":           nil,
+		"name":            nil,
+	})
+
+	stdout, _, err := runRoot(t,
+		map[string]string{"HAIL_API_KEY": "sk_test", "HAIL_API_URL": srv.URL},
+		"whoami",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout, "shared operator key") {
+		t.Fatalf("expected the no-user hint, got:\n%s", stdout)
+	}
+}
+
+func TestWhoami_JSONPassesThrough(t *testing.T) {
+	srv := newFakeServer(t, http.StatusOK, map[string]any{
+		"auth_kind":       "jwt",
+		"organization_id": "22222222-2222-2222-2222-222222222222",
+		"user_id":         "11111111-1111-1111-1111-111111111111",
+		"email":           "sarah@acme.test",
+		"name":            "Sarah Chen",
+	})
+
+	stdout, _, err := runRoot(t,
+		map[string]string{"HAIL_API_KEY": "sk_test", "HAIL_API_URL": srv.URL},
+		"whoami", "--json",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal([]byte(stdout), &body); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout)
+	}
+	if body["email"] != "sarah@acme.test" {
+		t.Fatalf("email = %v", body["email"])
+	}
+}
+
+// The default sender is printed even when the org owns no domains: that is
+// the only place the hail-mail address a first send would mint shows up.
+func TestEmailDomainList_PrintsDefaultFromOnEmptyList(t *testing.T) {
+	srv := newFakeServer(t, http.StatusOK, map[string]any{
+		"items":        []any{},
+		"next_cursor":  nil,
+		"default_from": "admin+acme@mail.hail.so",
+	})
+
+	stdout, _, err := runRoot(t,
+		map[string]string{"HAIL_API_KEY": "sk_test", "HAIL_API_URL": srv.URL},
+		"email", "domain", "list",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout, "admin+acme@mail.hail.so") {
+		t.Fatalf("stdout missing the minted address:\n%s", stdout)
+	}
+}
+
+func TestEmailDomainList_NullDefaultFromTellsCallerToPassFrom(t *testing.T) {
+	srv := newFakeServer(t, http.StatusOK, map[string]any{
+		"items": []any{
+			map[string]any{
+				"id":                  "33333333-3333-3333-3333-333333333333",
+				"organization_id":     "22222222-2222-2222-2222-222222222222",
+				"kind":                "custom",
+				"domain":              "acme.com",
+				"local_prefix_user":   nil,
+				"local_prefix_org":    nil,
+				"verification_status": "verified",
+				"dns_records":         []any{},
+				"mail_from_domain":    nil,
+				"provider":            "ses",
+				"verified_at":         nil,
+				"created_at":          "2026-01-01T00:00:00Z",
+				"updated_at":          "2026-01-01T00:00:00Z",
+			},
+		},
+		"next_cursor":  nil,
+		"default_from": nil,
+	})
+
+	stdout, _, err := runRoot(t,
+		map[string]string{"HAIL_API_KEY": "sk_test", "HAIL_API_URL": srv.URL},
+		"email", "domain", "list",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout, "a send without --from is rejected") {
+		t.Fatalf("expected the explicit-from hint, got:\n%s", stdout)
+	}
+}

--- a/core/hailhq/core/email_sender.py
+++ b/core/hailhq/core/email_sender.py
@@ -1,0 +1,40 @@
+"""How an ``email_domains`` row turns into a From-address.
+
+One formatter, three callers — ``POST /emails``, the voicebot's internal
+send route, and ``GET /email-domains`` (which previews the same decision
+as ``default_from``) — so the address a caller is shown cannot drift
+from the address a send actually goes out as.
+
+Row selection itself (which identity, and what happens when there is
+none) stays in ``api/hailhq/api/routes/email_domains.py``: it needs the
+session and the operator's hail-mail config.
+"""
+
+from __future__ import annotations
+
+from hailhq.core.models import EmailDomain
+
+# Local-part used when the caller names no address and the identity is a
+# custom domain (a hail-mail row already carries a full address).
+DEFAULT_LOCAL_PART = "noreply"
+
+
+def from_address_for(sd: EmailDomain, explicit: str | None = None) -> str:
+    """Resolve the wire ``From:`` for a send.
+
+    Hail-mail: ``sd.domain`` is the full address.
+    Custom:    ``sd.domain`` is just the DNS name; if the caller didn't
+               supply an explicit local-part, default to ``noreply``.
+
+    The no-``explicit`` result doubles as the ``from`` value a caller can
+    paste back: custom rows accept any local-part, so ``noreply@`` is a
+    working example rather than the only choice.
+    """
+    if explicit is not None:
+        return explicit
+    if sd.kind == "hail_mail":
+        return sd.domain
+    return f"{DEFAULT_LOCAL_PART}@{sd.domain}"
+
+
+__all__ = ["DEFAULT_LOCAL_PART", "from_address_for"]

--- a/core/hailhq/core/schemas.py
+++ b/core/hailhq/core/schemas.py
@@ -638,6 +638,10 @@ class EmailDomainResponse(BaseModel):
 class EmailDomainListResponse(BaseModel):
     items: list[EmailDomainResponse]
     next_cursor: str | None = None
+    # The address a send with no ``from`` goes out as. ``None`` when such a
+    # send would be rejected: several verified identities (name one), or
+    # none that can send yet. Computed across the whole org, not the page.
+    default_from: str | None = None
 
 
 class EmailCreate(ConsentAttestationMixin):
@@ -1079,6 +1083,22 @@ class MemberPhonePut(BaseModel):
     phone_e164: str
 
     _validate_phone = field_validator("phone_e164")(_e164_or_error)
+
+
+class WhoamiResponse(BaseModel):
+    """Who the caller is — the answer ``GET /whoami`` gives.
+
+    ``user_id``/``email``/``name`` are ``None`` for shared-key
+    (``HAIL_API_KEY``) callers: that key carries no human identity. An
+    agent that wants to put the operator's address in ``Reply-To`` reads
+    ``email`` and skips the header when it is ``None``.
+    """
+
+    auth_kind: Literal["apikey", "jwt", "shared"]
+    organization_id: UUID
+    user_id: UUID | None = None
+    email: str | None = None
+    name: str | None = None
 
 
 # --------------------------------------------------------------------------- #

--- a/docs/public/architecture.md
+++ b/docs/public/architecture.md
@@ -96,10 +96,12 @@ Hail validates both prefixes against `^[a-z0-9]([a-z0-9-]{0,18}[a-z0-9])?$` (1â€
 `POST /emails` picks a sender in this order:
 
 1. An explicit `from` â€” it must match a `verified` row that the caller's org owns.
-2. The first verified org-owned domain (ordered by `created_at`, so a tenant's "default sender" stays stable).
+2. The org's single verified domain. With two or more, there is no default: the request returns `422` listing them, and the caller must pass `from`.
 3. An auto-minted hail-mail row with the configured prefixes, if `HAIL_MAIL_BASE_DOMAIN` is set.
 
 If none of those resolve, the request returns `503` with instructions on how to register a domain.
+
+`GET /email-domains` answers the same question ahead of a send: its `default_from` field holds the address a `from`-less send would use, and is `null` when the caller must choose.
 
 Refer to [`docs/setup/aws-ses.md`](./self-host/aws-ses.md) for the operator-side setup. Refer to [`docs/superpowers/plans/2026-05-17-hail-mail-addressing.md`](https://github.com/hail-hq/hail/blob/main/docs/superpowers/plans/2026-05-17-hail-mail-addressing.md) for the addressing/configurability plan.
 

--- a/docs/public/cli.md
+++ b/docs/public/cli.md
@@ -96,7 +96,22 @@ hail email domain delete <id>   # also drops the SES identity for custom rows
 
 `register` flags: `--kind` (`hail_mail|custom`, required), `--domain` (required for `custom`), `--local-prefix-user`, `--local-prefix-org` (for `hail_mail`), `--idempotency-key`. `list` takes `--limit` / `--cursor`. Aliases: `list`→`ls`, `delete`→`rm`.
 
+`hail email domain list` closes with the address a send without `--from` goes out as. Own two or more verified identities and there is no default: the line reads `No default sender — a send without --from is rejected.`, and a `--from`-less `hail email send` fails with a 422 listing them.
+
 > Renamed: `hail sender-domain ...` is now `hail email domain ...`. The old name no longer exists.
+
+## Whoami
+
+```bash
+hail whoami          # human-readable
+hail whoami --json   # for scripts
+```
+
+Prints the organization and the user the API key belongs to, plus how the
+request authenticated (`apikey`, `jwt`, or `shared`). A shared operator key
+carries no user, so the email and name come back empty. Use the email as
+`hail email send --reply-to` so replies reach the person rather than the
+sending domain.
 
 ## Contacts
 

--- a/docs/public/mcp.md
+++ b/docs/public/mcp.md
@@ -15,7 +15,7 @@ The Streamable HTTP transport serves the MCP root path. There is no `/mcp` suffi
 
 ## Tools
 
-The server exposes 18 tools. Schemas (args, validation, return shapes) are the source of truth — refer to [`mcp/hailhq/mcp/tools.py`](https://github.com/hail-hq/hail/blob/main/mcp/hailhq/mcp/tools.py).
+The server exposes 20 tools. Schemas (args, validation, return shapes) are the source of truth — refer to [`mcp/hailhq/mcp/tools.py`](https://github.com/hail-hq/hail/blob/main/mcp/hailhq/mcp/tools.py).
 
 | Tool                      | Does                                                    |
 | ------------------------- | ------------------------------------------------------- |
@@ -34,6 +34,8 @@ The server exposes 18 tools. Schemas (args, validation, return shapes) are the s
 | `get_email_events`        | Page through one email's event history.                 |
 | `get_email_stats`         | Aggregate email counts for a time window.               |
 | `get_events`              | Page through the event stream.                          |
+| `list_email_domains`      | List sending identities + the default `from` address.   |
+| `whoami`                  | Identify the human behind the session (for `reply_to`). |
 | `list_contacts`           | List the org's contacts (members + manual contacts).    |
 | `lookup_contact`          | Find one contact by name, email, or phone fragment.     |
 | `create_contact`          | Add a manual contact.                                   |

--- a/docs/public/self-host/aws-ses.md
+++ b/docs/public/self-host/aws-ses.md
@@ -161,10 +161,12 @@ curl -X POST $HAIL_API_URL/emails \
 The `from` field is optional. Resolution order:
 
 1. Explicit `from` — must match a `verified` email_domain row owned by the caller's org.
-2. The first verified org-owned domain (ordered by `created_at`, so the default sender stays stable when you add more domains).
+2. The org's single verified domain. Own two or more and there is no default — the call returns `422` listing them, so `from` must be explicit.
 3. The auto-minted hail-mail row, if `HAIL_MAIL_BASE_DOMAIN` and the prefixes are configured.
 
 If none of these resolve, the call returns `503` with instructions to register a domain.
+
+To see which address a `from`-less send would use, read `default_from` on `GET /email-domains` (`hail email domain list`). It is `null` when the org owns several verified identities.
 
 The optional `from_name` field sets a display name on the `From:` header (`"Acme Billing" <billing@acme.com>`). Non-ASCII names are RFC-2047-encoded automatically; control characters are rejected with `422`.
 

--- a/mcp/hailhq/mcp/hail_client.py
+++ b/mcp/hailhq/mcp/hail_client.py
@@ -34,6 +34,7 @@ from hailhq.core.schemas import (
     ContactEntry,
     ContactListResponse,
     EmailCreate,
+    EmailDomainListResponse,
     EmailEventListResponse,
     EmailListResponse,
     EmailResponse,
@@ -42,6 +43,7 @@ from hailhq.core.schemas import (
     SmsCreate,
     SmsListResponse,
     SmsResponse,
+    WhoamiResponse,
 )
 from typing_extensions import Self
 
@@ -511,6 +513,33 @@ class HailClient:
         return EmailStatsResponse.model_validate(_decode(resp)).model_dump(
             mode="json", by_alias=True
         )
+
+    # ------------------------------------------------------------------ #
+    # GET /email-domains
+    # ------------------------------------------------------------------ #
+
+    async def list_email_domains(
+        self, *, cursor: str | None = None, limit: int | None = None
+    ) -> dict[str, Any]:
+        """GET /email-domains — the identities this org can send from."""
+        params: dict[str, Any] = {}
+        if cursor is not None:
+            params["cursor"] = cursor
+        if limit is not None:
+            params["limit"] = limit
+        resp = await self._client.get("/email-domains", params=params)
+        return EmailDomainListResponse.model_validate(_decode(resp)).model_dump(
+            mode="json"
+        )
+
+    # ------------------------------------------------------------------ #
+    # GET /whoami
+    # ------------------------------------------------------------------ #
+
+    async def whoami(self) -> dict[str, Any]:
+        """GET /whoami — the caller's identity behind this bearer token."""
+        resp = await self._client.get("/whoami")
+        return WhoamiResponse.model_validate(_decode(resp)).model_dump(mode="json")
 
 
 def _decode(resp: httpx.Response) -> Any:

--- a/mcp/hailhq/mcp/tools.py
+++ b/mcp/hailhq/mcp/tools.py
@@ -1,6 +1,6 @@
 """MCP tool surface for Hail's outbound-call API.
 
-Exposes eighteen tools to the calling agent:
+Exposes the following tools to the calling agent:
 
 * ``place_call`` — originate an outbound phone call
 * ``get_call`` — fetch the current state of one call
@@ -14,6 +14,10 @@ Exposes eighteen tools to the calling agent:
 * ``get_email_attachment`` — presigned URL for one inbound attachment
 * ``get_email_events`` — delivery/engagement timeline for one email
 * ``get_email_stats`` — account-level deliverability stats (counts, rates, series)
+* ``list_email_domains`` — the identities this org can send from, plus the
+  address a ``from_``-less send goes out as
+* ``whoami`` — the org/user behind the session (its ``email`` is what an
+  agent passes as ``reply_to``)
 * ``send_sms`` — send an outbound SMS
 * ``get_sms`` — fetch the current state of one SMS
 * ``list_sms`` — page through recent SMS messages
@@ -34,7 +38,7 @@ mapped to an ``{"error": ...}`` dict. Only the ``<type>:<uuid>``
 resource-id shape for ``get_events`` is still checked locally via
 ``parse_resource_id``.
 
-The fifteen tool functions are kept module-importable so unit tests can
+The tool functions are kept module-importable so unit tests can
 call them directly with a constructed ``HailClient``; ``register_tools``
 is the FastMCP wiring step. Each registered tool closure accepts a
 FastMCP ``Context`` (auto-injected on dispatch) and uses the
@@ -380,6 +384,29 @@ async def get_email_stats(
         return _format_api_error(exc)
 
 
+async def list_email_domains(
+    *,
+    client: HailClient,
+    cursor: str | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    try:
+        return await client.list_email_domains(cursor=cursor, limit=limit)
+    except ValidationError as exc:
+        return {"error": _validation_error_message(exc)}
+    except HailAPIError as exc:
+        return _format_api_error(exc)
+
+
+async def whoami(*, client: HailClient) -> dict[str, Any]:
+    try:
+        return await client.whoami()
+    except ValidationError as exc:
+        return {"error": _validation_error_message(exc)}
+    except HailAPIError as exc:
+        return _format_api_error(exc)
+
+
 async def get_events(
     *,
     client: HailClient,
@@ -651,7 +678,9 @@ def register_tools(
         least one of ``body_text`` / ``body_html`` is required (both
         is fine — multipart-alternative). ``cc``, ``bcc``, and
         ``reply_to`` are optional and follow the usual mail
-        conventions.
+        conventions. Hail sets no ``reply_to`` of its own — to have
+        replies reach the human running this session, call ``whoami``
+        and pass their ``email``.
 
         ``recipient_consent`` is required: attest that you (the caller
         triggering this request) have obtained the lawful consent needed
@@ -662,16 +691,17 @@ def register_tools(
         how/where consent was obtained) — leave as the default
         ``"informational"`` for transactional/service email.
 
-        ``from_`` is optional. When omitted, Hail picks the first
-        verified sender domain on your organization, or — if the
-        operator configured ``HAIL_MAIL_BASE_DOMAIN`` — auto-mints a
-        per-org hail-mail address of the form ``<user>+<org>@<base>``
-        (the ``<org>`` part is derived from your organization id; the
-        ``<user>`` part comes from ``HAIL_MAIL_FROM`` /
-        ``HAIL_MAIL_DEFAULT_USER_PREFIX``, or an explicit row created
-        via ``POST /email-domains``). When supplied, it must
-        match a verified row already in ``email_domains`` (register
-        one with the website console or ``POST /email-domains``).
+        ``from_`` is optional only while the workspace has one verified
+        sender identity. With several, omitting it returns 422 listing
+        them — call ``list_email_domains`` and pass one. With none, the
+        server auto-mints a per-org hail-mail address of the form
+        ``<user>+<org>@<base>`` if the operator configured
+        ``HAIL_MAIL_BASE_DOMAIN`` (the ``<org>`` part is derived from your
+        organization id; the ``<user>`` part comes from ``HAIL_MAIL_FROM``
+        / ``HAIL_MAIL_DEFAULT_USER_PREFIX``, or an explicit row created
+        via ``POST /email-domains``). When supplied, ``from_`` must match
+        a verified row already in ``email_domains`` (register one with
+        the website console or ``POST /email-domains``).
 
         ``from_name`` is an optional display name rendered on the
         From: header ("Acme Billing <billing@acme.com>"). Control
@@ -1121,6 +1151,61 @@ def register_tools(
         except RuntimeError as exc:
             return {"error": str(exc)}
 
+    @mcp_app.tool(name="list_email_domains")
+    async def list_email_domains_tool(
+        ctx: Context,
+        cursor: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """List the addresses this workspace can send email from. Call this
+        BEFORE ``send_email`` when you do not already know the ``from_``
+        address — do not guess a domain.
+
+        Returns ``{"items": [...], "next_cursor": ..., "default_from": ...}``.
+        Each item carries ``domain``, ``kind`` (``"custom"`` or
+        ``"hail_mail"``) and ``verification_status``; only ``"verified"``
+        rows can send. A ``custom`` item's ``domain`` is a bare DNS name
+        that accepts any local-part (``sales@acme.com``); a ``hail_mail``
+        item's ``domain`` is already a full address.
+
+        ``default_from`` is the address a ``send_email`` with no ``from_``
+        goes out as. It is null when the workspace has several verified
+        identities — then ``send_email`` rejects a missing ``from_`` and you
+        must pass one from ``items``.
+
+        Example:
+            list_email_domains()
+        """
+        try:
+            async with _client_for(ctx, mode=mode, singleton=singleton) as client:
+                return await list_email_domains(
+                    client=client, cursor=cursor, limit=limit
+                )
+        except RuntimeError as exc:
+            return {"error": str(exc)}
+
+    @mcp_app.tool(name="whoami")
+    async def whoami_tool(ctx: Context) -> dict[str, Any]:
+        """Identify the human whose credentials this session runs under.
+
+        Use it to sign or route mail as that person: pass their address as
+        ``send_email(reply_to=...)`` so replies reach them rather than the
+        sending domain, which is often an unattended ``noreply@``.
+
+        Returns ``{"auth_kind", "organization_id", "user_id", "email",
+        "name"}``. ``user_id``/``email``/``name`` are null when the server
+        runs on a shared operator key (``auth_kind="shared"``) — there is no
+        human behind it, so send without a ``reply_to``.
+
+        Example:
+            whoami()
+        """
+        try:
+            async with _client_for(ctx, mode=mode, singleton=singleton) as client:
+                return await whoami(client=client)
+        except RuntimeError as exc:
+            return {"error": str(exc)}
+
     @mcp_app.tool(name="create_contact")
     async def create_contact_tool(
         ctx: Context,
@@ -1160,6 +1245,7 @@ __all__ = [
     "get_sms",
     "list_calls",
     "list_contacts",
+    "list_email_domains",
     "list_emails",
     "list_sms",
     "lookup_contact",
@@ -1167,4 +1253,5 @@ __all__ = [
     "register_tools",
     "send_email",
     "send_sms",
+    "whoami",
 ]

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -1400,3 +1400,132 @@ async def test_api_error_mapping_409_idempotency(client: HailClient) -> None:
     )
     assert "error" in result
     assert "Idempotency-Key" in result["error"]
+
+
+# --------------------------------------------------------------------------- #
+# list_email_domains / whoami — the two discovery tools an agent calls
+# before it can address mail as a person.
+# --------------------------------------------------------------------------- #
+
+
+def _email_domain(domain: str = "acme.com", kind: str = "custom") -> dict:
+    return {
+        "id": str(uuid4()),
+        "organization_id": str(uuid4()),
+        "kind": kind,
+        "domain": domain,
+        "local_prefix_user": None,
+        "local_prefix_org": None,
+        "verification_status": "verified",
+        "dns_records": [],
+        "mail_from_domain": None,
+        "mail_from_status": None,
+        "provider": "ses",
+        "verified_at": "2026-01-01T00:00:00Z",
+        "inbound_enabled": False,
+        "forward_to": None,
+        "forward_rate_per_hour": None,
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+    }
+
+
+@respx.mock
+async def test_list_email_domains_surfaces_default_from(client: HailClient) -> None:
+    captured: dict = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200,
+            json={
+                "items": [_email_domain()],
+                "next_cursor": None,
+                "default_from": "noreply@acme.com",
+            },
+        )
+
+    respx.get(f"{_BASE_URL}/email-domains").mock(side_effect=_handler)
+
+    result = await tools.list_email_domains(client=client)
+    assert "error" not in result, result
+    assert result["items"][0]["domain"] == "acme.com"
+    assert result["default_from"] == "noreply@acme.com"
+    assert captured["url"] == f"{_BASE_URL}/email-domains"
+
+
+@respx.mock
+async def test_list_email_domains_null_default_from_on_ambiguity(
+    client: HailClient,
+) -> None:
+    """Null is the signal that send_email needs an explicit from_."""
+    respx.get(f"{_BASE_URL}/email-domains").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "items": [_email_domain(), _email_domain("mail.acme.io")],
+                "next_cursor": None,
+                "default_from": None,
+            },
+        )
+    )
+
+    result = await tools.list_email_domains(client=client)
+    assert "error" not in result, result
+    assert result["default_from"] is None
+
+
+@respx.mock
+async def test_whoami_returns_the_caller_email(client: HailClient) -> None:
+    captured: dict = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200,
+            json={
+                "auth_kind": "apikey",
+                "organization_id": str(uuid4()),
+                "user_id": str(uuid4()),
+                "email": "sarah@acme.test",
+                "name": "Sarah Chen",
+            },
+        )
+
+    respx.get(f"{_BASE_URL}/whoami").mock(side_effect=_handler)
+
+    result = await tools.whoami(client=client)
+    assert "error" not in result, result
+    assert result["email"] == "sarah@acme.test"
+    assert captured["url"] == f"{_BASE_URL}/whoami"
+
+
+@respx.mock
+async def test_whoami_has_no_human_on_a_shared_key(client: HailClient) -> None:
+    respx.get(f"{_BASE_URL}/whoami").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "auth_kind": "shared",
+                "organization_id": str(uuid4()),
+                "user_id": None,
+                "email": None,
+                "name": None,
+            },
+        )
+    )
+
+    result = await tools.whoami(client=client)
+    assert "error" not in result, result
+    assert result["email"] is None
+    assert result["auth_kind"] == "shared"
+
+
+@respx.mock
+async def test_whoami_maps_api_errors(client: HailClient) -> None:
+    respx.get(f"{_BASE_URL}/whoami").mock(
+        return_value=httpx.Response(401, json={"detail": "invalid api key"})
+    )
+
+    result = await tools.whoami(client=client)
+    assert "auth failed" in result["error"]

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,52 +1,54 @@
 openapi: 3.1.0
 info:
   title: Hail
-  description: "Universal communication platform for AI agents.\n\nThis file is the\
+  description:
+    "Universal communication platform for AI agents.\n\nThis file is the\
     \ source of truth for the Go CLI. Regenerate it after\nchanging API routes \u2014\
     \ see docs/public/contributing.md.\n"
   version: 0.1.0
 servers:
-- url: https://api.hail.so
-  description: Hail Cloud
+  - url: https://api.hail.so
+    description: Hail Cloud
 paths:
   /calls:
     post:
       tags:
-      - calls
+        - calls
       summary: Create Call
       operationId: create_call_calls_post
       parameters:
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
-      - name: Idempotency-Key
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Idempotency-Key
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Idempotency-Key
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CallCreate'
+              $ref: "#/components/schemas/CallCreate"
       responses:
-        '201':
+        "201":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CallResponse'
-        '429':
-          description: Rate limited. The agent-origin workspace exceeded a per-channel
+                $ref: "#/components/schemas/CallResponse"
+        "429":
+          description:
+            Rate limited. The agent-origin workspace exceeded a per-channel
             velocity cap, or the platform kill switch is on. Retry after the Retry-After
             header (seconds).
           headers:
@@ -54,189 +56,190 @@ paths:
               description: Seconds to wait before retrying.
               schema:
                 type: integer
-        '422':
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
     get:
       tags:
-      - calls
+        - calls
       summary: List Calls
       operationId: list_calls_calls_get
       parameters:
-      - name: cursor
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Cursor
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 200
-          minimum: 1
-          default: 50
-          title: Limit
-      - name: status
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - enum:
-            - queued
-            - dialing
-            - ringing
-            - in_progress
-            - completed
-            - failed
-            - busy
-            - no_answer
-            - canceled
-            type: string
-          - type: 'null'
-          title: Status
-      - name: to
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: To
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Cursor
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 200
+            minimum: 1
+            default: 50
+            title: Limit
+        - name: status
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - enum:
+                  - queued
+                  - dialing
+                  - ringing
+                  - in_progress
+                  - completed
+                  - failed
+                  - busy
+                  - no_answer
+                  - canceled
+                type: string
+              - type: "null"
+            title: Status
+        - name: to
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: To
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CallListResponse'
-        '422':
+                $ref: "#/components/schemas/CallListResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /calls/{call_id}:
     get:
       tags:
-      - calls
+        - calls
       summary: Get Call
       operationId: get_call_calls__call_id__get
       parameters:
-      - name: call_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Call Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: call_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Call Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CallResponse'
-        '422':
+                $ref: "#/components/schemas/CallResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /email-attachments:
     post:
       tags:
-      - email-attachments
+        - email-attachments
       summary: Create Email Attachment
       operationId: upload_email_attachment
       parameters:
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       requestBody:
         required: true
         content:
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/Body_upload_email_attachment'
+              $ref: "#/components/schemas/Body_upload_email_attachment"
       responses:
-        '201':
+        "201":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmailAttachmentUploadResponse'
-        '422':
+                $ref: "#/components/schemas/EmailAttachmentUploadResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /emails:
     post:
       tags:
-      - emails
+        - emails
       summary: Create Email
       operationId: create_email_emails_post
       parameters:
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
-      - name: Idempotency-Key
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Idempotency-Key
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Idempotency-Key
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EmailCreate'
+              $ref: "#/components/schemas/EmailCreate"
       responses:
-        '201':
+        "201":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmailResponse'
-        '429':
-          description: Rate limited. The agent-origin workspace exceeded a per-channel
+                $ref: "#/components/schemas/EmailResponse"
+        "429":
+          description:
+            Rate limited. The agent-origin workspace exceeded a per-channel
             velocity cap, or the platform kill switch is on. Retry after the Retry-After
             header (seconds).
           headers:
@@ -244,524 +247,526 @@ paths:
               description: Seconds to wait before retrying.
               schema:
                 type: integer
-        '422':
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
     get:
       tags:
-      - emails
+        - emails
       summary: List Emails
       operationId: list_emails_emails_get
       parameters:
-      - name: cursor
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Cursor
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 200
-          minimum: 1
-          default: 50
-          title: Limit
-      - name: status
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - enum:
-            - queued
-            - sent
-            - delivered
-            - failed
-            - bounced
-            - complained
-            - received
-            type: string
-          - type: 'null'
-          title: Status
-      - name: direction
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - enum:
-            - outbound
-            - inbound
-            type: string
-          - type: 'null'
-          title: Direction
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Cursor
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 200
+            minimum: 1
+            default: 50
+            title: Limit
+        - name: status
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - enum:
+                  - queued
+                  - sent
+                  - delivered
+                  - failed
+                  - bounced
+                  - complained
+                  - received
+                type: string
+              - type: "null"
+            title: Status
+        - name: direction
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - enum:
+                  - outbound
+                  - inbound
+                type: string
+              - type: "null"
+            title: Direction
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmailListResponse'
-        '422':
+                $ref: "#/components/schemas/EmailListResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /emails/{email_id}/events:
     get:
       tags:
-      - emails
+        - emails
       summary: List Email Events
-      description: 'Chronological lifecycle events for one email (org-scoped).
+      description: "Chronological lifecycle events for one email (org-scoped).
 
 
         Cursor-paginated with the same forward-walk shape as ``GET /events``:
 
-        strictly-greater on ``(occurred_at, id)``, ascending.'
+        strictly-greater on ``(occurred_at, id)``, ascending."
       operationId: list_email_events_emails__email_id__events_get
       parameters:
-      - name: email_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Email Id
-      - name: cursor
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Cursor
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 1000
-          minimum: 1
-          default: 100
-          title: Limit
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: email_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Email Id
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Cursor
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 1000
+            minimum: 1
+            default: 100
+            title: Limit
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmailEventListResponse'
-        '422':
+                $ref: "#/components/schemas/EmailEventListResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /emails/stats:
     get:
       tags:
-      - emails
+        - emails
       summary: Get Email Stats
       operationId: get_email_stats_emails_stats_get
       parameters:
-      - name: from
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
-          title: From
-      - name: to
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
-          title: To
-      - name: bucket
-        in: query
-        required: false
-        schema:
-          enum:
-          - hour
-          - day
-          type: string
-          default: day
-          title: Bucket
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: from
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+                format: date-time
+              - type: "null"
+            title: From
+        - name: to
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+                format: date-time
+              - type: "null"
+            title: To
+        - name: bucket
+          in: query
+          required: false
+          schema:
+            enum:
+              - hour
+              - day
+            type: string
+            default: day
+            title: Bucket
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmailStatsResponse'
-        '422':
+                $ref: "#/components/schemas/EmailStatsResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /emails/{email_id}:
     get:
       tags:
-      - emails
+        - emails
       summary: Get Email
       operationId: get_email_emails__email_id__get
       parameters:
-      - name: email_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Email Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: email_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Email Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmailResponse'
-        '422':
+                $ref: "#/components/schemas/EmailResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /emails/{email_id}/raw:
     get:
       tags:
-      - emails
+        - emails
       summary: Get Email Raw
-      description: "302 \u2192 presigned S3 URL for the raw inbound MIME (404 for\
+      description:
+        "302 \u2192 presigned S3 URL for the raw inbound MIME (404 for\
         \ outbound)."
       operationId: get_email_raw_emails__email_id__raw_get
       parameters:
-      - name: email_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Email Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: email_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Email Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema: {}
-        '422':
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /emails/{email_id}/attachments/{attachment_id}:
     get:
       tags:
-      - emails
+        - emails
       summary: Get Email Attachment
       description: "302 \u2192 presigned S3 URL for one attachment."
       operationId: get_email_attachment_emails__email_id__attachments__attachment_id__get
       parameters:
-      - name: email_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Email Id
-      - name: attachment_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Attachment Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: email_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Email Id
+        - name: attachment_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Attachment Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema: {}
-        '422':
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /events:
     get:
       tags:
-      - events
+        - events
       summary: List Events
       operationId: list_events_events_get
       parameters:
-      - name: cursor
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Cursor
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 1000
-          minimum: 1
-          default: 100
-          title: Limit
-      - name: id
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Id
-      - name: kind
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Kind
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Cursor
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 1000
+            minimum: 1
+            default: 100
+            title: Limit
+        - name: id
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Id
+        - name: kind
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Kind
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventStreamResponse'
-        '422':
+                $ref: "#/components/schemas/EventStreamResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /email-domains:
     post:
       tags:
-      - email-domains
+        - email-domains
       summary: Create Email Domain
       operationId: create_email_domain_email_domains_post
       parameters:
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EmailDomainCreate'
+              $ref: "#/components/schemas/EmailDomainCreate"
       responses:
-        '201':
+        "201":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmailDomainResponse'
-        '422':
+                $ref: "#/components/schemas/EmailDomainResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
     get:
       tags:
-      - email-domains
+        - email-domains
       summary: List Email Domains
       operationId: list_email_domains_email_domains_get
       parameters:
-      - name: cursor
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Cursor
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 200
-          minimum: 1
-          default: 50
-          title: Limit
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Cursor
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 200
+            minimum: 1
+            default: 50
+            title: Limit
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmailDomainListResponse'
-        '422':
+                $ref: "#/components/schemas/EmailDomainListResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /email-domains/check-domain:
     get:
       tags:
-      - email-domains
+        - email-domains
       summary: Check Domain
       description: Does this domain already receive mail? Drives apex-vs-prefix onboarding.
       operationId: check_domain_email_domains_check_domain_get
       parameters:
-      - name: domain
-        in: query
-        required: true
-        schema:
-          type: string
-          title: Domain
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: domain
+          in: query
+          required: true
+          schema:
+            type: string
+            title: Domain
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DomainCheckResponse'
-        '422':
+                $ref: "#/components/schemas/DomainCheckResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /email-domains/{domain_id}:
     get:
       tags:
-      - email-domains
+        - email-domains
       summary: Get Email Domain
       operationId: get_email_domain_email_domains__domain_id__get
       parameters:
-      - name: domain_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Domain Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: domain_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Domain Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmailDomainResponse'
-        '422':
+                $ref: "#/components/schemas/EmailDomainResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
     patch:
       tags:
-      - email-domains
+        - email-domains
       summary: Patch Email Domain
-      description: "Edit hail-mail prefixes and/or inbound action settings.\n\nTwo\
+      description:
+        "Edit hail-mail prefixes and/or inbound action settings.\n\nTwo\
         \ modes, mutually compatible:\n\n* **Prefix edit** (``local_prefix_user``\
         \ / ``local_prefix_org``):\n  hail_mail rows only. The managed-cloud console\
         \ writes here when\n  an org admin changes the visible hail-mail address.\n\
@@ -769,677 +774,680 @@ paths:
         \ any row kind."
       operationId: patch_email_domain_email_domains__domain_id__patch
       parameters:
-      - name: domain_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Domain Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: domain_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Domain Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EmailDomainPatch'
+              $ref: "#/components/schemas/EmailDomainPatch"
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmailDomainResponse'
-        '422':
+                $ref: "#/components/schemas/EmailDomainResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
     delete:
       tags:
-      - email-domains
+        - email-domains
       summary: Delete Email Domain
       operationId: delete_email_domain_email_domains__domain_id__delete
       parameters:
-      - name: domain_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Domain Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: domain_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Domain Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '204':
+        "204":
           description: Successful Response
-        '422':
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /email-domains/{domain_id}/verify:
     post:
       tags:
-      - email-domains
+        - email-domains
       summary: Verify Email Domain
-      description: "Re-poll the email provider for the current verification status.\n\
+      description:
+        "Re-poll the email provider for the current verification status.\n\
         \nOn-demand only \u2014 there is no background poller in v1. Operators /\n\
         tenants hit this after publishing DNS to flip the row to ``verified``.\nHail-mail\
         \ rows are no-ops (they're already verified by construction)."
       operationId: verify_email_domain_email_domains__domain_id__verify_post
       parameters:
-      - name: domain_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Domain Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: domain_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Domain Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmailDomainResponse'
-        '422':
+                $ref: "#/components/schemas/EmailDomainResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /numbers:
     post:
       tags:
-      - numbers
+        - numbers
       summary: Acquire Number
       operationId: acquire_number_numbers_post
       parameters:
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
-      - name: Idempotency-Key
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Idempotency-Key
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Idempotency-Key
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NumberAcquireRequest'
+              $ref: "#/components/schemas/NumberAcquireRequest"
       responses:
-        '201':
+        "201":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PhoneNumberResponse'
-        '422':
+                $ref: "#/components/schemas/PhoneNumberResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
     get:
       tags:
-      - numbers
+        - numbers
       summary: List Numbers
       operationId: list_numbers_numbers_get
       parameters:
-      - name: cursor
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Cursor
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 200
-          minimum: 1
-          default: 50
-          title: Limit
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Cursor
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 200
+            minimum: 1
+            default: 50
+            title: Limit
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PhoneNumberListResponse'
-        '422':
+                $ref: "#/components/schemas/PhoneNumberListResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /numbers/{number_id}:
     delete:
       tags:
-      - numbers
+        - numbers
       summary: Release Number
-      description: 'Release a dedicated number. The monthly fee stops accruing after
+      description:
+        "Release a dedicated number. The monthly fee stops accruing after
         the
 
         release month; months already accrued stay owed (the rater bills late,
 
-        never forgives).'
+        never forgives)."
       operationId: release_number_numbers__number_id__delete
       parameters:
-      - name: number_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Number Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: number_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Number Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '204':
+        "204":
           description: Successful Response
-        '422':
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
     get:
       tags:
-      - numbers
+        - numbers
       summary: Get Number
       operationId: get_number_numbers__number_id__get
       parameters:
-      - name: number_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Number Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: number_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Number Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PhoneNumberResponse'
-        '422':
+                $ref: "#/components/schemas/PhoneNumberResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /numbers/{number_id}/enable-sms:
     post:
       tags:
-      - numbers
+        - numbers
       summary: Enable Sms
       operationId: enable_sms_numbers__number_id__enable_sms_post
       parameters:
-      - name: number_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Number Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: number_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Number Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PhoneNumberResponse'
-        '422':
+                $ref: "#/components/schemas/PhoneNumberResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /webhooks:
     post:
       tags:
-      - webhooks
+        - webhooks
       summary: Create Subscription
       operationId: create_subscription_webhooks_post
       parameters:
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/WebhookSubscriptionCreate'
+              $ref: "#/components/schemas/WebhookSubscriptionCreate"
       responses:
-        '201':
+        "201":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WebhookSubscriptionResponse'
-        '422':
+                $ref: "#/components/schemas/WebhookSubscriptionResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
     get:
       tags:
-      - webhooks
+        - webhooks
       summary: List Subscriptions
       operationId: list_subscriptions_webhooks_get
       parameters:
-      - name: cursor
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Cursor
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 200
-          minimum: 1
-          default: 50
-          title: Limit
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Cursor
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 200
+            minimum: 1
+            default: 50
+            title: Limit
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WebhookSubscriptionListResponse'
-        '422':
+                $ref: "#/components/schemas/WebhookSubscriptionListResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /webhooks/{sub_id}:
     get:
       tags:
-      - webhooks
+        - webhooks
       summary: Get Subscription
       operationId: get_subscription_webhooks__sub_id__get
       parameters:
-      - name: sub_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Sub Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: sub_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Sub Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WebhookSubscriptionResponse'
-        '422':
+                $ref: "#/components/schemas/WebhookSubscriptionResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
     patch:
       tags:
-      - webhooks
+        - webhooks
       summary: Patch Subscription
       operationId: patch_subscription_webhooks__sub_id__patch
       parameters:
-      - name: sub_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Sub Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: sub_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Sub Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/WebhookSubscriptionPatch'
+              $ref: "#/components/schemas/WebhookSubscriptionPatch"
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WebhookSubscriptionResponse'
-        '422':
+                $ref: "#/components/schemas/WebhookSubscriptionResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
     delete:
       tags:
-      - webhooks
+        - webhooks
       summary: Delete Subscription
       operationId: delete_subscription_webhooks__sub_id__delete
       parameters:
-      - name: sub_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Sub Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: sub_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Sub Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '204':
+        "204":
           description: Successful Response
-        '422':
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /webhooks/{sub_id}/rotate-secret:
     post:
       tags:
-      - webhooks
+        - webhooks
       summary: Rotate Secret
       operationId: rotate_secret_webhooks__sub_id__rotate_secret_post
       parameters:
-      - name: sub_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Sub Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: sub_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Sub Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WebhookSubscriptionResponse'
-        '422':
+                $ref: "#/components/schemas/WebhookSubscriptionResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /webhooks/{sub_id}/deliveries:
     get:
       tags:
-      - webhooks
+        - webhooks
       summary: List Deliveries
       operationId: list_deliveries_webhooks__sub_id__deliveries_get
       parameters:
-      - name: sub_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Sub Id
-      - name: cursor
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Cursor
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 200
-          minimum: 1
-          default: 50
-          title: Limit
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: sub_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Sub Id
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Cursor
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 200
+            minimum: 1
+            default: 50
+            title: Limit
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WebhookDeliveryListResponse'
-        '422':
+                $ref: "#/components/schemas/WebhookDeliveryListResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /webhooks/{sub_id}/deliveries/{delivery_id}/redeliver:
     post:
       tags:
-      - webhooks
+        - webhooks
       summary: Redeliver
       operationId: redeliver_webhooks__sub_id__deliveries__delivery_id__redeliver_post
       parameters:
-      - name: sub_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Sub Id
-      - name: delivery_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Delivery Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: sub_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Sub Id
+        - name: delivery_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Delivery Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WebhookDeliveryResponse'
-        '422':
+                $ref: "#/components/schemas/WebhookDeliveryResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /unsubscribe:
     get:
       tags:
-      - unsubscribe
+        - unsubscribe
       summary: Unsubscribe
       operationId: unsubscribe_unsubscribe_get
       parameters:
-      - name: token
-        in: query
-        required: true
-        schema:
-          type: string
-          title: Token
+        - name: token
+          in: query
+          required: true
+          schema:
+            type: string
+            title: Token
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             text/html:
               schema:
                 type: string
-        '422':
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /sms:
     post:
       tags:
-      - sms
+        - sms
       summary: Create Sms
       operationId: create_sms_sms_post
       parameters:
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
-      - name: Idempotency-Key
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Idempotency-Key
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Idempotency-Key
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SmsCreate'
+              $ref: "#/components/schemas/SmsCreate"
       responses:
-        '201':
+        "201":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SmsResponse'
-        '429':
-          description: Rate limited. The agent-origin workspace exceeded a per-channel
+                $ref: "#/components/schemas/SmsResponse"
+        "429":
+          description:
+            Rate limited. The agent-origin workspace exceeded a per-channel
             velocity cap, or the platform kill switch is on. Retry after the Retry-After
             header (seconds).
           headers:
@@ -1447,434 +1455,434 @@ paths:
               description: Seconds to wait before retrying.
               schema:
                 type: integer
-        '422':
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
     get:
       tags:
-      - sms
+        - sms
       summary: List Sms
       operationId: list_sms_sms_get
       parameters:
-      - name: cursor
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Cursor
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 200
-          minimum: 1
-          default: 50
-          title: Limit
-      - name: status
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - enum:
-            - queued
-            - sent
-            - delivered
-            - failed
-            - undelivered
-            - received
-            type: string
-          - type: 'null'
-          title: Status
-      - name: to
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: To
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Cursor
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 200
+            minimum: 1
+            default: 50
+            title: Limit
+        - name: status
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - enum:
+                  - queued
+                  - sent
+                  - delivered
+                  - failed
+                  - undelivered
+                  - received
+                type: string
+              - type: "null"
+            title: Status
+        - name: to
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: To
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SmsListResponse'
-        '422':
+                $ref: "#/components/schemas/SmsListResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /sms/suppressions:
     get:
       tags:
-      - sms
+        - sms
       summary: List Sms Suppressions
       operationId: list_sms_suppressions_sms_suppressions_get
       parameters:
-      - name: cursor
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Cursor
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 200
-          minimum: 1
-          default: 50
-          title: Limit
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Cursor
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 200
+            minimum: 1
+            default: 50
+            title: Limit
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuppressionListResponse'
-        '422':
+                $ref: "#/components/schemas/SuppressionListResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /sms/suppressions/{number}:
     delete:
       tags:
-      - sms
+        - sms
       summary: Delete Sms Suppression
       operationId: delete_sms_suppression_sms_suppressions__number__delete
       parameters:
-      - name: number
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Number
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: number
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Number
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '204':
+        "204":
           description: Successful Response
-        '422':
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /sms/sender-id:
     get:
       tags:
-      - sms
+        - sms
       summary: Get Sender Id
       operationId: get_sender_id_sms_sender_id_get
       parameters:
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SenderIdResponse'
-        '422':
+                $ref: "#/components/schemas/SenderIdResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
     patch:
       tags:
-      - sms
+        - sms
       summary: Patch Sender Id
       operationId: patch_sender_id_sms_sender_id_patch
       parameters:
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SenderIdPatch'
+              $ref: "#/components/schemas/SenderIdPatch"
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SenderIdResponse'
-        '422':
+                $ref: "#/components/schemas/SenderIdResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /sms/{sms_id}:
     get:
       tags:
-      - sms
+        - sms
       summary: Get Sms
       operationId: get_sms_sms__sms_id__get
       parameters:
-      - name: sms_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Sms Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: sms_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Sms Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SmsResponse'
-        '422':
+                $ref: "#/components/schemas/SmsResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /contacts:
     get:
       tags:
-      - contacts
+        - contacts
       summary: List Contacts
       operationId: list_contacts_contacts_get
       parameters:
-      - name: q
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Q
-      - name: cursor
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Cursor
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 500
-          minimum: 1
-          default: 100
-          title: Limit
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: q
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Q
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Cursor
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 500
+            minimum: 1
+            default: 100
+            title: Limit
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContactListResponse'
-        '422':
+                $ref: "#/components/schemas/ContactListResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
     post:
       tags:
-      - contacts
+        - contacts
       summary: Create Contact
       operationId: create_contact_contacts_post
       parameters:
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ContactCreate'
+              $ref: "#/components/schemas/ContactCreate"
       responses:
-        '201':
+        "201":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContactEntry'
-        '422':
+                $ref: "#/components/schemas/ContactEntry"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /contacts/{contact_id}:
     patch:
       tags:
-      - contacts
+        - contacts
       summary: Patch Contact
       operationId: patch_contact_contacts__contact_id__patch
       parameters:
-      - name: contact_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Contact Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: contact_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Contact Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ContactPatch'
+              $ref: "#/components/schemas/ContactPatch"
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContactEntry'
-        '422':
+                $ref: "#/components/schemas/ContactEntry"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
     delete:
       tags:
-      - contacts
+        - contacts
       summary: Delete Contact
       operationId: delete_contact_contacts__contact_id__delete
       parameters:
-      - name: contact_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Contact Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: contact_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Contact Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '204':
+        "204":
           description: Successful Response
-        '422':
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /members/{user_id}/phone:
     put:
       tags:
-      - contacts
+        - contacts
       summary: Put Member Phone
       operationId: put_member_phone_members__user_id__phone_put
       parameters:
-      - name: user_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: User Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: User Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MemberPhonePut'
+              $ref: "#/components/schemas/MemberPhonePut"
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
@@ -1883,76 +1891,105 @@ paths:
                 additionalProperties:
                   type: string
                 title: Response Put Member Phone Members  User Id  Phone Put
-        '422':
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
     delete:
       tags:
-      - contacts
+        - contacts
       summary: Delete Member Phone
       operationId: delete_member_phone_members__user_id__phone_delete
       parameters:
-      - name: user_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: User Id
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: User Id
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '204':
+        "204":
           description: Successful Response
-        '422':
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
+  /whoami:
+    get:
+      tags:
+        - whoami
+      summary: Get Whoami
+      operationId: get_whoami_whoami_get
+      parameters:
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WhoamiResponse"
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPValidationError"
   /providers:
     get:
       tags:
-      - providers
+        - providers
       summary: List Providers
       description: Every saved provider row for the caller's organization, all layers.
       operationId: list_providers
       parameters:
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProviderConfigListResponse'
-        '422':
+                $ref: "#/components/schemas/ProviderConfigListResponse"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /providers/{layer}:
     put:
       tags:
-      - providers
+        - providers
       summary: Upsert Provider
-      description: "Save a provider for ``layer`` and make it the active one.\n\n\
+      description:
+        "Save a provider for ``layer`` and make it the active one.\n\n\
         A partial write: anything you omit keeps its saved value. Omitting\n``api_key``\
         \ keeps the stored key, ``params`` keys you don't send are\npreserved, and\
         \ omitting ``fallback_enabled`` leaves the flag alone\n(``false`` on a new\
@@ -1960,178 +1997,180 @@ paths:
         \ against the layer's schema (422 on a mismatch). 404 on an\nunknown layer."
       operationId: upsert_provider
       parameters:
-      - name: layer
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Layer
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: layer
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Layer
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProviderConfigUpsert'
+              $ref: "#/components/schemas/ProviderConfigUpsert"
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProviderConfigEntry'
-        '422':
+                $ref: "#/components/schemas/ProviderConfigEntry"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /providers/{layer}/{provider}:
     delete:
       tags:
-      - providers
+        - providers
       summary: Delete Provider
-      description: 'Delete one provider row. Deleting the active row promotes the
+      description:
+        "Delete one provider row. Deleting the active row promotes the
 
-        most-recently-updated sibling. Idempotent: deleting a row that isn''t
+        most-recently-updated sibling. Idempotent: deleting a row that isn't
 
-        there is a 204 too. 404 on an unknown layer.'
+        there is a 204 too. 404 on an unknown layer."
       operationId: delete_provider
       parameters:
-      - name: layer
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Layer
-      - name: provider
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Provider
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: layer
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Layer
+        - name: provider
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Provider
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       responses:
-        '204':
+        "204":
           description: Successful Response
-        '422':
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /providers/{layer}/activate:
     post:
       tags:
-      - providers
+        - providers
       summary: Activate Provider
-      description: 'Switch which saved provider is active for ``layer``. 404 when
+      description:
+        "Switch which saved provider is active for ``layer``. 404 when
         that
 
-        provider has no saved config.'
+        provider has no saved config."
       operationId: activate_provider
       parameters:
-      - name: layer
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Layer
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: layer
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Layer
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProviderActivateRequest'
+              $ref: "#/components/schemas/ProviderActivateRequest"
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProviderConfigEntry'
-        '422':
+                $ref: "#/components/schemas/ProviderConfigEntry"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /providers/{layer}/validate:
     post:
       tags:
-      - providers
+        - providers
       summary: Validate Provider
-      description: 'Probe a provider key against the real provider.
+      description: "Probe a provider key against the real provider.
 
 
-        Empty body tests the layer''s active provider with its stored key; send
+        Empty body tests the layer's active provider with its stored key; send
 
         ``provider`` to test a specific saved row, or ``api_key`` (plus
 
-        ``provider``/``params``) to test a key before saving it.'
+        ``provider``/``params``) to test a key before saving it."
       operationId: validate_provider
       parameters:
-      - name: layer
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Layer
-      - name: authorization
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Authorization
+        - name: layer
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Layer
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Authorization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProviderValidateRequest'
+              $ref: "#/components/schemas/ProviderValidateRequest"
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProviderValidateResult'
-        '422':
+                $ref: "#/components/schemas/ProviderValidateResult"
+        "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: "#/components/schemas/HTTPValidationError"
   /healthz:
     get:
       summary: Healthz
       operationId: healthz_healthz_get
       responses:
-        '200':
+        "200":
           description: Successful Response
           content:
             application/json:
@@ -2150,66 +2189,70 @@ components:
           title: File
       type: object
       required:
-      - file
+        - file
       title: Body_upload_email_attachment
     CallCreate:
       properties:
         recipient_consent:
           type: boolean
           title: Recipient Consent
-          description: "Attestation that you have obtained the lawful consent required\
+          description:
+            "Attestation that you have obtained the lawful consent required\
             \ to contact this recipient. Hail does not verify consent itself \u2014\
             \ you are responsible for a lawful basis under TCPA/ePrivacy/PECR/CAN-SPAM/GDPR\
             \ as applicable. Rejected (422) if not true."
         consent_source:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Consent Source
-          description: Where/how consent was obtained (e.g. 'signup form', 'prior
+          description:
+            Where/how consent was obtained (e.g. 'signup form', 'prior
             customer relationship'). Required (non-empty) when message_type is 'marketing'.
         consent_obtained_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Consent Obtained At
           description: When consent was obtained, if known.
         message_type:
           type: string
           enum:
-          - marketing
-          - informational
+            - marketing
+            - informational
           title: Message Type
-          description: '''marketing'' additionally requires a non-empty consent_source.
-            Use ''informational'' for transactional/service communications.'
+          description:
+            "'marketing' additionally requires a non-empty consent_source.
+            Use 'informational' for transactional/service communications."
           default: informational
         to:
           type: string
           title: To
         from:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: From
         system_prompt:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: System Prompt
         llm:
           anyOf:
-          - $ref: '#/components/schemas/LLMConfig'
-          - type: 'null'
+            - $ref: "#/components/schemas/LLMConfig"
+            - type: "null"
         first_message:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: First Message
         ai_disclosure:
           type: boolean
           title: Ai Disclosure
-          description: "Speak the AI self-disclosure line ('Hi, this is an AI assistant\
+          description:
+            "Speak the AI self-disclosure line ('Hi, this is an AI assistant\
             \ calling on behalf of ...') as the first thing on the call. Enabled by\
             \ default. Disable only if you have verified the disclosure is not required\
             \ for this call \u2014 47 CFR 64.1200(b)(1) requires identifying the initiating\
@@ -2218,12 +2261,12 @@ components:
             \ for you. The agent still identifies itself as an AI if asked."
           default: true
         voice_config:
-          $ref: '#/components/schemas/VoiceConfig'
+          $ref: "#/components/schemas/VoiceConfig"
         conversation_id:
           anyOf:
-          - type: string
-            format: uuid
-          - type: 'null'
+            - type: string
+              format: uuid
+            - type: "null"
           title: Conversation Id
         metadata:
           additionalProperties: true
@@ -2231,35 +2274,36 @@ components:
           title: Metadata
         tools:
           anyOf:
-          - items:
-              type: string
-            type: array
-          - type: 'null'
+            - items:
+                type: string
+              type: array
+            - type: "null"
           title: Tools
-          description: 'Agent tools to allow on this call. Omitted: every tool the
-            organization''s configured channels support (new channels appear automatically).
-            Empty list: no tools. Tool names are validated against the server''s registry.'
+          description:
+            "Agent tools to allow on this call. Omitted: every tool the
+            organization's configured channels support (new channels appear automatically).
+            Empty list: no tools. Tool names are validated against the server's registry."
       additionalProperties: false
       type: object
       required:
-      - recipient_consent
-      - to
+        - recipient_consent
+        - to
       title: CallCreate
     CallListResponse:
       properties:
         items:
           items:
-            $ref: '#/components/schemas/CallResponse'
+            $ref: "#/components/schemas/CallResponse"
           type: array
           title: Items
         next_cursor:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Next Cursor
       type: object
       required:
-      - items
+        - items
       title: CallListResponse
     CallResponse:
       properties:
@@ -2273,9 +2317,9 @@ components:
           title: Organization Id
         conversation_id:
           anyOf:
-          - type: string
-            format: uuid
-          - type: 'null'
+            - type: string
+              format: uuid
+            - type: "null"
           title: Conversation Id
         from_e164:
           type: string
@@ -2286,46 +2330,46 @@ components:
         direction:
           type: string
           enum:
-          - outbound
-          - inbound
+            - outbound
+            - inbound
           title: Direction
         status:
           type: string
           enum:
-          - queued
-          - dialing
-          - ringing
-          - in_progress
-          - completed
-          - failed
-          - busy
-          - no_answer
-          - canceled
+            - queued
+            - dialing
+            - ringing
+            - in_progress
+            - completed
+            - failed
+            - busy
+            - no_answer
+            - canceled
           title: Status
         end_reason:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: End Reason
         provider_call_sid:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Provider Call Sid
         livekit_room:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Livekit Room
         initial_prompt:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Initial Prompt
         recording_s3_key:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Recording S3 Key
         requested_at:
           type: string
@@ -2333,40 +2377,40 @@ components:
           title: Requested At
         started_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Started At
         answered_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Answered At
         ended_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Ended At
       type: object
       required:
-      - id
-      - organization_id
-      - conversation_id
-      - from_e164
-      - to_e164
-      - direction
-      - status
-      - end_reason
-      - provider_call_sid
-      - livekit_room
-      - initial_prompt
-      - recording_s3_key
-      - requested_at
-      - started_at
-      - answered_at
-      - ended_at
+        - id
+        - organization_id
+        - conversation_id
+        - from_e164
+        - to_e164
+        - direction
+        - status
+        - end_reason
+        - provider_call_sid
+        - livekit_room
+        - initial_prompt
+        - recording_s3_key
+        - requested_at
+        - started_at
+        - answered_at
+        - ended_at
       title: CallResponse
     ContactCreate:
       properties:
@@ -2377,18 +2421,18 @@ components:
           title: Name
         phone_e164:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Phone E164
         email:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Email
       additionalProperties: false
       type: object
       required:
-      - name
+        - name
       title: ContactCreate
     ContactEntry:
       properties:
@@ -2398,70 +2442,71 @@ components:
         kind:
           type: string
           enum:
-          - member
-          - manual
+            - member
+            - manual
           title: Kind
         name:
           type: string
           title: Name
         phone_e164:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Phone E164
         email:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Email
         role:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Role
       type: object
       required:
-      - id
-      - kind
-      - name
+        - id
+        - kind
+        - name
       title: ContactEntry
-      description: "One row in the computed contacts union \u2014 an org member or\
+      description:
+        "One row in the computed contacts union \u2014 an org member or\
         \ a manual\ncontact. ``id`` is ``member:<user_id>`` for members, the contact\
         \ row's\nUUID (as str) for manual rows."
     ContactListResponse:
       properties:
         items:
           items:
-            $ref: '#/components/schemas/ContactEntry'
+            $ref: "#/components/schemas/ContactEntry"
           type: array
           title: Items
         next_cursor:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Next Cursor
       type: object
       required:
-      - items
+        - items
       title: ContactListResponse
     ContactPatch:
       properties:
         name:
           anyOf:
-          - type: string
-            maxLength: 200
-            minLength: 1
-          - type: 'null'
+            - type: string
+              maxLength: 200
+              minLength: 1
+            - type: "null"
           title: Name
         phone_e164:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Phone E164
         email:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Email
       additionalProperties: false
       type: object
@@ -2477,26 +2522,26 @@ components:
         type:
           type: string
           enum:
-          - CNAME
-          - MX
-          - TXT
+            - CNAME
+            - MX
+            - TXT
           title: Type
           default: CNAME
         priority:
           anyOf:
-          - type: integer
-          - type: 'null'
+            - type: integer
+            - type: "null"
           title: Priority
       additionalProperties: true
       type: object
       required:
-      - name
-      - value
+        - name
+        - value
       title: DnsRecordSchema
-      description: 'One DNS record the tenant must publish for a sending domain.
+      description: "One DNS record the tenant must publish for a sending domain.
 
 
-        Covers DKIM CNAMEs, MAIL FROM MX, and SPF TXT records.'
+        Covers DKIM CNAMEs, MAIL FROM MX, and SPF TXT records."
     DomainCheckResponse:
       properties:
         domain:
@@ -2515,10 +2560,10 @@ components:
           title: Suggested Domain
       type: object
       required:
-      - domain
-      - in_use
-      - existing_mx
-      - suggested_domain
+        - domain
+        - in_use
+        - existing_mx
+        - suggested_domain
       title: DomainCheckResponse
     EmailAttachmentResponse:
       properties:
@@ -2537,21 +2582,22 @@ components:
           title: Size Bytes
         content_id:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Content Id
         url:
           type: string
           title: Url
       type: object
       required:
-      - id
-      - filename
-      - content_type
-      - size_bytes
-      - url
+        - id
+        - filename
+        - content_type
+        - size_bytes
+        - url
       title: EmailAttachmentResponse
-      description: "One inbound MIME attachment as exposed to API consumers.\n\n``url``\
+      description:
+        "One inbound MIME attachment as exposed to API consumers.\n\n``url``\
         \ is the stable Hail API endpoint that 302-redirects to a\npresigned S3 URL\
         \ on access \u2014 see GET /emails/{id}/attachments/{aid}."
     EmailAttachmentUploadResponse:
@@ -2571,55 +2617,58 @@ components:
           title: Size Bytes
       type: object
       required:
-      - id
-      - filename
-      - content_type
-      - size_bytes
+        - id
+        - filename
+        - content_type
+        - size_bytes
       title: EmailAttachmentUploadResponse
-      description: 'Returned by POST /email-attachments.
+      description: "Returned by POST /email-attachments.
 
 
         ``id`` is reusable across many ``POST /emails`` calls via
 
         ``EmailCreate.attachment_ids`` until Hail garbage-collects it (24h
 
-        if never referenced by a send).'
+        if never referenced by a send)."
     EmailCreate:
       properties:
         recipient_consent:
           type: boolean
           title: Recipient Consent
-          description: "Attestation that you have obtained the lawful consent required\
+          description:
+            "Attestation that you have obtained the lawful consent required\
             \ to contact this recipient. Hail does not verify consent itself \u2014\
             \ you are responsible for a lawful basis under TCPA/ePrivacy/PECR/CAN-SPAM/GDPR\
             \ as applicable. Rejected (422) if not true."
         consent_source:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Consent Source
-          description: Where/how consent was obtained (e.g. 'signup form', 'prior
+          description:
+            Where/how consent was obtained (e.g. 'signup form', 'prior
             customer relationship'). Required (non-empty) when message_type is 'marketing'.
         consent_obtained_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Consent Obtained At
           description: When consent was obtained, if known.
         message_type:
           type: string
           enum:
-          - marketing
-          - informational
+            - marketing
+            - informational
           title: Message Type
-          description: '''marketing'' additionally requires a non-empty consent_source.
-            Use ''informational'' for transactional/service communications.'
+          description:
+            "'marketing' additionally requires a non-empty consent_source.
+            Use 'informational' for transactional/service communications."
           default: informational
         from:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: From
         from_name:
           anyOf:
@@ -2635,22 +2684,22 @@ components:
           title: To
         cc:
           anyOf:
-          - items:
-              type: string
-            type: array
-          - type: 'null'
+            - items:
+                type: string
+              type: array
+            - type: "null"
           title: Cc
         bcc:
           anyOf:
-          - items:
-              type: string
-            type: array
-          - type: 'null'
+            - items:
+                type: string
+              type: array
+            - type: "null"
           title: Bcc
         reply_to:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Reply To
         subject:
           type: string
@@ -2659,19 +2708,19 @@ components:
           title: Subject
         body_text:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Body Text
         body_html:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Body Html
         conversation_id:
           anyOf:
-          - type: string
-            format: uuid
-          - type: 'null'
+            - type: string
+              format: uuid
+            - type: "null"
           title: Conversation Id
         metadata:
           additionalProperties: true
@@ -2679,51 +2728,51 @@ components:
           title: Metadata
         attachment_ids:
           anyOf:
-          - items:
-              type: string
-              format: uuid
-            type: array
-          - type: 'null'
+            - items:
+                type: string
+                format: uuid
+              type: array
+            - type: "null"
           title: Attachment Ids
       additionalProperties: false
       type: object
       required:
-      - recipient_consent
-      - to
-      - subject
+        - recipient_consent
+        - to
+        - subject
       title: EmailCreate
     EmailDomainCreate:
       properties:
         kind:
           type: string
           enum:
-          - hail_mail
-          - custom
+            - hail_mail
+            - custom
           title: Kind
         domain:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Domain
         local_prefix_user:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Local Prefix User
         local_prefix_org:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Local Prefix Org
       additionalProperties: false
       type: object
       required:
-      - kind
+        - kind
       title: EmailDomainCreate
-      description: 'Request body for POST /email-domains.
+      description: "Request body for POST /email-domains.
 
 
-        For ``kind=''hail_mail''`` ``domain`` is omitted; the server composes
+        For ``kind='hail_mail'`` ``domain`` is omitted; the server composes
 
         the full address as ``<local_prefix_user>+<local_prefix_org>@<base>``.
 
@@ -2731,58 +2780,64 @@ components:
 
         ``HAIL_MAIL_DEFAULT_*_PREFIX`` env vars; the server returns 503 if
 
-        neither is supplied. For ``kind=''custom''`` ``domain`` is required and
+        neither is supplied. For ``kind='custom'`` ``domain`` is required and
 
-        the prefix fields must be omitted.'
+        the prefix fields must be omitted."
     EmailDomainListResponse:
       properties:
         items:
           items:
-            $ref: '#/components/schemas/EmailDomainResponse'
+            $ref: "#/components/schemas/EmailDomainResponse"
           type: array
           title: Items
         next_cursor:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Next Cursor
+        default_from:
+          anyOf:
+            - type: string
+            - type: "null"
+          title: Default From
       type: object
       required:
-      - items
+        - items
       title: EmailDomainListResponse
     EmailDomainPatch:
       properties:
         local_prefix_user:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Local Prefix User
         local_prefix_org:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Local Prefix Org
         inbound_enabled:
           anyOf:
-          - type: boolean
-          - type: 'null'
+            - type: boolean
+            - type: "null"
           title: Inbound Enabled
         forward_to:
           anyOf:
-          - items:
-              type: string
-            type: array
-          - type: 'null'
+            - items:
+                type: string
+              type: array
+            - type: "null"
           title: Forward To
         forward_rate_per_hour:
           anyOf:
-          - type: integer
-          - type: 'null'
+            - type: integer
+            - type: "null"
           title: Forward Rate Per Hour
       additionalProperties: false
       type: object
       title: EmailDomainPatch
-      description: "Body for PATCH /email-domains/{id}.\n\nTwo clusters of mutable\
+      description:
+        "Body for PATCH /email-domains/{id}.\n\nTwo clusters of mutable\
         \ fields:\n\n* Hail-mail addressing \u2014 the user/org prefix pair (only\
         \ valid on\n  ``kind='hail_mail'`` rows; the handler returns 422 if a tenant\
         \ tries\n  to PATCH these on a custom row).\n* Inbound action \u2014 ``inbound_enabled``\
@@ -2807,52 +2862,52 @@ components:
         kind:
           type: string
           enum:
-          - hail_mail
-          - custom
+            - hail_mail
+            - custom
           title: Kind
         domain:
           type: string
           title: Domain
         local_prefix_user:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Local Prefix User
         local_prefix_org:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Local Prefix Org
         verification_status:
           type: string
           enum:
-          - pending
-          - verified
-          - failed
+            - pending
+            - verified
+            - failed
           title: Verification Status
         dns_records:
           items:
-            $ref: '#/components/schemas/DnsRecordSchema'
+            $ref: "#/components/schemas/DnsRecordSchema"
           type: array
           title: Dns Records
         mail_from_domain:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Mail From Domain
         mail_from_status:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Mail From Status
         provider:
           type: string
           title: Provider
         verified_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Verified At
         inbound_enabled:
           type: boolean
@@ -2860,15 +2915,15 @@ components:
           default: false
         forward_to:
           anyOf:
-          - items:
-              type: string
-            type: array
-          - type: 'null'
+            - items:
+                type: string
+              type: array
+            - type: "null"
           title: Forward To
         forward_rate_per_hour:
           anyOf:
-          - type: integer
-          - type: 'null'
+            - type: integer
+            - type: "null"
           title: Forward Rate Per Hour
         created_at:
           type: string
@@ -2880,48 +2935,48 @@ components:
           title: Updated At
         receive_ready:
           anyOf:
-          - type: boolean
-          - type: 'null'
+            - type: boolean
+            - type: "null"
           title: Receive Ready
       type: object
       required:
-      - id
-      - organization_id
-      - kind
-      - domain
-      - local_prefix_user
-      - local_prefix_org
-      - verification_status
-      - dns_records
-      - mail_from_domain
-      - provider
-      - verified_at
-      - created_at
-      - updated_at
+        - id
+        - organization_id
+        - kind
+        - domain
+        - local_prefix_user
+        - local_prefix_org
+        - verification_status
+        - dns_records
+        - mail_from_domain
+        - provider
+        - verified_at
+        - created_at
+        - updated_at
       title: EmailDomainResponse
-      description: 'Read view for an email domain.
+      description: "Read view for an email domain.
 
 
         The inbound-action fields (``inbound_enabled``, ``forward_to``,
 
         ``forward_rate_per_hour``) surface what the row has configured for
 
-        incoming mail.'
+        incoming mail."
     EmailEventListResponse:
       properties:
         items:
           items:
-            $ref: '#/components/schemas/EmailEventResponse'
+            $ref: "#/components/schemas/EmailEventResponse"
           type: array
           title: Items
         next_cursor:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Next Cursor
       type: object
       required:
-      - items
+        - items
       title: EmailEventListResponse
     EmailEventResponse:
       properties:
@@ -2936,14 +2991,14 @@ components:
         kind:
           type: string
           enum:
-          - sent
-          - delivered
-          - delivery_delayed
-          - bounced
-          - complained
-          - rejected
-          - opened
-          - clicked
+            - sent
+            - delivered
+            - delivery_delayed
+            - bounced
+            - complained
+            - rejected
+            - opened
+            - clicked
           title: Kind
         payload:
           additionalProperties: true
@@ -2955,27 +3010,27 @@ components:
           title: Occurred At
       type: object
       required:
-      - id
-      - email_id
-      - kind
-      - payload
-      - occurred_at
+        - id
+        - email_id
+        - kind
+        - payload
+        - occurred_at
       title: EmailEventResponse
     EmailListResponse:
       properties:
         items:
           items:
-            $ref: '#/components/schemas/EmailSummary'
+            $ref: "#/components/schemas/EmailSummary"
           type: array
           title: Items
         next_cursor:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Next Cursor
       type: object
       required:
-      - items
+        - items
       title: EmailListResponse
     EmailResponse:
       properties:
@@ -2989,21 +3044,21 @@ components:
           title: Organization Id
         conversation_id:
           anyOf:
-          - type: string
-            format: uuid
-          - type: 'null'
+            - type: string
+              format: uuid
+            - type: "null"
           title: Conversation Id
         email_domain_id:
           anyOf:
-          - type: string
-            format: uuid
-          - type: 'null'
+            - type: string
+              format: uuid
+            - type: "null"
           title: Email Domain Id
         direction:
           type: string
           enum:
-          - outbound
-          - inbound
+            - outbound
+            - inbound
           title: Direction
           default: outbound
         from_address:
@@ -3021,22 +3076,22 @@ components:
           title: To Addresses
         cc_addresses:
           anyOf:
-          - items:
-              type: string
-            type: array
-          - type: 'null'
+            - items:
+                type: string
+              type: array
+            - type: "null"
           title: Cc Addresses
         bcc_addresses:
           anyOf:
-          - items:
-              type: string
-            type: array
-          - type: 'null'
+            - items:
+                type: string
+              type: array
+            - type: "null"
           title: Bcc Addresses
         reply_to:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Reply To
         subject:
           type: string
@@ -3044,23 +3099,23 @@ components:
         status:
           type: string
           enum:
-          - queued
-          - sent
-          - delivered
-          - failed
-          - bounced
-          - complained
-          - received
+            - queued
+            - sent
+            - delivered
+            - failed
+            - bounced
+            - complained
+            - received
           title: Status
         end_reason:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: End Reason
         provider_message_id:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Provider Message Id
         requested_at:
           type: string
@@ -3068,15 +3123,15 @@ components:
           title: Requested At
         sent_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Sent At
         failed_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Failed At
         metadata:
           additionalProperties: true
@@ -3084,99 +3139,99 @@ components:
           title: Metadata
         body_text:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Body Text
         body_html:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Body Html
         message_id:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Message Id
         in_reply_to:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: In Reply To
         references_ids:
           anyOf:
-          - items:
-              type: string
-            type: array
-          - type: 'null'
+            - items:
+                type: string
+              type: array
+            - type: "null"
           title: References Ids
         spam_verdict:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Spam Verdict
         virus_verdict:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Virus Verdict
         dkim_verdict:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Dkim Verdict
         spf_verdict:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Spf Verdict
         dmarc_verdict:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Dmarc Verdict
         provider_received_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Provider Received At
         raw_url:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Raw Url
         attachments:
           items:
-            $ref: '#/components/schemas/EmailAttachmentResponse'
+            $ref: "#/components/schemas/EmailAttachmentResponse"
           type: array
           title: Attachments
           default: []
         last_event_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Last Event At
       type: object
       required:
-      - id
-      - organization_id
-      - conversation_id
-      - email_domain_id
-      - from_address
-      - to_addresses
-      - cc_addresses
-      - bcc_addresses
-      - reply_to
-      - subject
-      - status
-      - end_reason
-      - provider_message_id
-      - requested_at
-      - sent_at
-      - failed_at
-      - body_text
-      - body_html
+        - id
+        - organization_id
+        - conversation_id
+        - email_domain_id
+        - from_address
+        - to_addresses
+        - cc_addresses
+        - bcc_addresses
+        - reply_to
+        - subject
+        - status
+        - end_reason
+        - provider_message_id
+        - requested_at
+        - sent_at
+        - failed_at
+        - body_text
+        - body_html
       title: EmailResponse
     EmailStatsBucket:
       properties:
@@ -3230,7 +3285,7 @@ components:
           title: Bucket Start
       type: object
       required:
-      - bucket_start
+        - bucket_start
       title: EmailStatsBucket
     EmailStatsCounts:
       properties:
@@ -3284,28 +3339,28 @@ components:
       properties:
         delivery:
           anyOf:
-          - type: number
-          - type: 'null'
+            - type: number
+            - type: "null"
           title: Delivery
         bounce:
           anyOf:
-          - type: number
-          - type: 'null'
+            - type: number
+            - type: "null"
           title: Bounce
         complaint:
           anyOf:
-          - type: number
-          - type: 'null'
+            - type: number
+            - type: "null"
           title: Complaint
         open:
           anyOf:
-          - type: number
-          - type: 'null'
+            - type: number
+            - type: "null"
           title: Open
         click:
           anyOf:
-          - type: number
-          - type: 'null'
+            - type: number
+            - type: "null"
           title: Click
       type: object
       title: EmailStatsRates
@@ -3323,26 +3378,26 @@ components:
         bucket:
           type: string
           enum:
-          - hour
-          - day
+            - hour
+            - day
           title: Bucket
         totals:
-          $ref: '#/components/schemas/EmailStatsCounts'
+          $ref: "#/components/schemas/EmailStatsCounts"
         rates:
-          $ref: '#/components/schemas/EmailStatsRates'
+          $ref: "#/components/schemas/EmailStatsRates"
         series:
           items:
-            $ref: '#/components/schemas/EmailStatsBucket'
+            $ref: "#/components/schemas/EmailStatsBucket"
           type: array
           title: Series
       type: object
       required:
-      - from
-      - to
-      - bucket
-      - totals
-      - rates
-      - series
+        - from
+        - to
+        - bucket
+        - totals
+        - rates
+        - series
       title: EmailStatsResponse
     EmailSummary:
       properties:
@@ -3356,21 +3411,21 @@ components:
           title: Organization Id
         conversation_id:
           anyOf:
-          - type: string
-            format: uuid
-          - type: 'null'
+            - type: string
+              format: uuid
+            - type: "null"
           title: Conversation Id
         email_domain_id:
           anyOf:
-          - type: string
-            format: uuid
-          - type: 'null'
+            - type: string
+              format: uuid
+            - type: "null"
           title: Email Domain Id
         direction:
           type: string
           enum:
-          - outbound
-          - inbound
+            - outbound
+            - inbound
           title: Direction
           default: outbound
         from_address:
@@ -3388,22 +3443,22 @@ components:
           title: To Addresses
         cc_addresses:
           anyOf:
-          - items:
-              type: string
-            type: array
-          - type: 'null'
+            - items:
+                type: string
+              type: array
+            - type: "null"
           title: Cc Addresses
         bcc_addresses:
           anyOf:
-          - items:
-              type: string
-            type: array
-          - type: 'null'
+            - items:
+                type: string
+              type: array
+            - type: "null"
           title: Bcc Addresses
         reply_to:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Reply To
         subject:
           type: string
@@ -3411,23 +3466,23 @@ components:
         status:
           type: string
           enum:
-          - queued
-          - sent
-          - delivered
-          - failed
-          - bounced
-          - complained
-          - received
+            - queued
+            - sent
+            - delivered
+            - failed
+            - bounced
+            - complained
+            - received
           title: Status
         end_reason:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: End Reason
         provider_message_id:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Provider Message Id
         requested_at:
           type: string
@@ -3435,15 +3490,15 @@ components:
           title: Requested At
         sent_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Sent At
         failed_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Failed At
         metadata:
           additionalProperties: true
@@ -3451,24 +3506,25 @@ components:
           title: Metadata
       type: object
       required:
-      - id
-      - organization_id
-      - conversation_id
-      - email_domain_id
-      - from_address
-      - to_addresses
-      - cc_addresses
-      - bcc_addresses
-      - reply_to
-      - subject
-      - status
-      - end_reason
-      - provider_message_id
-      - requested_at
-      - sent_at
-      - failed_at
+        - id
+        - organization_id
+        - conversation_id
+        - email_domain_id
+        - from_address
+        - to_addresses
+        - cc_addresses
+        - bcc_addresses
+        - reply_to
+        - subject
+        - status
+        - end_reason
+        - provider_message_id
+        - requested_at
+        - sent_at
+        - failed_at
       title: EmailSummary
-      description: "Trimmed view for list endpoints \u2014 drops the message bodies.\n\
+      description:
+        "Trimmed view for list endpoints \u2014 drops the message bodies.\n\
         \nBodies can be large and contain PII; paging through a year of mail\nshouldn't\
         \ return every byte of every message just to render a list.\nUse ``EmailResponse``\
         \ (via ``GET /emails/{id}``) for the full row."
@@ -3481,27 +3537,27 @@ components:
         source:
           type: string
           enum:
-          - call
-          - email
-          - sms
+            - call
+            - email
+            - sms
           title: Source
         call_id:
           anyOf:
-          - type: string
-            format: uuid
-          - type: 'null'
+            - type: string
+              format: uuid
+            - type: "null"
           title: Call Id
         email_id:
           anyOf:
-          - type: string
-            format: uuid
-          - type: 'null'
+            - type: string
+              format: uuid
+            - type: "null"
           title: Email Id
         sms_id:
           anyOf:
-          - type: string
-            format: uuid
-          - type: 'null'
+            - type: string
+              format: uuid
+            - type: "null"
           title: Sms Id
         kind:
           type: string
@@ -3516,49 +3572,49 @@ components:
           title: Occurred At
       type: object
       required:
-      - id
-      - source
-      - kind
-      - payload
-      - occurred_at
+        - id
+        - source
+        - kind
+        - payload
+        - occurred_at
       title: EventResponse
       description: One event on the unified GET /events stream (call, email, or SMS).
     EventStreamResponse:
       properties:
         items:
           items:
-            $ref: '#/components/schemas/EventResponse'
+            $ref: "#/components/schemas/EventResponse"
           type: array
           title: Items
         next_cursor:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Next Cursor
         call_status:
           anyOf:
-          - type: string
-            enum:
-            - queued
-            - dialing
-            - ringing
-            - in_progress
-            - completed
-            - failed
-            - busy
-            - no_answer
-            - canceled
-          - type: 'null'
+            - type: string
+              enum:
+                - queued
+                - dialing
+                - ringing
+                - in_progress
+                - completed
+                - failed
+                - busy
+                - no_answer
+                - canceled
+            - type: "null"
           title: Call Status
       type: object
       required:
-      - items
+        - items
       title: EventStreamResponse
     HTTPValidationError:
       properties:
         detail:
           items:
-            $ref: '#/components/schemas/ValidationError'
+            $ref: "#/components/schemas/ValidationError"
           type: array
           title: Detail
       type: object
@@ -3577,9 +3633,9 @@ components:
       additionalProperties: false
       type: object
       required:
-      - base_url
-      - api_key
-      - model
+        - base_url
+        - api_key
+        - model
       title: LLMConfig
     MemberPhonePut:
       properties:
@@ -3589,7 +3645,7 @@ components:
       additionalProperties: false
       type: object
       required:
-      - phone_e164
+        - phone_e164
       title: MemberPhonePut
     NumberAcquireRequest:
       properties:
@@ -3601,32 +3657,32 @@ components:
         number_type:
           type: string
           enum:
-          - local
-          - mobile
-          - toll_free
-          - national
+            - local
+            - mobile
+            - toll_free
+            - national
           title: Number Type
           default: local
       additionalProperties: false
       type: object
       required:
-      - country_code
+        - country_code
       title: NumberAcquireRequest
     PhoneNumberListResponse:
       properties:
         items:
           items:
-            $ref: '#/components/schemas/PhoneNumberResponse'
+            $ref: "#/components/schemas/PhoneNumberResponse"
           type: array
           title: Items
         next_cursor:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Next Cursor
       type: object
       required:
-      - items
+        - items
       title: PhoneNumberListResponse
     PhoneNumberResponse:
       properties:
@@ -3656,18 +3712,18 @@ components:
           title: Is Dedicated
         messaging_service_sid:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Messaging Service Sid
       type: object
       required:
-      - id
-      - e164
-      - country_code
-      - number_type
-      - capabilities
-      - provisioning_state
-      - is_dedicated
+        - id
+        - e164
+        - country_code
+        - number_type
+        - capabilities
+        - provisioning_state
+        - is_dedicated
       title: PhoneNumberResponse
     ProviderActivateRequest:
       properties:
@@ -3677,7 +3733,7 @@ components:
       additionalProperties: false
       type: object
       required:
-      - provider
+        - provider
       title: ProviderActivateRequest
       description: Body of ``POST /providers/{layer}/activate``.
     ProviderConfigEntry:
@@ -3685,22 +3741,22 @@ components:
         layer:
           type: string
           enum:
-          - llm
-          - tts
-          - stt
+            - llm
+            - tts
+            - stt
           title: Layer
         provider:
           type: string
           title: Provider
         key_last4:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Key Last4
         key_set_at:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Key Set At
         params:
           additionalProperties: true
@@ -3714,15 +3770,15 @@ components:
           title: Is Active
       type: object
       required:
-      - layer
-      - provider
-      - key_last4
-      - key_set_at
-      - params
-      - fallback_enabled
-      - is_active
+        - layer
+        - provider
+        - key_last4
+        - key_set_at
+        - params
+        - fallback_enabled
+        - is_active
       title: ProviderConfigEntry
-      description: 'One saved provider row. Write-only key: ``key_last4`` and
+      description: "One saved provider row. Write-only key: ``key_last4`` and
 
         ``key_set_at`` are the only key-derived fields that leave the API.
 
@@ -3731,17 +3787,17 @@ components:
 
         serializer always emits all of them, and required response fields
 
-        generate plain values instead of pointers in the Go CLI''s client.'
+        generate plain values instead of pointers in the Go CLI's client."
     ProviderConfigListResponse:
       properties:
         providers:
           items:
-            $ref: '#/components/schemas/ProviderConfigEntry'
+            $ref: "#/components/schemas/ProviderConfigEntry"
           type: array
           title: Providers
       type: object
       required:
-      - providers
+        - providers
       title: ProviderConfigListResponse
     ProviderConfigUpsert:
       properties:
@@ -3750,8 +3806,8 @@ components:
           title: Provider
         api_key:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Api Key
         params:
           additionalProperties: true
@@ -3759,15 +3815,16 @@ components:
           title: Params
         fallback_enabled:
           anyOf:
-          - type: boolean
-          - type: 'null'
+            - type: boolean
+            - type: "null"
           title: Fallback Enabled
       additionalProperties: false
       type: object
       required:
-      - provider
+        - provider
       title: ProviderConfigUpsert
-      description: "Body of ``PUT /providers/{layer}`` \u2014 save and activate one\
+      description:
+        "Body of ``PUT /providers/{layer}`` \u2014 save and activate one\
         \ provider.\n\nA partial write. Fields you omit keep the value already saved\
         \ for this\n``(layer, provider)`` pair: omit ``api_key`` to edit params without\n\
         resending the key, send only the ``params`` keys you want to change,\nand\
@@ -3783,13 +3840,13 @@ components:
       properties:
         api_key:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Api Key
         provider:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Provider
         params:
           additionalProperties: true
@@ -3798,7 +3855,8 @@ components:
       additionalProperties: false
       type: object
       title: ProviderValidateRequest
-      description: "Body of ``POST /providers/{layer}/validate`` \u2014 a live key\
+      description:
+        "Body of ``POST /providers/{layer}/validate`` \u2014 a live key\
         \ probe.\n\nAll fields optional: with an empty body the layer's active provider\
         \ and\nits stored key are tested. ``provider`` tests that provider's stored\
         \ key\ninstead. ``api_key`` tests a key that has not been saved yet."
@@ -3809,21 +3867,21 @@ components:
           title: Status
         message:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Message
       type: object
       required:
-      - status
-      - message
+        - status
+        - message
       title: ProviderValidateResult
       description: Outcome of a live provider-key probe.
     SenderIdPatch:
       properties:
         custom_sender_id:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Custom Sender Id
       additionalProperties: false
       type: object
@@ -3832,8 +3890,8 @@ components:
       properties:
         custom_sender_id:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Custom Sender Id
         effective_default:
           type: string
@@ -3841,47 +3899,50 @@ components:
           default: HAIL
       type: object
       required:
-      - custom_sender_id
+        - custom_sender_id
       title: SenderIdResponse
     SmsCreate:
       properties:
         recipient_consent:
           type: boolean
           title: Recipient Consent
-          description: "Attestation that you have obtained the lawful consent required\
+          description:
+            "Attestation that you have obtained the lawful consent required\
             \ to contact this recipient. Hail does not verify consent itself \u2014\
             \ you are responsible for a lawful basis under TCPA/ePrivacy/PECR/CAN-SPAM/GDPR\
             \ as applicable. Rejected (422) if not true."
         consent_source:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Consent Source
-          description: Where/how consent was obtained (e.g. 'signup form', 'prior
+          description:
+            Where/how consent was obtained (e.g. 'signup form', 'prior
             customer relationship'). Required (non-empty) when message_type is 'marketing'.
         consent_obtained_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Consent Obtained At
           description: When consent was obtained, if known.
         message_type:
           type: string
           enum:
-          - marketing
-          - informational
+            - marketing
+            - informational
           title: Message Type
-          description: '''marketing'' additionally requires a non-empty consent_source.
-            Use ''informational'' for transactional/service communications.'
+          description:
+            "'marketing' additionally requires a non-empty consent_source.
+            Use 'informational' for transactional/service communications."
           default: informational
         to:
           type: string
           title: To
         from:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: From
         body:
           type: string
@@ -3895,25 +3956,25 @@ components:
       additionalProperties: false
       type: object
       required:
-      - recipient_consent
-      - to
-      - body
+        - recipient_consent
+        - to
+        - body
       title: SmsCreate
     SmsListResponse:
       properties:
         items:
           items:
-            $ref: '#/components/schemas/SmsResponse'
+            $ref: "#/components/schemas/SmsResponse"
           type: array
           title: Items
         next_cursor:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Next Cursor
       type: object
       required:
-      - items
+        - items
       title: SmsListResponse
     SmsResponse:
       properties:
@@ -3934,34 +3995,34 @@ components:
         direction:
           type: string
           enum:
-          - outbound
-          - inbound
+            - outbound
+            - inbound
           title: Direction
         status:
           type: string
           enum:
-          - queued
-          - sent
-          - delivered
-          - failed
-          - undelivered
-          - received
+            - queued
+            - sent
+            - delivered
+            - failed
+            - undelivered
+            - received
           title: Status
         body:
           type: string
           title: Body
         provider_message_sid:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Provider Message Sid
         segment_count:
           type: integer
           title: Segment Count
         error_code:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Error Code
         requested_at:
           type: string
@@ -3969,40 +4030,40 @@ components:
           title: Requested At
         sent_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Sent At
       type: object
       required:
-      - id
-      - organization_id
-      - from_e164
-      - to_e164
-      - direction
-      - status
-      - body
-      - provider_message_sid
-      - segment_count
-      - error_code
-      - requested_at
-      - sent_at
+        - id
+        - organization_id
+        - from_e164
+        - to_e164
+        - direction
+        - status
+        - body
+        - provider_message_sid
+        - segment_count
+        - error_code
+        - requested_at
+        - sent_at
       title: SmsResponse
     SuppressionListResponse:
       properties:
         items:
           items:
-            $ref: '#/components/schemas/SuppressionResponse'
+            $ref: "#/components/schemas/SuppressionResponse"
           type: array
           title: Items
         next_cursor:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Next Cursor
       type: object
       required:
-      - items
+        - items
       title: SuppressionListResponse
     SuppressionResponse:
       properties:
@@ -4028,20 +4089,20 @@ components:
           title: Created At
       type: object
       required:
-      - id
-      - recipient
-      - channel
-      - reason
-      - source
-      - created_at
+        - id
+        - recipient
+        - channel
+        - reason
+        - source
+        - created_at
       title: SuppressionResponse
     ValidationError:
       properties:
         loc:
           items:
             anyOf:
-            - type: string
-            - type: integer
+              - type: string
+              - type: integer
           type: array
           title: Location
         msg:
@@ -4057,9 +4118,9 @@ components:
           title: Context
       type: object
       required:
-      - loc
-      - msg
-      - type
+        - loc
+        - msg
+        - type
       title: ValidationError
     VoiceConfig:
       properties:
@@ -4080,55 +4141,56 @@ components:
           default: livekit
         voice_id:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Voice Id
         language:
           anyOf:
-          - type: string
-            enum:
-            - ar
-            - bg
-            - bn
-            - cs
-            - da
-            - de
-            - el
-            - en
-            - es
-            - fi
-            - fr
-            - gu
-            - he
-            - hi
-            - hr
-            - hu
-            - id
-            - it
-            - ja
-            - kn
-            - ko
-            - mr
-            - ms
-            - nl
-            - 'no'
-            - pl
-            - pt
-            - ro
-            - ru
-            - sk
-            - sv
-            - ta
-            - te
-            - th
-            - tl
-            - tr
-            - uk
-            - vi
-            - zh
-          - type: 'null'
+            - type: string
+              enum:
+                - ar
+                - bg
+                - bn
+                - cs
+                - da
+                - de
+                - el
+                - en
+                - es
+                - fi
+                - fr
+                - gu
+                - he
+                - hi
+                - hr
+                - hu
+                - id
+                - it
+                - ja
+                - kn
+                - ko
+                - mr
+                - ms
+                - nl
+                - "no"
+                - pl
+                - pt
+                - ro
+                - ru
+                - sk
+                - sv
+                - ta
+                - te
+                - th
+                - tl
+                - tr
+                - uk
+                - vi
+                - zh
+            - type: "null"
           title: Language
-          description: "Spoken language for the call as a lowercase ISO 639-1 code\
+          description:
+            "Spoken language for the call as a lowercase ISO 639-1 code\
             \ (e.g. 'da'). One of the 39 supported codes \u2014 see docs/languages.md.\
             \ Applied to STT, TTS, and turn detection. Omitted: the providers' defaults\
             \ (English)."
@@ -4139,17 +4201,17 @@ components:
       properties:
         items:
           items:
-            $ref: '#/components/schemas/WebhookDeliveryResponse'
+            $ref: "#/components/schemas/WebhookDeliveryResponse"
           type: array
           title: Items
         next_cursor:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Next Cursor
       type: object
       required:
-      - items
+        - items
       title: WebhookDeliveryListResponse
     WebhookDeliveryResponse:
       properties:
@@ -4159,15 +4221,15 @@ components:
           title: Id
         subscription_id:
           anyOf:
-          - type: string
-            format: uuid
-          - type: 'null'
+            - type: string
+              format: uuid
+            - type: "null"
           title: Subscription Id
         email_domain_id:
           anyOf:
-          - type: string
-            format: uuid
-          - type: 'null'
+            - type: string
+              format: uuid
+            - type: "null"
           title: Email Domain Id
         event_type:
           type: string
@@ -4182,20 +4244,20 @@ components:
         status:
           type: string
           enum:
-          - pending
-          - succeeded
-          - failed
-          - dead
+            - pending
+            - succeeded
+            - failed
+            - dead
           title: Status
         response_status:
           anyOf:
-          - type: integer
-          - type: 'null'
+            - type: integer
+            - type: "null"
           title: Response Status
         response_body:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Response Body
         next_attempt_at:
           type: string
@@ -4203,9 +4265,9 @@ components:
           title: Next Attempt At
         succeeded_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Succeeded At
         created_at:
           type: string
@@ -4213,15 +4275,15 @@ components:
           title: Created At
       type: object
       required:
-      - id
-      - subscription_id
-      - email_domain_id
-      - event_type
-      - event_id
-      - attempt
-      - status
-      - next_attempt_at
-      - created_at
+        - id
+        - subscription_id
+        - email_domain_id
+        - event_type
+        - event_id
+        - attempt
+        - status
+        - next_attempt_at
+        - created_at
       title: WebhookDeliveryResponse
     WebhookSubscriptionCreate:
       properties:
@@ -4233,60 +4295,6 @@ components:
           items:
             type: string
             enum:
-            - email.received
-            - email.delivered
-            - email.delivery_delayed
-            - email.bounced
-            - email.complained
-            - email.opened
-            - email.clicked
-            - email.received.suppressed
-            - email.send_failed
-            - sms.received
-            - sms.delivered
-            - sms.undelivered
-            - sms.failed
-            - call.answered
-            - call.completed
-            - call.failed
-            - call.busy
-            - call.no_answer
-          type: array
-          minItems: 1
-          title: Event Types
-      type: object
-      required:
-      - target_url
-      - event_types
-      title: WebhookSubscriptionCreate
-    WebhookSubscriptionListResponse:
-      properties:
-        items:
-          items:
-            $ref: '#/components/schemas/WebhookSubscriptionResponse'
-          type: array
-          title: Items
-        next_cursor:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Next Cursor
-      type: object
-      required:
-      - items
-      title: WebhookSubscriptionListResponse
-    WebhookSubscriptionPatch:
-      properties:
-        target_url:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Target Url
-        event_types:
-          anyOf:
-          - items:
-              type: string
-              enum:
               - email.received
               - email.delivered
               - email.delivery_delayed
@@ -4305,16 +4313,70 @@ components:
               - call.failed
               - call.busy
               - call.no_answer
-            type: array
-          - type: 'null'
+          type: array
+          minItems: 1
+          title: Event Types
+      type: object
+      required:
+        - target_url
+        - event_types
+      title: WebhookSubscriptionCreate
+    WebhookSubscriptionListResponse:
+      properties:
+        items:
+          items:
+            $ref: "#/components/schemas/WebhookSubscriptionResponse"
+          type: array
+          title: Items
+        next_cursor:
+          anyOf:
+            - type: string
+            - type: "null"
+          title: Next Cursor
+      type: object
+      required:
+        - items
+      title: WebhookSubscriptionListResponse
+    WebhookSubscriptionPatch:
+      properties:
+        target_url:
+          anyOf:
+            - type: string
+            - type: "null"
+          title: Target Url
+        event_types:
+          anyOf:
+            - items:
+                type: string
+                enum:
+                  - email.received
+                  - email.delivered
+                  - email.delivery_delayed
+                  - email.bounced
+                  - email.complained
+                  - email.opened
+                  - email.clicked
+                  - email.received.suppressed
+                  - email.send_failed
+                  - sms.received
+                  - sms.delivered
+                  - sms.undelivered
+                  - sms.failed
+                  - call.answered
+                  - call.completed
+                  - call.failed
+                  - call.busy
+                  - call.no_answer
+              type: array
+            - type: "null"
           title: Event Types
         status:
           anyOf:
-          - type: string
-            enum:
-            - active
-            - disabled
-          - type: 'null'
+            - type: string
+              enum:
+                - active
+                - disabled
+            - type: "null"
           title: Status
       type: object
       title: WebhookSubscriptionPatch
@@ -4339,23 +4401,23 @@ components:
         status:
           type: string
           enum:
-          - active
-          - disabled
+            - active
+            - disabled
           title: Status
         consecutive_failures:
           type: integer
           title: Consecutive Failures
         last_success_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Last Success At
         last_failure_at:
           anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+            - type: string
+              format: date-time
+            - type: "null"
           title: Last Failure At
         created_at:
           type: string
@@ -4367,23 +4429,63 @@ components:
           title: Updated At
         secret:
           anyOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           title: Secret
       type: object
       required:
-      - id
-      - organization_id
-      - target_url
-      - event_types
-      - status
-      - consecutive_failures
-      - created_at
-      - updated_at
+        - id
+        - organization_id
+        - target_url
+        - event_types
+        - status
+        - consecutive_failures
+        - created_at
+        - updated_at
       title: WebhookSubscriptionResponse
-      description: 'Subscription as returned by the API.
+      description: "Subscription as returned by the API.
 
 
         ``secret`` is populated **only** by create + rotate-secret responses;
 
-        later GETs return ``None`` so the plaintext never round-trips.'
+        later GETs return ``None`` so the plaintext never round-trips."
+    WhoamiResponse:
+      properties:
+        auth_kind:
+          type: string
+          enum:
+            - apikey
+            - jwt
+            - shared
+          title: Auth Kind
+        organization_id:
+          type: string
+          format: uuid
+          title: Organization Id
+        user_id:
+          anyOf:
+            - type: string
+              format: uuid
+            - type: "null"
+          title: User Id
+        email:
+          anyOf:
+            - type: string
+            - type: "null"
+          title: Email
+        name:
+          anyOf:
+            - type: string
+            - type: "null"
+          title: Name
+      type: object
+      required:
+        - auth_kind
+        - organization_id
+      title: WhoamiResponse
+      description:
+        "Who the caller is \u2014 the answer ``GET /whoami`` gives.\n\n\
+        ``user_id``/``email``/``name`` are ``None`` for shared-key\n(``HAIL_API_KEY``)\
+        \ callers: that key carries no human identity. An\nagent that wants to put\
+        \ the operator's address in ``Reply-To`` reads\n``email`` and skips the header\
+        \ when it is ``None``."

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -52,9 +52,13 @@ asyncio.run(main())
 
 ### Emails
 
-- `client.emails.create(*, to, subject, body_text=None, body_html=None, from_=None, cc=None, bcc=None, reply_to=None, conversation_id=None, metadata=None, idempotency_key=None)` — send an outbound email. At least one of `body_text` / `body_html` is required. `from_` is optional; when omitted the server picks a verified sender or auto-mints a hail-mail address (operator-configured). `idempotency_key` defaults to a fresh UUIDv4.
+- `client.emails.create(*, to, subject, body_text=None, body_html=None, from_=None, cc=None, bcc=None, reply_to=None, conversation_id=None, metadata=None, idempotency_key=None)` — send an outbound email. At least one of `body_text` / `body_html` is required. `from_` is optional while the org has one verified sender; with several the server returns 422 and you must name one (read `default_from` from `client.email_domains.list()`). With none it auto-mints a hail-mail address (operator-configured). `idempotency_key` defaults to a fresh UUIDv4.
 - `client.emails.get(email_id)` — fetch a single email.
 - `client.emails.list(*, cursor=None, limit=50, status=None)` — cursor-paginated org list.
+
+### Identity
+
+- `client.whoami()` — who the API key belongs to: `auth_kind`, `organization_id`, `user_id`, `email`, `name`. The user fields are `None` for a shared operator key. Use `email` as `reply_to` so replies reach the person, not the sending domain.
 
 ### Events
 

--- a/sdk/hail/__init__.py
+++ b/sdk/hail/__init__.py
@@ -55,9 +55,10 @@ from hail.models import (
     SmsResponse,
     SmsStatus,
     VoiceConfig,
+    WhoamiResponse,
 )
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"
 
 __all__ = [
     # helpers
@@ -110,6 +111,7 @@ __all__ = [
     "SmsResponse",
     "SmsStatus",
     "VoiceConfig",
+    "WhoamiResponse",
     "__version__",
     "parse_resource_id",
 ]

--- a/sdk/hail/client.py
+++ b/sdk/hail/client.py
@@ -60,6 +60,7 @@ from hail.models import (
     SmsResponse,
     SmsStatus,
     SuppressionListResponse,
+    WhoamiResponse,
 )
 
 _DEFAULT_BASE_URL = "https://api.hail.so"
@@ -312,9 +313,11 @@ class _EmailsResource:
 
         At least one of ``body_text`` / ``body_html`` is required; the
         server returns 422 if neither is supplied. ``recipient_consent``
-        is required — the server 422s without it. ``from_`` is optional:
-        when omitted the server picks the first verified sender on the
-        org or auto-mints a hail-mail address (operator-configured).
+        is required — the server 422s without it. ``from_`` is optional
+        while the org has one verified sender; with several the server
+        422s and you must name one (read ``default_from`` from
+        :meth:`Client.email_domains.list`). With none it auto-mints a
+        hail-mail address (operator-configured).
         ``idempotency_key`` defaults to a fresh UUIDv4.
         """
         # Build the body with the wire-side ``"from"`` alias. We don't
@@ -913,6 +916,17 @@ class Client:
         self.providers = _ProvidersResource(self._http)
         self.events = _EventsResource(self._http)
         self.base_url = resolved_base.rstrip("/")
+
+    async def whoami(self) -> WhoamiResponse:
+        """Identify the caller behind this API key.
+
+        Returns the organization plus the human the key belongs to.
+        ``user_id``/``email``/``name`` are ``None`` for a shared operator
+        key. Useful for addressing mail as that person — pass ``email``
+        as ``reply_to`` on :meth:`emails.create`.
+        """
+        data = await self._http.request("GET", "/whoami")
+        return WhoamiResponse.model_validate(data)
 
     async def aclose(self) -> None:
         await self._http.aclose()

--- a/sdk/hail/models.py
+++ b/sdk/hail/models.py
@@ -319,8 +319,9 @@ class EmailCreate(BaseModel):
     """Body shape for ``POST /emails``.
 
     At least one of ``body_text`` / ``body_html`` is required. ``to`` is a
-    non-empty list of recipient addresses. ``from_`` is optional; when
-    omitted the server picks a verified sender (or auto-mints a hail-mail
+    non-empty list of recipient addresses. ``from_`` is optional while the
+    org has one verified sender; with several the server 422s and the
+    caller must name one (or none at all, which auto-mints a hail-mail
     address per the operator's configuration). ``populate_by_name=True``
     so ``EmailCreate(from_="...")`` works at the Python boundary while
     ``model_dump(by_alias=True)`` still emits ``"from"`` on the wire.
@@ -632,6 +633,25 @@ class EmailDomainResponse(BaseModel):
 class EmailDomainListResponse(BaseModel):
     items: list[EmailDomainResponse]
     next_cursor: str | None = None
+    # The address a send with no ``from_`` goes out as. ``None`` when such
+    # a send would be rejected: several verified identities (name one), or
+    # none that can send yet. Whole-org answer, not per-page.
+    default_from: str | None = None
+
+
+class WhoamiResponse(BaseModel):
+    """Who the API key belongs to — the answer ``client.whoami()`` gives.
+
+    ``user_id``/``email``/``name`` are ``None`` when the caller is a
+    shared operator key (``auth_kind == "shared"``), which carries no
+    human identity.
+    """
+
+    auth_kind: Literal["apikey", "jwt", "shared"]
+    organization_id: UUID
+    user_id: UUID | None = None
+    email: str | None = None
+    name: str | None = None
 
 
 # --------------------------------------------------------------------------- #
@@ -716,4 +736,5 @@ __all__ = [
     "SuppressionListResponse",
     "SuppressionResponse",
     "VoiceConfig",
+    "WhoamiResponse",
 ]

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hail-sdk"
-version = "0.14.0"
+version = "0.15.0"
 description = "Python SDK for Hail — universal communication platform for AI agents."
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/sdk/tests/test_client.py
+++ b/sdk/tests/test_client.py
@@ -549,3 +549,48 @@ async def test_error_mapping_500(base_url: str, api_key: str) -> None:
     finally:
         await http.aclose()
     assert exc.value.status_code == 500
+
+
+@respx.mock
+async def test_whoami_returns_the_key_owner(base_url: str, api_key: str) -> None:
+    org_id = str(uuid4())
+    user_id = str(uuid4())
+    route = respx.get(f"{base_url}/whoami").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "auth_kind": "apikey",
+                "organization_id": org_id,
+                "user_id": user_id,
+                "email": "sarah@acme.test",
+                "name": "Sarah Chen",
+            },
+        )
+    )
+    async with Client(api_key=api_key, base_url=base_url) as c:
+        me = await c.whoami()
+    assert me.email == "sarah@acme.test"
+    assert str(me.organization_id) == org_id
+    assert str(me.user_id) == user_id
+    assert route.calls.last.request.url.path == "/whoami"
+
+
+@respx.mock
+async def test_whoami_shared_key_has_no_user(base_url: str, api_key: str) -> None:
+    respx.get(f"{base_url}/whoami").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "auth_kind": "shared",
+                "organization_id": str(uuid4()),
+                "user_id": None,
+                "email": None,
+                "name": None,
+            },
+        )
+    )
+    async with Client(api_key=api_key, base_url=base_url) as c:
+        me = await c.whoami()
+    assert me.auth_kind == "shared"
+    assert me.user_id is None
+    assert me.email is None

--- a/sdk/tests/test_email_domains.py
+++ b/sdk/tests/test_email_domains.py
@@ -279,3 +279,45 @@ def test_email_domain_response_inbound_fields_default_to_safe_values() -> None:
     assert dom.webhook_url is None
     assert dom.webhook_secret is None
     assert dom.forward_rate_per_hour is None
+
+
+@respx.mock
+async def test_email_domains_list_exposes_default_from(
+    base_url: str, api_key: str
+) -> None:
+    """The address a send with no ``from_`` uses, before sending anything."""
+    respx.get(f"{base_url}/email-domains").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "items": [make_email_domain_response(kind="custom", domain="acme.com")],
+                "next_cursor": None,
+                "default_from": "noreply@acme.com",
+            },
+        )
+    )
+    async with Client(api_key=api_key, base_url=base_url) as c:
+        resp = await c.email_domains.list()
+    assert resp.default_from == "noreply@acme.com"
+
+
+@respx.mock
+async def test_email_domains_list_default_from_null_when_ambiguous(
+    base_url: str, api_key: str
+) -> None:
+    respx.get(f"{base_url}/email-domains").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "items": [
+                    make_email_domain_response(kind="custom", domain="acme.com"),
+                    make_email_domain_response(kind="custom", domain="mail.acme.io"),
+                ],
+                "next_cursor": None,
+                "default_from": None,
+            },
+        )
+    )
+    async with Client(api_key=api_key, base_url=base_url) as c:
+        resp = await c.email_domains.list()
+    assert resp.default_from is None

--- a/uv.lock
+++ b/uv.lock
@@ -1009,7 +1009,7 @@ wheels = [
 
 [[package]]
 name = "hail-sdk"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "sdk" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Why

`POST /emails` with no `from` silently picked the oldest verified domain. That pick changes whenever a domain is added or deleted, so the sending identity of every `from`-less caller could move without anyone touching the caller. Agents also had no way to discover which addresses an org can send from, or who the human behind the session is.

## What changed

**Sender resolution — breaking**

- Two or more verified identities and no `from` → `422` listing every address the org can send from (`api/hailhq/api/routes/emails.py`). One identity, or none (which still auto-mints hail-mail), is unchanged.
- The voicebot's internal send route keeps the old oldest-verified pick (`allow_ambiguous=True`): a voice agent cannot name a domain mid-call, and the alternative was speaking "email isn't set up" to the caller.

**Discovery**

- `GET /email-domains` gains `default_from` — the address a `from`-less send goes out as, `null` when the caller must choose, and the un-minted `@mail.hail.so` address when the org owns no rows (previously unknowable until the first send).
- New `list_email_domains` MCP tool.

**whoami**

- New `GET /whoami` → `auth_kind`, `organization_id`, `user_id`, `email`, `name`. The user fields are `null` for a shared operator key.
- Exposed as `client.whoami()` (SDK), `hail whoami` (CLI), and the `whoami` MCP tool. An agent reads `email` and passes it as `reply_to`, so replies reach the person rather than an unattended `noreply@`.

Shared formatting moved to `core/hailhq/core/email_sender.py` so the address shown by `default_from` cannot drift from the address a send actually uses.

## Breaking change

Any org with 2+ verified identities that sends without `from` starts getting 422s. Callers must pass `from` (read `default_from` / `list_email_domains` to pick one).

## Tests

`api` 520, `core` 613, `voicebot` 170, `mcp` 93, `sdk` 110, Go CLI — all pass. `openapi.yaml` regenerated (semantic gate OK); the large diff there is the pre-commit prettier hook reformatting the whole file.