### PR TITLE
chore(release): stop hand-tagging v<semver>, guard the CLI release

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -65,6 +65,29 @@ jobs:
             exit 1
           fi
 
+      # GoReleaser publishes the release page under the prefix-stripped name,
+      # so `cli-v0.20.0` creates (or reuses) a release on tag `v0.20.0`. If
+      # that tag already exists on the remote at another commit — someone
+      # tagged a repo release by hand — GitHub keeps the old tag and the
+      # binaries land on a page pointing at unrelated code. That shipped once
+      # on 2026-08-13. Fail here instead.
+      - name: Assert the stripped tag is free or already ours
+        env:
+          CURRENT: ${{ steps.tags.outputs.current }}
+        run: |
+          remote_sha=$(git ls-remote origin "refs/tags/${CURRENT}" | cut -f1)
+          if [ -z "${remote_sha}" ]; then
+            echo "${CURRENT} is free — GoReleaser will create it at HEAD"
+            exit 0
+          fi
+          peeled=$(git rev-parse "${remote_sha}^{}" 2>/dev/null || echo "${remote_sha}")
+          if [ "${peeled}" != "$(git rev-parse HEAD)" ]; then
+            echo "tag ${CURRENT} already exists on origin at ${peeled}, which is not HEAD." >&2
+            echo "GoReleaser would publish ${GITHUB_REF_NAME} binaries onto that commit's release page." >&2
+            echo "Delete the stray tag (refer to docs/public/self-host/operations.md) and re-run." >&2
+            exit 1
+          fi
+
       # GoReleaser's default changelog runs `git log <prev>..<current>` using
       # the prefix-stripped names from GORELEASER_{CURRENT,PREVIOUS}_TAG.
       # Those names don't exist as git refs (the real tags are `cli-v…`), so
@@ -72,8 +95,8 @@ jobs:
       # Lightweight tags created in this throwaway checkout never reach the
       # remote; they only need to satisfy GoReleaser's local git lookup.
       #
