### PR TITLE
docs: fix self-hosting setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,33 +9,65 @@
 
 Your agent needs to call a person to move an appointment. Hail connects to the telephone carrier and runs the voice pipeline — STT, TTS, turn detection. Your agent is the brain: point Hail at any OpenAI-compatible endpoint ([bring your own LLM](docs/public/byo-llm.md)), or let Hail's fallback chain (OpenAI → Gemini → Anthropic) do the talking. SMS and email work the same way — one MCP endpoint, one API key, one invoice.
 
-Self-hostable with `docker compose up`. Open source under AGPLv3.
+Self-hostable with Docker Compose; LiveKit Cloud and the communication
+providers remain external. Open source under AGPLv3.
 
 ![Animated terminal demo of hail tail streaming live call events](docs/assets/gifs/hail-tail-live-stream.gif)
 
-## Quick start
+## Self-host quick start
+
+Prerequisites: Git, Docker Engine, and Docker Compose v2. For a public
+production deployment you also need a domain, HTTPS, and a managed Postgres;
+start with the [VM deployment guide](docs/public/self-host/vm-deploy.md).
+
+The commands below run a local evaluation stack with bundled Postgres and
+MinIO. Voice calls additionally require LiveKit Cloud, Twilio, Deepgram,
+Cartesia, and at least one LLM provider. Email is optional and requires AWS SES.
 
 ```bash
 git clone https://github.com/hail-hq/hail
 cd hail
-cp .env.example .env   # add Twilio, LiveKit Cloud, Deepgram, Cartesia keys
-                       # + one of OpenAI / Gemini / Anthropic
-docker compose up
+cp .env.example .env
+
+# Generate a shared self-host key, then put it in .env as HAIL_API_KEY.
+printf 'hk_%s\n' "$(openssl rand -base64 32 | tr -d '/+=' | head -c 40)"
+
+# Edit .env and add the providers required for the channels you will use.
+docker compose -f docker-compose.yml -f docker-compose.local.yml \
+  run --rm api alembic upgrade head
+docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
+docker compose -f docker-compose.yml -f docker-compose.local.yml ps
+curl --fail http://localhost:8080/healthz
 ```
 
