### PR TITLE
fix(voicebot): merge disclosure and first_message into one spoken turn

### DIFF
--- a/voicebot/hailhq/voicebot/agent.py
+++ b/voicebot/hailhq/voicebot/agent.py
@@ -424,10 +424,15 @@ async def speak_greeting(
     ``ai_disclosure`` default is ``True`` so a dispatch that predates the
     field (rolling deploy) keeps the disclosure.
 
-    A caller ``first_message`` is spoken verbatim. Without one, the LLM
-    generates the opening (see :func:`opening_instructions`) so the call
-    never opens in dead air — including with ``ai_disclosure: false``.
-    Call this right after ``session.start()``.
+    A caller ``first_message`` is spoken verbatim, concatenated onto the
+    disclosure as a single ``session.say()`` call — one spoken turn, not
+    two back-to-back utterances that sound like the agent introducing
+    itself twice. Without a ``first_message``, the LLM generates the
+    opening (see :func:`opening_instructions`) so the call never opens in
+    dead air — including with ``ai_disclosure: false``; that path stays a
+    separate turn since a generated reply's text isn't known until the
+    model produces it, so it can't be joined into the literal disclosure
+    string. Call this right after ``session.start()``.
 
     ``generate_opening=False`` skips that generated turn. It exists for
     the deferred IVR path (:func:`arm_deferred_greeting`), where the
@@ -436,13 +441,19 @@ async def speak_greeting(
     opening would race it and its "they have not said anything yet"
     premise would be false.
     """
-    if metadata.get("ai_disclosure", True):
-        await session.say(
-            disclosure_line(metadata.get("org_name")), allow_interruptions=True
-        )
-    if metadata.get("first_message"):
-        await session.say(metadata["first_message"], allow_interruptions=True)
-    elif generate_opening:
+    disclosure = (
+        disclosure_line(metadata.get("org_name"))
+        if metadata.get("ai_disclosure", True)
+        else None
+    )
+    first_message = metadata.get("first_message")
+    if first_message:
+        greeting = f"{disclosure} {first_message}" if disclosure else first_message
+        await session.say(greeting, allow_interruptions=True)
+        return
+    if disclosure:
+        await session.say(disclosure, allow_interruptions=True)
+    if generate_opening:
         session.generate_reply(instructions=opening_instructions(pickup_transcript))
 
 

--- a/voicebot/tests/test_agent.py
+++ b/voicebot/tests/test_agent.py
@@ -1023,17 +1023,15 @@ async def test_on_call_end_no_override_defaults_to_normal_hangup(
 
 
 async def test_speak_greeting_speaks_disclosure_before_first_message() -> None:
-    """The disclosure is always spoken, and always before ``first_message``."""
+    """The disclosure and ``first_message`` are spoken as one turn, disclosure
+    leading."""
     session = FakeAnnouncingSession()
 
     await speak_greeting(session, {"first_message": "Hi, calling about your order."})
 
-    assert len(session.say_calls) == 2
-    first_text, first_allow_interruptions = session.say_calls[0]
-    second_text, _ = session.say_calls[1]
-    assert first_text == AI_DISCLOSURE_LINE
-    assert first_allow_interruptions is True
-    assert second_text == "Hi, calling about your order."
+    assert session.say_calls == [
+        (f"{AI_DISCLOSURE_LINE} Hi, calling about your order.", True)
+    ]
 
 
 async def test_speak_greeting_skips_disclosure_when_opted_out() -> None:
@@ -1214,8 +1212,10 @@ async def test_speak_greeting_first_message_cannot_precede_disclosure() -> None:
         session, {"first_message": AI_DISCLOSURE_LINE + " (impersonated)"}
     )
 
-    assert session.say_calls[0] == (AI_DISCLOSURE_LINE, True)
-    assert session.say_calls[0] != session.say_calls[1]
+    assert len(session.say_calls) == 1
+    text, allow_interruptions = session.say_calls[0]
+    assert text.startswith(AI_DISCLOSURE_LINE)
+    assert allow_interruptions is True
 
 
 async def test_speak_greeting_names_the_org_when_dispatch_metadata_has_it() -> None:


### PR DESCRIPTION
## Summary
- `speak_greeting()` spoke the AI disclosure and a caller's `first_message` as two separate `session.say()` calls, which played as two back-to-back introductions on the call.
- Concatenates them into a single `session.say()` call — one spoken turn. Disclosure still always leads and stays literal/non-customizable; only the pure string concatenation changed.
- The no-`first_message` path (LLM-generated opening) is unchanged — stays two turns since the generated text isn't known until the model produces it.

## Test plan
- [x] `uv run pytest tests/test_agent.py -q` — 66 passed
- [x] `uv run ruff check` / `ruff format --check` on changed files