-      # `-f` is required because umbrella `v<semver>` tags can already exist
-      # (see docs/public/self-host/operations.md "Cutting an umbrella release") and would
+      # `-f` is required because a stray `v<semver>` tag can already exist in
+      # this checkout (refer to docs/public/self-host/operations.md) and would
       # collide with our mirror names. Force-replacing is safe because the
       # workflow never pushes tags back to origin.
       - name: Mirror prefix-stripped tags for GoReleaser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Hail are documented here. The format is based on [Keep a 
 
 ## [Unreleased]
 
+### Internal
+
+- Release tags: there is no umbrella `v<X.Y.Z>` tag any more. GoReleaser strips
+  the `cli-` prefix, so that name already belongs to the CLI's release page; a
+  hand-made one made `cli-v0.20.0` publish its binaries onto a page whose tag
+  pointed at older code. `release-cli.yml` now fails when the stripped tag
+  already exists on another commit, and the runbook documents the rule.
+
 ## [0.21.0] — 2026-08-13
 
 No more guessing which address your mail goes out as, and a `whoami` on every surface.

--- a/docs/public/self-host/operations.md
+++ b/docs/public/self-host/operations.md
@@ -16,7 +16,6 @@ This document is the single source of truth for how to develop, deploy, migrate,
 | Regenerate OpenAPI + Go client | refer to _Development → Regenerating OpenAPI_ below                                                                                  |
 | Publish SDK                    | tag `sdk-v<X.Y.Z>` and push (fires `release-sdk.yml`)                                                                                |
 | Publish CLI                    | tag `cli-v<X.Y.Z>` and push (fires `release-cli.yml`)                                                                                |
-| Cut umbrella release           | tag `v<X.Y.Z>` and push (no workflow; just a marker)                                                                                 |
 
 ## Local development
 
@@ -293,11 +292,17 @@ The migration `0001_initial.py` issues `CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 Tag conventions:
 
-| tag prefix     | what fires                               | what it produces                                                                                      |
-| -------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `sdk-v<X.Y.Z>` | `.github/workflows/release-sdk.yml`      | `hail-sdk` on PyPI (trusted publishing — no token)                                                    |
-| `cli-v<X.Y.Z>` | `.github/workflows/release-cli.yml`      | GoReleaser → multi-arch binaries on GitHub Releases + Homebrew formula push to `hail-hq/homebrew-tap` |
-| `v<X.Y.Z>`     | nothing — no workflow keys off bare `v*` | umbrella marker for "this is the v0.1.0 commit"                                                       |
+| tag prefix     | what fires                          | what it produces                                                                                                                                                |
+| -------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sdk-v<X.Y.Z>` | `.github/workflows/release-sdk.yml` | `hail-sdk` on PyPI (trusted publishing — no token)                                                                                                              |
+| `cli-v<X.Y.Z>` | `.github/workflows/release-cli.yml` | GoReleaser → multi-arch binaries on GitHub Releases + Homebrew formula push to `hail-hq/homebrew-tap`                                                           |
+| `v<X.Y.Z>`     | nothing directly                    | **owned by the CLI release.** GoReleaser strips the `cli-` prefix, so `cli-v<X.Y.Z>` publishes its release page under `v<X.Y.Z>`. Never tag `v<X.Y.Z>` by hand. |
+
+There is no umbrella release tag. `CHANGELOG.md` is the record of what each repo
+version contains; the merge commit is the pointer. A hand-made `v<X.Y.Z>` tag
+collides with the CLI's release namespace — it did once (2026-08-13), and the CLI
+release then published its binaries onto a page whose tag pointed at older code.
+`release-cli.yml` now fails loudly if that tag already exists somewhere else.
 
 Hail does **not** release the service images (`hail-api`, `hail-voicebot`, `hail-mcp`) as versioned artifacts. The deploy workflow (`.github/workflows/deploy.yml`) pushes `latest` and `sha-<commit>` tags to GHCR on each push to `main` — the production VM pulls these. Self-hosters build from source via `docker compose up`. Versioned image releases are on the v1.x list.
 
@@ -332,18 +337,28 @@ GoReleaser quirks to know:
 - OSS GoReleaser does not have the Pro `monorepo:` block. The workflow strips the `cli-` prefix into the `GORELEASER_CURRENT_TAG` / `GORELEASER_PREVIOUS_TAG` env vars. It also passes `--skip=validate`, so GoReleaser does not reject the env-var-overridden tag. The manual `git rev-parse` and `git diff --exit-code HEAD` steps before GoReleaser keep the validate checks that _do_ matter.
 - The snapshot version template is the literal `0.0.0-snapshot-{{ .ShortCommit }}` (not `incpatch`), because the repo carries non-semver tags like `sdk-v0.0.1` that confuse the parser.
 
-### Cutting an umbrella release
+### Cutting a repo release
+
+A repo release is a CHANGELOG section, not a tag. Only components carry tags.
 
 ```bash
-# 1. Update CHANGELOG.md
+# 1. Move CHANGELOG.md's [Unreleased] block under the new version heading
 # 2. Tick newly-shipped milestones in README.md
-# 3. Commit
-# 4. Tag (no prefix)
-git tag v0.2.0
-git push origin v0.2.0
-# 5. Optional: GitHub Release page from the tag
-gh release create v0.2.0 --repo hail-hq/hail --notes-file CHANGELOG.md
+# 3. Bump sdk/pyproject.toml + sdk/hail/__init__.py if the SDK ships, then `uv lock`
+# 4. Commit as `chore(release): <X.Y.Z> — <summary>`, merge to main
+# 5. Tag the components that actually changed
+git tag sdk-v0.15.0 cli-v0.20.0
+git push origin sdk-v0.15.0 cli-v0.20.0
 ```
+
+Do **not** tag a bare `v<X.Y.Z>`. That name belongs to the CLI release: GoReleaser
+strips the `cli-` prefix, so `cli-v0.20.0` publishes its page under `v0.20.0`. A
+hand-made `v<X.Y.Z>` makes the next CLI release upload its binaries onto whatever
+commit that tag already points at. `release-cli.yml` fails the release when it
+detects this.
+
+The CLI release page carries the CHANGELOG prose for the matching repo version, so
+edit its body after GoReleaser publishes.
 
 ## Conventions
 
@@ -353,7 +368,7 @@ gh release create v0.2.0 --repo hail-hq/hail --notes-file CHANGELOG.md
   - Internal monorepo: `hailhq.*` (PEP 420 implicit namespace; no `hailhq/__init__.py` at the namespace root).
   - External SDK: `hail` — published as `hail-sdk` on PyPI, imports as `import hail`. Standalone — does **not** depend on any `hailhq.*` package.
 - **Provider model IDs**: live only in `.env.example`; `Settings` fields default to empty strings. Do not set `Settings.<provider>_model = "literal"` — that is wrong.
-- **Tag prefix grammar**: `<package>-v<semver>` for component releases (`sdk-v…`, `cli-v…`); bare `v<semver>` for the umbrella.
+- **Tag prefix grammar**: `<package>-v<semver>` for component releases (`sdk-v…`, `cli-v…`). Bare `v<semver>` is not a tag anyone creates by hand — GoReleaser mints it from `cli-v<semver>`.
 - **No Opero references** in any committed file.
 
 ## Footguns (every one of these has bitten us)


### PR DESCRIPTION
## The bug

GoReleaser OSS has no `monorepo:` block (verified: `goreleaser check` rejects it with `field monorepo not found in type config.Project`). So `release-cli.yml` strips the `cli-` prefix and GoReleaser publishes the CLI's release page under the bare `v<X.Y.Z>` name.

The runbook separately told operators to tag `v<X.Y.Z>` by hand as an "umbrella marker" (`operations.md:19`). Same namespace, two owners.

It stayed invisible while the repo version and the CLI version moved together. On 2026-08-13 the repo cut 0.21.0 while the CLI cut 0.20.0. `cli-v0.20.0` therefore looked for a release on tag `v0.20.0`, found the umbrella tag from 2026-08-10 pointing at `604bcea`, and uploaded the new binaries onto that page.

## Fix

- **Guard.** `release-cli.yml` fails when the stripped tag already exists on origin at a commit other than HEAD, naming the stray tag. Verified both branches against the live remote: `v0.20.0` (at HEAD) passes, `v0.99.0` (absent) passes, `v0.19.0` (at `c824c7a`) fails.
- **Convention.** The umbrella tag is gone. A repo release is a CHANGELOG section plus component tags. `operations.md` now says bare `v<semver>` belongs to the CLI release and must never be created by hand.

## Already repaired outside this PR

- Deleted the stray `v0.21.0` tag.
- Re-pointed `v0.20.0` at `1bef8bf`, the commit its binaries were built from, and restored the release page with its original title, body, and all 5 assets. Re-downloaded `hail_0.20.0_darwin_arm64.tar.gz` and confirmed the SHA-256 still matches `checksums.txt`, so the published Homebrew formula stays valid.