-Then get an API key:
+Self-host authentication uses the `HAIL_API_KEY` value from `.env`; it does not
+need an API-key row in Postgres. Export the same key and API URL in the shell
+where you use the CLI or SDK (Compose does not export `.env` into your shell):
+
+```bash
+export HAIL_API_URL=http://localhost:8080
+export HAIL_API_KEY='<same value as .env>'
+```
+
+Next, follow [LiveKit Cloud](docs/public/self-host/livekit-cloud.md) and
+[Twilio](docs/public/self-host/twilio.md), then bind a phone number to the
+self-host organization using the
+[first-run setup](docs/public/self-host/operations.md#self-host-first-run-setup).
+To enable email, follow [AWS SES](docs/public/self-host/aws-ses.md).
+
+Authentication differs by deployment:
 
 - **Hail Cloud** (managed, at [hail.so](https://hail.so)): run `hail login`. The device flow writes a key to `~/.hail/credentials.json`.
-- **Self-host**: seed a key into your database — see [operations.md, "Self-host: first-run setup"](docs/public/operations.md#self-host-first-run-setup) — then set `HAIL_API_KEY` or pass `--api-key`.
+- **Self-host**: do not run `hail login`; set `HAIL_API_URL` and `HAIL_API_KEY` as shown above, or pass `--api-url` and `--api-key`.
 
-Full setup guides: [Twilio](docs/public/setup/twilio.md) · [LiveKit Cloud](docs/public/setup/livekit-cloud.md) · [AWS SES](docs/public/setup/aws-ses.md) · [Webhooks](docs/public/setup/webhooks.md) · [MCP](docs/public/setup/mcp.md)
+Full setup guides: [self-hosting](docs/public/self-host/README.md) · [Webhooks](docs/public/webhooks.md) · [MCP](docs/public/mcp.md) · [operations](docs/public/self-host/operations.md)
 
 ## Make your first call
 
-**CLI** ([GitHub Releases](https://github.com/hail-hq/hail/releases)):
+**CLI** ([install a binary from GitHub Releases](https://github.com/hail-hq/hail/releases)):
 
 ```bash
-hail login                        # authenticate (device flow)
+hail login                        # Hail Cloud only (device flow)
 hail auth logout                  # remove local credentials
 hail auth token                   # print bare API key for scripting
 
@@ -102,10 +134,13 @@ asyncio.run(main())
 ```bash
 curl -X POST http://localhost:8080/calls \
   -H "Authorization: Bearer $HAIL_API_KEY" \
+  -H "Content-Type: application/json" \
   -d '{"to":"+15551234567","recipient_consent":true,"system_prompt":"..."}'
 ```
 
-**MCP** (Claude.ai, Claude Code, ChatGPT, Cursor, …): add a remote MCP connector pointing at `http://<your-host>:8081` (self-hosted). See [setup/mcp.md](docs/public/setup/mcp.md).
+**MCP** (Claude.ai, Claude Code, ChatGPT, Cursor, …): local clients can use
+`http://localhost:8081`. Web-based clients require a publicly reachable HTTPS
+endpoint. See the [MCP setup guide](docs/public/mcp.md).
 
 ## Bring your own LLM
 
@@ -121,7 +156,8 @@ Any OpenAI chat-completions-compatible endpoint works. A complete runnable examp
 1. **Clear comms.** Explicit OpenAPI contracts. No hidden behavior.
 2. **Simple code.** Boring is best. No abstraction before it has two uses.
 3. **Brief docs.** Each page fits on one screen. Setup takes 10 minutes from a fresh clone.
-4. **Self-hostable.** `docker compose up` runs everything except LiveKit Cloud.
+4. **Self-hostable.** Docker Compose runs Hail's API, voicebot, MCP server,
+   Postgres, and MinIO; LiveKit Cloud and channel providers remain external.
 5. **Pluggable brain.** [BYO LLM endpoint](docs/public/byo-llm.md), or Hail's bundled fallback. The voice pipeline and transport are always Hail's.
 6. **Agent-first docs.** AI agents are first-class readers. Runnable examples first; links to canonical sources, not paraphrase.
 
@@ -186,7 +222,7 @@ A checked box is a released feature. Per-artifact changelogs (GitHub Releases fo
   - [x] `hail` binary via GitHub Releases
 - MCP server
   - [x] Remote Streamable HTTP endpoint included with each Hail deployment
-  - ~~PyPI stdio package~~ — deliberately not shipped; see [setup/mcp.md](docs/public/setup/mcp.md)
+  - ~~PyPI stdio package~~ — deliberately not shipped; see [MCP setup](docs/public/mcp.md)
 - Python SDK
   - [x] `hail-sdk` on PyPI, imports as `hail`
 

--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -1,6 +1,6 @@
 # Hail documentation
 
-Hail is a universal communication platform for AI agents — outbound phone calls, SMS, and email behind one MCP endpoint, one API key, one invoice. Most people use [Hail Cloud](https://hail.so); the whole stack is also self-hostable (AGPLv3).
+Hail is a universal communication platform for AI agents — outbound phone calls, SMS, and email behind one MCP endpoint, one API key, one invoice. Most people use [Hail Cloud](https://hail.so); Hail's services are also self-hostable under AGPLv3, with LiveKit Cloud and channel providers remaining external.
 
 ## Using Hail Cloud
 

--- a/docs/public/architecture.md
+++ b/docs/public/architecture.md
@@ -103,7 +103,7 @@ If none of those resolve, the request returns `503` with instructions on how to 
 
 `GET /email-domains` answers the same question ahead of a send: its `default_from` field holds the address a `from`-less send would use, and is `null` when the caller must choose.
 
-Refer to [`docs/setup/aws-ses.md`](./self-host/aws-ses.md) for the operator-side setup. Refer to [`docs/superpowers/plans/2026-05-17-hail-mail-addressing.md`](https://github.com/hail-hq/hail/blob/main/docs/superpowers/plans/2026-05-17-hail-mail-addressing.md) for the addressing/configurability plan.
+Refer to [AWS SES setup](./self-host/aws-ses.md) for the operator-side setup. Refer to [`docs/superpowers/plans/2026-05-17-hail-mail-addressing.md`](https://github.com/hail-hq/hail/blob/main/docs/superpowers/plans/2026-05-17-hail-mail-addressing.md) for the addressing/configurability plan.
 
 ## Inbound email
 
@@ -134,7 +134,7 @@ inbound SMTP ──► SES Receipt Rule
 
 The cloud-agnostic SMTP path is a stub
 ([`SmtpInboundProvider`](https://github.com/hail-hq/hail/blob/main/core/hailhq/core/providers/email/inbound/smtp.py)).
-[`docs/setup/smtp-inbound.md`](./self-host/smtp-inbound.md) tracks it.
+[SMTP inbound](./self-host/smtp-inbound.md) tracks it.
 
 ### Per-domain routing — forward and/or webhook
 
@@ -149,4 +149,4 @@ A separate `inbound_routes` table, for per-mailbox routing in custom domains, is
 
 The `/webhooks` CRUD surface is the firehose pattern — one subscription covers multiple event types (`email.received`, `email.bounced`, `email.complained`). Signatures are Stripe-style: `X-Hail-Signature: t=<unix>,v1=<hex>`. Hail retries deliveries on a fixed `0/30s/2m/10m/1h/6h/24h` ladder. After the last retry, Hail marks the delivery `dead`. After 50 consecutive dead deliveries, the subscription auto-disables.
 
-Refer to [`docs/setup/aws-ses.md`](./self-host/aws-ses.md) §10 for the operator runbook. Refer to [`docs/superpowers/specs/2026-06-06-inbound-email-design.md`](https://github.com/hail-hq/hail/blob/main/docs/superpowers/specs/2026-06-06-inbound-email-design.md) for the full spec.
+Refer to [AWS SES setup](./self-host/aws-ses.md) §10 for the operator runbook. Refer to [`docs/superpowers/specs/2026-06-06-inbound-email-design.md`](https://github.com/hail-hq/hail/blob/main/docs/superpowers/specs/2026-06-06-inbound-email-design.md) for the full spec.

--- a/docs/public/self-host/README.md
+++ b/docs/public/self-host/README.md
@@ -1,15 +1,42 @@
 # Self-hosting
 
-Run the whole Hail stack yourself. The code is AGPLv3; the stack is three Python services, a Go CLI, and Postgres. Provision the three external providers below, put the credentials in `.env`, and `docker compose up` does the rest.
+Run Hail's API, voicebot, MCP server, Postgres, and object storage with Docker
+Compose. LiveKit Cloud and the providers for the channels you enable remain
+external. The code is AGPLv3.
+
+## Local evaluation
+
+Prerequisites: Git, Docker Engine, and Docker Compose v2.
+
+```bash
+git clone https://github.com/hail-hq/hail
+cd hail
+cp .env.example .env
+
+# Generate a key and put it in .env as HAIL_API_KEY.
+printf 'hk_%s\n' "$(openssl rand -base64 32 | tr -d '/+=' | head -c 40)"
+
+docker compose -f docker-compose.yml -f docker-compose.local.yml \
+  run --rm api alembic upgrade head
+docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
+curl --fail http://localhost:8080/healthz
+```
+
+The local overlay supplies Postgres. Plain `docker compose up` is only for a
+managed database after `DATABASE_URL` has been changed from its bundled
+`postgres` default. Compose reads `.env` for containers but does not export it
+to your shell; set `HAIL_API_URL` and `HAIL_API_KEY` before using the CLI or SDK.
 
 ## Order
 
-1. **[VM deployment](./vm-deploy.md)** — run the full stack on one Ubuntu VM behind HTTPS. GitHub Actions deploys each commit on `main` automatically.
-2. **[LiveKit Cloud](./livekit-cloud.md)** — media (SIP bridge + WebRTC). This is necessary before the voicebot can join calls.
-3. **[Twilio](./twilio.md)** — phone numbers, SMS, and the SIP trunk. Put the Origination URI from LiveKit in the Twilio trunk configuration.
-4. **[AWS SES](./aws-ses.md)** — outbound and inbound email. This is independent of the voice setup. You need it only if you send or receive mail. To receive without AWS, refer to [SMTP inbound](./smtp-inbound.md).
+1. **[Operations](./operations.md#deployment-self-host)** — required credentials, migrations, authentication, phone-number binding, and troubleshooting.
+2. **[LiveKit Cloud](./livekit-cloud.md)** — required media and SIP bridge for voice calls.
+3. **[Twilio](./twilio.md)** — required phone numbers and SIP trunk for voice/SMS.
+4. **[AWS SES](./aws-ses.md)** — optional outbound/inbound email. To receive without AWS, see [SMTP inbound](./smtp-inbound.md).
+5. **[VM deployment](./vm-deploy.md)** — production deployment on Ubuntu with managed Postgres and HTTPS.
 
-Then connect your agent the same way cloud users do: [MCP clients](../mcp.md) — the self-host URL is `http://<your-host>:8081`.
+Local MCP clients use `http://localhost:8081`. Web-based clients need a public
+HTTPS endpoint; see [MCP clients](../mcp.md#self-host).
 
 ## Day 2
 

--- a/docs/public/self-host/aws-ses.md
+++ b/docs/public/self-host/aws-ses.md
@@ -217,7 +217,7 @@ Hail garbage-collects unused uploads (not attached to any send) 24 hours after u
 Skip these until later milestones. This list names them so that you do not use SES features that are not wired yet:
 
 - **Templates** — the API takes raw `body_text` / `body_html`. SES templates are a v2 request.
-- **Cloud-agnostic inbound** — the SMTP listener is stubbed at [`docs/setup/smtp-inbound.md`](./smtp-inbound.md); inbound currently runs on AWS only.
+- **Cloud-agnostic inbound** — the SMTP listener is described in [SMTP inbound](./smtp-inbound.md); inbound currently runs on AWS only.
 
 ## 10. Inbound email
 
@@ -250,7 +250,7 @@ terragrunt apply
 Do a one-time bootstrap per AWS account before the first `terragrunt init`:
 the state bucket + lock table do not auto-create. Refer to the comment block
 at the top of [`infra/terragrunt.hcl`](https://github.com/hail-hq/hail/blob/main/infra/terragrunt.hcl) for
-the AWS CLI one-liners. Refer to [`docs/operations.md`](./operations.md) →
+the AWS CLI one-liners. Refer to [operations](./operations.md) →
 "Inbound email rollout → Stage 4" for the full sequence.
 
 Outputs:

--- a/docs/public/self-host/livekit-cloud.md
+++ b/docs/public/self-host/livekit-cloud.md
@@ -11,14 +11,36 @@ LiveKit Cloud supplies the media (SIP bridge + WebRTC) in v1. A self-hosted SFU 
    - `LIVEKIT_API_KEY`
    - `LIVEKIT_API_SECRET`
 
-## 2. SIP inbound trunk
+## 2. SIP outbound trunk
 
-1. **SIP → Inbound Trunks → Create**.
-2. Allow calls from your Twilio SIP trunk. Use the IP/user auth that matches your Twilio configuration.
-3. Add a **Dispatch Rule** that routes incoming calls to a per-call `individual` room.
+First create the Twilio trunk and credentials in the [Twilio guide](./twilio.md).
+Then, in LiveKit Cloud:
+
+1. Open **Telephony → SIP trunks → Create new trunk**.
+2. Select **Outbound** and use the Twilio termination domain
+   (`<name>.pstn.twilio.com`) as the address.
+3. Add the Twilio number in E.164 format and enter the same username/password
+   configured on the Twilio trunk.
+4. Create the trunk and copy its ID into `.env` as
+   `LIVEKIT_SIP_OUTBOUND_TRUNK_ID`.
+
+Hail passes this ID to LiveKit for every outbound call. It does not read a
+Twilio trunk-domain environment variable. See LiveKit's
+[outbound trunk reference](https://docs.livekit.io/telephony/making-calls/outbound-trunk/)
+for the current UI and JSON forms.
+
+`LIVEKIT_SIP_INBOUND_TRUNK_ID` is reserved for a future inbound-calling
+release and can remain empty today.
 
 ## 3. Voicebot worker
 
-Run `docker compose up voicebot`. At startup, the worker registers with LiveKit as a dispatchable agent. The Hail API dispatches it into a room for each call.
+With the local Compose overlay, run:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.local.yml up -d voicebot
+```
+
+At startup, the worker registers with LiveKit as a dispatchable agent. The
+Hail API dispatches it into a room for each call.
 
 For the full flow, refer to [Architecture](../architecture.md).

--- a/docs/public/self-host/operations.md
+++ b/docs/public/self-host/operations.md
@@ -4,18 +4,18 @@ This document is the single source of truth for how to develop, deploy, migrate,
 
 ## Quick reference
 
-| task                           | command                                                                                                                              |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| Bring up stack (bundled DB)    | `docker compose -f docker-compose.yml -f docker-compose.local.yml up -d`                                                             |
-| Bring up stack (managed DB)    | `docker compose up -d`                                                                                                               |
-| Bring up stack (prod VM)       | `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d` — pulls images from GHCR; refer to `docs/setup/vm-deploy.md` |
-| Tail one service               | `docker compose logs -f <api\|voicebot\|mcp\|postgres>`                                                                              |
-| Run all tests                  | `cd <core\|api\|voicebot\|mcp\|sdk> && uv run pytest` (per suite, **from each dir**)                                                 |
-| Lint                           | `uvx ruff check .` then `uvx black --check .` (repo root)                                                                            |
-| Apply DB migrations            | `docker compose run --rm api alembic upgrade head`                                                                                   |
-| Regenerate OpenAPI + Go client | refer to _Development → Regenerating OpenAPI_ below                                                                                  |
-| Publish SDK                    | tag `sdk-v<X.Y.Z>` and push (fires `release-sdk.yml`)                                                                                |
-| Publish CLI                    | tag `cli-v<X.Y.Z>` and push (fires `release-cli.yml`)                                                                                |
+| task                           | command                                                                                                                                   |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Bring up stack (bundled DB)    | `docker compose -f docker-compose.yml -f docker-compose.local.yml up -d`                                                                  |
+| Bring up stack (managed DB)    | `docker compose up -d`                                                                                                                    |
+| Bring up stack (prod VM)       | `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d` — pulls images from GHCR; refer to the [VM guide](./vm-deploy.md) |
+| Tail one service               | `docker compose logs -f <api\|voicebot\|mcp\|postgres>`                                                                                   |
+| Run all tests                  | `cd <core\|api\|voicebot\|mcp\|sdk> && uv run pytest` (per suite, **from each dir**)                                                      |
+| Lint                           | `uvx ruff check .` then `uvx black --check .` (repo root)                                                                                 |
+| Apply DB migrations            | `docker compose run --rm api alembic upgrade head`                                                                                        |
+| Regenerate OpenAPI + Go client | refer to _Development → Regenerating OpenAPI_ below                                                                                       |
+| Publish SDK                    | tag `sdk-v<X.Y.Z>` and push (fires `release-sdk.yml`)                                                                                     |
+| Publish CLI                    | tag `cli-v<X.Y.Z>` and push (fires `release-cli.yml`)                                                                                     |
 
 ## Local development
 
@@ -28,7 +28,7 @@ docker compose \
   -f docker-compose.yml -f docker-compose.local.yml \
   up -d                                                    # postgres + minio + api + voicebot + mcp
 docker compose run --rm api alembic upgrade head           # apply schema
-# seed an org + api_key + phone_number (see Deployment → DB seed below)
+# bind a phone number to the self-host sentinel (see first-run setup below)
 ```
 
 ### Per-service dev loops (host-side, no Docker)
@@ -105,7 +105,10 @@ Put new adapters under `core/hailhq/core/providers/<channel>/<name>.py`. Each ad
 - **ElevenLabs** (fallback TTS, optional): API key + a voice ID. If `ELEVEN_API_KEY` is set, the system uses it automatically when Cartesia fails.
 - **At least one LLM provider**: OpenAI / Gemini / Anthropic API key. The voicebot's mode-A FallbackAdapter chains all three. Mode-B uses a caller-provided OpenAI-compatible endpoint for each call.
 
-For detailed setup walkthroughs, refer to `docs/setup/twilio.md`, `docs/setup/livekit-cloud.md`, and `docs/setup/mcp.md`. To run the whole stack on a single Ubuntu VM with HTTPS + auto-deploy from `main`, refer to `docs/setup/vm-deploy.md`.
+For detailed setup walkthroughs, see [Twilio](./twilio.md),
+[LiveKit Cloud](./livekit-cloud.md), and [MCP](../mcp.md). To run the stack on a
+single Ubuntu VM with HTTPS and automatic deployment from `main`, see the
+[VM deployment guide](./vm-deploy.md).
 
 ### Authentication
 
@@ -126,7 +129,8 @@ A managed-cloud user with no `member` row gets a **403 "user not provisioned"**,
 # 1) Generate a shared API key — used for BOTH directions:
 #    inbound (API checks bearer) + outbound (CLI/MCP/voicebot send it).
 HAIL_API_KEY="hk_$(openssl rand -base64 32 | tr -d '/+=' | head -c 40)"
-echo "HAIL_API_KEY=$HAIL_API_KEY" >> hail/.env
+printf '%s\n' "$HAIL_API_KEY"
+# Replace the blank HAIL_API_KEY= line in .env with this value.
 
 # 2) Add a phone number bound to the self-host sentinel org id.
 export TWILIO_E164='+1XXXXXXXXXX' TWILIO_PN_SID='PNxxxxxxxxxxxxxxxx'

--- a/docs/public/self-host/smtp-inbound.md
+++ b/docs/public/self-host/smtp-inbound.md
@@ -14,7 +14,7 @@ When it is released, this page will describe:
 - self-host quickstart
 
 Until then, use the SES-backed inbound path documented in
-[`docs/setup/aws-ses.md`](./aws-ses.md). If you must avoid AWS, file an
+[AWS SES](./aws-ses.md). If you must avoid AWS, file an
 issue that tracks your need. Then we can give the SMTP listener priority.
 
 ## References

--- a/docs/public/self-host/twilio.md
+++ b/docs/public/self-host/twilio.md
@@ -18,9 +18,22 @@ Go to **Phone Numbers → Buy a number**. Select a number with the Voice capabil
 ## 3. SIP trunk
 
 1. **Elastic SIP Trunking → Trunks → Create new Trunk**.
-2. **Origination**: add the URI from [LiveKit Cloud setup](./livekit-cloud.md).
-3. **Numbers**: attach the phone number from step 2.
-4. Put the Termination URI (for example, `your-trunk.pstn.twilio.com`) in `.env` as `TWILIO_SIP_TRUNK_DOMAIN`.
+2. Under **Termination**, choose a unique termination domain such as
+   `your-trunk.pstn.twilio.com`.
+3. Add a credential list with a SIP username and password. LiveKit's outbound
+   trunk must use the same credentials.
+4. Under **Numbers**, attach the phone number from step 2.
+5. Continue with [LiveKit Cloud setup](./livekit-cloud.md), using the Twilio
+   termination domain and credentials to create a LiveKit outbound trunk.
+
+Do not add the termination domain to Hail's `.env`: Hail uses the resulting
+LiveKit trunk ID (`LIVEKIT_SIP_OUTBOUND_TRUNK_ID`) at runtime. Twilio calls
+traffic from LiveKit to the PSTN “termination.” Its “origination” settings are
+for inbound PSTN calls, which Hail does not yet support.
+
+Twilio requires outbound destinations and caller IDs in E.164 format. Trial
+accounts can call only verified destination numbers. See Twilio's
+[Elastic SIP Trunking reference](https://www.twilio.com/docs/sip-trunking).
 
 ## 4. Outbound SMS
 

--- a/docs/public/self-host/vm-deploy.md
+++ b/docs/public/self-host/vm-deploy.md
@@ -83,7 +83,7 @@ cp .env.example .env
 
 Edit `/opt/hail/.env` and fill in:
 
-- All provider secrets (Twilio, LiveKit, Deepgram, Cartesia (+ optional ElevenLabs fallback), at least one LLM key — refer to `docs/setup/`).
+- All provider secrets (Twilio, LiveKit, Deepgram, Cartesia, optional ElevenLabs fallback, and at least one LLM key); see [Twilio](./twilio.md) and [LiveKit Cloud](./livekit-cloud.md).
 - `HAIL_API_KEY` — generate with `openssl rand -base64 32 | tr -d '/+=' | head -c 40 | sed 's/^/hk_/'`.
 - `DATABASE_URL` — the managed Postgres connection string. Most providers require `?sslmode=require`.
 - `HAIL_DOMAIN` — your apex (for example, `hail.example.com`). Both `api.` and `mcp.` subdomains derive from it.
@@ -112,7 +112,7 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml ps
 
 To skip the manual GHCR login, trigger the GitHub Actions workflow (step 6) first. Its `docker login` step writes credentials that the VM can use again.
 
-Seed your first phone number with the snippet in `docs/operations.md` → _Self-host: first-run setup_. Replace `docker compose exec postgres …` with `psql "$DATABASE_URL" -c …`.
+Bind your first phone number using [Self-host: first-run setup](./operations.md#self-host-first-run-setup). Because this deployment uses managed Postgres, replace `docker compose exec postgres …` with `psql "$DATABASE_URL" -c …`.
 
 Send a request to `https://api.<domain>/healthz` from your laptop. You must see `{"status":"ok"}`. Caddy gets a Let's Encrypt cert on the first request. The first call after boot can take 10–20 seconds.
 


### PR DESCRIPTION
## Summary

- replace the broken bare `docker compose up` quick start with the bundled-Postgres overlay and explicit migrations
- correct self-host authentication, CLI environment, HTTP, MCP, and first-run guidance
- align Twilio and LiveKit SIP setup with the runtime `LIVEKIT_SIP_OUTBOUND_TRUNK_ID` contract
- repair stale links and clarify local versus production self-hosting boundaries

## Validation

- `pnpm docs:check-urls`
- Prettier checks for all edited Markdown
- `docker compose -f docker-compose.yml -f docker-compose.local.yml config --services`
- `git diff --check`

A live container boot was not run because the local Docker daemon was unavailable.