### PR TITLE
Agent-readiness: /v1 versioning, rate limits, OpenAPI descriptions, MCP discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -225,6 +225,10 @@ AGENT_GLOBAL_EMAIL_PER_HOUR=200
 AGENT_GLOBAL_SMS_PER_HOUR=30
 AGENT_GLOBAL_VOICE_PER_HOUR=15
 
+# General per-caller HTTP request-rate ceiling (api/hailhq/api/ratelimit.py).
+# 300/min = 5 req/sec sustained per caller.
+API_RATE_LIMIT_PER_MINUTE=300
+
 # ─── Call recordings (S3-compatible — MinIO in dev) ──────────────────────────
 
 S3_ENDPOINT=http://minio:9000

--- a/api/hailhq/api/deprecation.py
+++ b/api/hailhq/api/deprecation.py
@@ -1,0 +1,38 @@
+"""Marks legacy (unprefixed) customer-API responses as deprecated.
+
+/v1/<resource> is canonical (see main.py's router dual-mount). The
+unprefixed path keeps working — no existing integration breaks — but
+every response on it carries a Deprecation: true header (the widely
+deployed form; RFC 9745 is the current authority for this header) plus a
+Link pointing at the /v1 successor, so a client (or an agent reading the
+response) can tell the path is being phased out without guessing.
+
+Matches on path shape, not a route allowlist: any request whose path does
+NOT start with /v1/ and does NOT start with /internal/ is presumed to be
+hitting a legacy-mounted customer route. /healthz and unmatched 404s also
+pass through this middleware harmlessly (a Deprecation header on a 404 or
+a healthcheck is inert, not incorrect) — this stays simple rather than
+duplicating the router list here too.
+"""
+
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+_V1_PREFIX = "/v1/"
+_INTERNAL_PREFIX = "/internal/"
+
+
+class DeprecationHeaderMiddleware(BaseHTTPMiddleware):
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        response = await call_next(request)
+        path = request.url.path
+        if not path.startswith(_V1_PREFIX) and not path.startswith(_INTERNAL_PREFIX):
+            response.headers["Deprecation"] = "true"
+            versioned = "/v1" + path
+            response.headers["Link"] = f'<{versioned}>; rel="successor-version"'
+        return response

--- a/api/hailhq/api/deprecation.py
+++ b/api/hailhq/api/deprecation.py
@@ -17,12 +17,11 @@ duplicating the router list here too.
 
 from __future__ import annotations
 
+from hailhq.api.route_prefixes import INTERNAL_PREFIX as _INTERNAL_PREFIX
+from hailhq.api.route_prefixes import V1_PREFIX as _V1_PREFIX
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import Response
-
-_V1_PREFIX = "/v1/"
-_INTERNAL_PREFIX = "/internal/"
 
 
 class DeprecationHeaderMiddleware(BaseHTTPMiddleware):

--- a/api/hailhq/api/idempotency.py
+++ b/api/hailhq/api/idempotency.py
@@ -32,6 +32,7 @@ from uuid import UUID
 from fastapi import Depends, Header, HTTPException, Request, Response
 from fastapi import status as http_status
 from hailhq.api.deps import Principal, get_current_principal
+from hailhq.api.route_prefixes import request_mount_prefix
 from hailhq.core.db import session_scope
 from hailhq.core.models import IdempotencyKey
 from sqlalchemy import delete, select, update
@@ -75,7 +76,11 @@ async def cache_failure(
 
 
 def replay_cached(
-    idem: IdempotencyContext, response: Response, *, resource_prefix: str
+    idem: IdempotencyContext,
+    response: Response,
+    request: Request,
+    *,
+    resource_prefix: str,
 ) -> tuple[UUID, dict[str, Any]]:
     """Shared replay choreography for the create routes.
 
@@ -83,7 +88,10 @@ def replay_cached(
     header; otherwise sets the Idempotency-Replay + Location headers and
     returns ``(cached_id, cached_body)`` for the route to audit and
     model-validate. ``resource_prefix`` is the Location path prefix, e.g.
-    ``"/sms"``.
+    ``"/sms"`` — ``request`` supplies which mount (/v1 or legacy) the
+    caller actually used, so the emitted Location reflects that mount
+    rather than always pointing at the legacy path (see
+    route_prefixes.request_mount_prefix).
     """
     cached = idem.cached_response or {}
     if idem.cached_status and idem.cached_status >= 400:
@@ -94,7 +102,9 @@ def replay_cached(
         )
     cached_id = UUID(cached["id"])
     response.headers["Idempotency-Replay"] = "true"
-    response.headers["Location"] = f"{resource_prefix}/{cached_id}"
+    response.headers["Location"] = (
+        f"{request_mount_prefix(request)}{resource_prefix}/{cached_id}"
+    )
     return cached_id, cached
 
 

--- a/api/hailhq/api/main.py
+++ b/api/hailhq/api/main.py
@@ -251,27 +251,44 @@ app.add_middleware(GeneralRateLimitMiddleware)
 _default_openapi = app.openapi
 
 
+_VALIDATION_ERROR_FIELD_DESCRIPTIONS = {
+    "loc": (
+        "Path to the invalid field within the request, as a list of "
+        "keys/indices (e.g. ['body', 'to'])."
+    ),
+    "msg": "Human-readable description of the validation failure.",
+    "type": "Machine-readable error type code (e.g. 'missing', 'string_type').",
+    "input": "The value that was actually provided and failed validation.",
+    "ctx": "Additional machine-readable context for the error, when the error type provides one.",
+}
+
+
 def _openapi_with_validation_error_description() -> dict:
-    """Add a field description to the ``detail`` property of
-    ``HTTPValidationError`` — FastAPI generates that schema itself (from a
-    hardcoded dict in ``fastapi.openapi.utils``, not a model we own), so it
-    can't get a ``Field(description=...)`` the normal way. Every route with
-    a request body or query params gets a 422 response built from this
-    shared schema.
+    """Add field descriptions to ``HTTPValidationError.detail`` and to its
+    nested ``ValidationError`` item schema — FastAPI generates both itself
+    (hardcoded dicts in ``fastapi.openapi.utils``, not models we own), so
+    they can't get a ``Field(description=...)`` the normal way. Every route
+    with a request body or query params gets a 422 response built from
+    these shared schemas.
     """
     schema = _default_openapi()
-    detail = (
-        schema.get("components", {})
-        .get("schemas", {})
-        .get("HTTPValidationError", {})
-        .get("properties", {})
-        .get("detail")
-    )
+    schemas = schema.get("components", {}).get("schemas", {})
+
+    detail = schemas.get("HTTPValidationError", {}).get("properties", {}).get("detail")
     if detail is not None:
         detail["description"] = (
             "List of validation errors: each entry gives the field "
             "location (loc), the problem (msg), and the error type (type)."
         )
+
+    validation_error_properties = schemas.get("ValidationError", {}).get(
+        "properties", {}
+    )
+    for field_name, description in _VALIDATION_ERROR_FIELD_DESCRIPTIONS.items():
+        field_schema = validation_error_properties.get(field_name)
+        if field_schema is not None:
+            field_schema["description"] = description
+
     return schema
 
 

--- a/api/hailhq/api/main.py
+++ b/api/hailhq/api/main.py
@@ -248,6 +248,36 @@ app.add_middleware(DeprecationHeaderMiddleware)
 app.add_middleware(GeneralRateLimitMiddleware)
 
 
+_default_openapi = app.openapi
+
+
+def _openapi_with_validation_error_description() -> dict:
+    """Add a field description to the ``detail`` property of
+    ``HTTPValidationError`` — FastAPI generates that schema itself (from a
+    hardcoded dict in ``fastapi.openapi.utils``, not a model we own), so it
+    can't get a ``Field(description=...)`` the normal way. Every route with
+    a request body or query params gets a 422 response built from this
+    shared schema.
+    """
+    schema = _default_openapi()
+    detail = (
+        schema.get("components", {})
+        .get("schemas", {})
+        .get("HTTPValidationError", {})
+        .get("properties", {})
+        .get("detail")
+    )
+    if detail is not None:
+        detail["description"] = (
+            "List of validation errors: each entry gives the field "
+            "location (loc), the problem (msg), and the error type (type)."
+        )
+    return schema
+
+
+app.openapi = _openapi_with_validation_error_description
+
+
 @app.exception_handler(SecretKeyMissing)
 async def _secret_key_missing(_request: Request, exc: SecretKeyMissing) -> JSONResponse:
     """A Fernet secret key (webhooks or provider keys) is unset/invalid; 503, not 500."""

--- a/api/hailhq/api/main.py
+++ b/api/hailhq/api/main.py
@@ -317,4 +317,5 @@ app.include_router(internal_numbers.router)
 
 @app.get("/healthz")
 def healthz() -> dict[str, str]:
+    """Liveness check. Returns {"status": "ok"} with no auth required."""
     return {"status": "ok"}

--- a/api/hailhq/api/main.py
+++ b/api/hailhq/api/main.py
@@ -12,6 +12,7 @@ from fastapi.exception_handlers import request_validation_exception_handler
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response
 from hailhq.api.deprecation import DeprecationHeaderMiddleware
+from hailhq.api.ratelimit import GeneralRateLimitMiddleware
 from hailhq.api.routes import calls as calls_routes
 from hailhq.api.routes import contacts as contacts_routes
 from hailhq.api.routes import email_attachments as email_attachments_routes
@@ -241,6 +242,10 @@ app = FastAPI(
     lifespan=lifespan,
 )
 app.add_middleware(DeprecationHeaderMiddleware)
+# Starlette's add_middleware prepends, so the most-recently-added middleware
+# runs outermost/first. Rate limiting first means a 429 short-circuits
+# before the deprecation-header pass does any work on the same response.
+app.add_middleware(GeneralRateLimitMiddleware)
 
 
 @app.exception_handler(SecretKeyMissing)

--- a/api/hailhq/api/main.py
+++ b/api/hailhq/api/main.py
@@ -11,6 +11,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.exception_handlers import request_validation_exception_handler
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response
+from hailhq.api.deprecation import DeprecationHeaderMiddleware
 from hailhq.api.routes import calls as calls_routes
 from hailhq.api.routes import contacts as contacts_routes
 from hailhq.api.routes import email_attachments as email_attachments_routes
@@ -239,6 +240,7 @@ app = FastAPI(
     servers=[{"url": "https://api.hail.so", "description": "Hail Cloud"}],
     lifespan=lifespan,
 )
+app.add_middleware(DeprecationHeaderMiddleware)
 
 
 @app.exception_handler(SecretKeyMissing)
@@ -272,18 +274,34 @@ async def _cache_422_for_idempotent_retry(
     return await request_validation_exception_handler(request, exc)
 
 
-app.include_router(calls_routes.router)
-app.include_router(email_attachments_routes.router)
-app.include_router(emails_routes.router)
-app.include_router(events_routes.router)
-app.include_router(email_domains_routes.router)
-app.include_router(numbers_routes.router)
-app.include_router(webhooks_routes.router)
-app.include_router(unsubscribe_routes.router)
-app.include_router(sms_routes.router)
-app.include_router(contacts_routes.router)
-app.include_router(whoami_routes.router)
-app.include_router(providers_routes.router)
+# Customer-facing routers are dual-mounted: /v1/<resource> is canonical
+# and the only mount that appears in the OpenAPI schema. The unprefixed
+# path keeps working for existing integrations (routable, real handler)
+# but is excluded from the schema (include_in_schema=False) so it does
+# not create a second, colliding operationId per operation — FastAPI
+# derives operationId from the function name, and a route mounted twice
+# with schema inclusion on both would produce duplicate IDs and a spec
+# with two paths per operation. The unprefixed path is marked
+# Deprecation: true instead (see deprecation.py). No route handler is
+# duplicated, both mounts point at the same router object.
+_CUSTOMER_ROUTERS = [
+    calls_routes.router,
+    email_attachments_routes.router,
+    emails_routes.router,
+    events_routes.router,
+    email_domains_routes.router,
+    numbers_routes.router,
+    webhooks_routes.router,
+    unsubscribe_routes.router,
+    sms_routes.router,
+    contacts_routes.router,
+    whoami_routes.router,
+    providers_routes.router,
+]
+for _router in _CUSTOMER_ROUTERS:
+    app.include_router(_router, prefix="/v1")
+    app.include_router(_router, include_in_schema=False)
+
 app.include_router(internal_ses_events.router)
 app.include_router(internal_org_closures.router)
 app.include_router(internal_provider_config.router)

--- a/api/hailhq/api/main.py
+++ b/api/hailhq/api/main.py
@@ -292,7 +292,12 @@ def _openapi_with_validation_error_description() -> dict:
     return schema
 
 
-app.openapi = _openapi_with_validation_error_description
+app.openapi = _openapi_with_validation_error_description  # type: ignore[method-assign]
+# FastAPI's own documented pattern for customizing OpenAPI generation
+# (https://fastapi.tiangolo.com/how-to/extending-openapi/): `openapi` is an
+# instance attribute FastAPI expects apps to overwrite, not a method the
+# type checker should treat as fixed. Safe and intentional; mypy just can't
+# model an instance attribute overriding a bound method.
 
 
 @app.exception_handler(SecretKeyMissing)

--- a/api/hailhq/api/ratelimit.py
+++ b/api/hailhq/api/ratelimit.py
@@ -1,0 +1,187 @@
+"""General per-caller request-rate limiting.
+
+Distinct from core.agent_caps (a DB-backed, per-org, per-channel *send*
+velocity cap for agent-origin orgs only). This is a general HTTP
+request-rate limiter across every customer-facing route, for every
+caller. In-memory storage — safe because this API runs single-instance
+(one VM, docker-compose, no replica orchestration; see deploy.yml). If a
+second instance is ever added, swap the limiter's storage_uri to Redis
+(``Limiter(..., storage_uri="redis://...")``); no call-site changes
+needed.
+
+Keyed on the raw Authorization header value (hashed) rather than the
+resolved Principal, so the limiter runs before any DB round-trip —
+distinct callers with distinct keys/tokens get distinct buckets even
+before auth resolves whether the token is valid. One bucket per caller
+across *all* customer routes combined (not one bucket per route) — this
+is a blanket abuse guard on total request volume, not a per-endpoint
+budget.
+
+Wired as ``GeneralRateLimitMiddleware`` in main.py rather than slowapi's
+own ``SlowAPIMiddleware`` + ``default_limits`` pattern: that pattern
+matches every app route by handler identity and needs each exempt route
+individually registered via ``limiter.exempt(...)``, which would mean
+reaching into the internal/* route modules this task must not touch.
+Path-prefix exemption (``/internal/*``, ``/healthz``) is equivalent here
+and self-contained — same convention as ``deprecation.py``'s
+``DeprecationHeaderMiddleware``, which already matches on path shape for
+the identical prefix set.
+
+Emits the IETF ``draft-ietf-httpapi-ratelimit-headers`` header names
+directly (``RateLimit-Limit`` / ``RateLimit-Remaining`` / ``RateLimit-
+Reset``) rather than slowapi's own default ``X-RateLimit-*`` mapping —
+this middleware sets headers itself (see dispatch()) instead of relying
+on ``Limiter._inject_headers``, so there is no library default to
+diverge from.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from typing import Any
+
+from hailhq.core.config import settings
+from limits import RateLimitItem, parse
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+__all__ = [
+    "GENERAL_RATE_LIMITED_RESPONSES",
+    "GeneralRateLimitMiddleware",
+    "limiter",
+    "merge_rate_limited_responses",
+    "rate_limit_string",
+]
+
+
+def _rate_limit_key(request: Request) -> str:
+    auth = request.headers.get("authorization")
+    if not auth:
+        return get_remote_address(request)
+    return hashlib.sha256(auth.encode()).hexdigest()
+
+
+# Used for its key_func, in-memory storage, and fixed-window strategy — see
+# module docstring for why wiring is a custom middleware rather than
+# slowapi's own SlowAPIMiddleware.
+limiter = Limiter(key_func=_rate_limit_key)
+
+
+def rate_limit_string() -> str:
+    return f"{settings.api_rate_limit_per_minute}/minute"
+
+
+# Paths the general limiter never applies to: internal service-to-service
+# routes (HMAC-authenticated, not customer traffic — see routes/internal/)
+# and the health check. Matches on path shape, same convention as
+# deprecation.py's DeprecationHeaderMiddleware.
+_INTERNAL_PREFIX = "/internal/"
+_HEALTHZ_PATH = "/healthz"
+
+
+def _is_exempt(path: str) -> bool:
+    return path == _HEALTHZ_PATH or path.startswith(_INTERNAL_PREFIX)
+
+
+class GeneralRateLimitMiddleware(BaseHTTPMiddleware):
+    """Enforces ``rate_limit_string()`` per caller on every non-exempt route.
+
+    Reads ``settings.api_rate_limit_per_minute`` fresh on every request
+    (via ``rate_limit_string()``), not once at import/startup time, so a
+    runtime change to the setting takes effect immediately — including in
+    tests that monkeypatch ``settings.api_rate_limit_per_minute``.
+    """
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        if _is_exempt(request.url.path):
+            return await call_next(request)
+
+        key = _rate_limit_key(request)
+        item: RateLimitItem = parse(rate_limit_string())
+        allowed = limiter.limiter.hit(item, key)
+        stats = limiter.limiter.get_window_stats(item, key)
+        reset_in = max(int(stats.reset_time - time.time()), 0)
+
+        if not allowed:
+            return JSONResponse(
+                {
+                    "detail": (
+                        "Rate limit exceeded. Retry after the Retry-After "
+                        "header (seconds)."
+                    )
+                },
+                status_code=429,
+                headers={
+                    "Retry-After": str(max(reset_in, 1)),
+                    "RateLimit-Limit": str(item.amount),
+                    "RateLimit-Remaining": str(stats.remaining),
+                    "RateLimit-Reset": str(reset_in),
+                },
+            )
+
+        response = await call_next(request)
+        response.headers["RateLimit-Limit"] = str(item.amount)
+        response.headers["RateLimit-Remaining"] = str(stats.remaining)
+        response.headers["RateLimit-Reset"] = str(reset_in)
+        return response
+
+
+# OpenAPI doc for the 429 this middleware can return. FastAPI does not infer
+# statuses from a middleware short-circuit any more than it does from
+# `raise HTTPException`, so every customer route decorator must declare this
+# (`responses=GENERAL_RATE_LIMITED_RESPONSES`) for the generated spec — and
+# the CLI codegen from it — to reflect the rate limit. Regenerate
+# openapi/openapi.yaml after touching this (see docs/public/contributing.md).
+GENERAL_RATE_LIMITED_RESPONSES: dict[int | str, dict[str, Any]] = {
+    429: {
+        "description": (
+            "Rate limited. This caller exceeded the general request-rate "
+            "ceiling. Retry after the Retry-After header (seconds)."
+        ),
+        "headers": {
+            "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {"type": "integer"},
+            },
+            "RateLimit-Limit": {
+                "description": "The request ceiling for the current window.",
+                "schema": {"type": "integer"},
+            },
+            "RateLimit-Remaining": {
+                "description": "Requests remaining in the current window.",
+                "schema": {"type": "integer"},
+            },
+            "RateLimit-Reset": {
+                "description": "Seconds until the current window resets.",
+                "schema": {"type": "integer"},
+            },
+        },
+    }
+}
+
+
+def merge_rate_limited_responses(
+    *response_dicts: dict[int | str, dict[str, Any]],
+) -> dict[int | str, dict[str, Any]]:
+    """Merge several ``responses=`` 429 docs into one, without either
+    clobbering the other's description/headers.
+
+    Used on the 3 routes (calls/sms/emails create) that already document a
+    distinct 429 cause (the agent-abuse velocity cap, ``agent_gate.py``'s
+    ``RATE_LIMITED_RESPONSES``) — both 429 reasons are real and independently
+    reachable on those routes, so both need documenting on the same status
+    code rather than one silently replacing the other.
+    """
+    descriptions: list[str] = []
+    headers: dict[str, Any] = {}
+    for d in response_dicts:
+        entry = d[429]
+        descriptions.append(entry["description"])
+        headers.update(entry.get("headers", {}))
+    return {429: {"description": " ".join(descriptions), "headers": headers}}

--- a/api/hailhq/api/ratelimit.py
+++ b/api/hailhq/api/ratelimit.py
@@ -42,6 +42,7 @@ import time
 from typing import Any
 
 from hailhq.api.route_prefixes import INTERNAL_PREFIX as _INTERNAL_PREFIX
+from hailhq.api.route_prefixes import V1_PREFIX as _V1_PREFIX
 from hailhq.core.config import settings
 from limits import RateLimitItem, parse
 from slowapi import Limiter
@@ -97,7 +98,7 @@ _EXEMPT_PATHS = frozenset({"/sms/inbound", "/sms/status", "/unsubscribe"})
 def _is_exempt(path: str) -> bool:
     if path == _HEALTHZ_PATH or path.startswith(_INTERNAL_PREFIX):
         return True
-    unprefixed = path[len("/v1") :] if path.startswith("/v1/") else path
+    unprefixed = path[len(_V1_PREFIX) - 1 :] if path.startswith(_V1_PREFIX) else path
     return unprefixed in _EXEMPT_PATHS
 
 
@@ -118,9 +119,18 @@ class GeneralRateLimitMiddleware(BaseHTTPMiddleware):
 
         key = _rate_limit_key(request)
         item: RateLimitItem = parse(rate_limit_string())
-        allowed = limiter.limiter.hit(item, key)
-        stats = limiter.limiter.get_window_stats(item, key)
-        reset_in = max(int(stats.reset_time - time.time()), 0)
+        # Single atomic incr() instead of hit()+get_window_stats(): the
+        # latter is two separate storage calls, so a concurrent request's
+        # hit() could land between them and the returned Remaining/Reset
+        # headers would reflect that other caller's increment, not this
+        # request's own. incr() returns the post-increment count directly.
+        storage_key = item.key_for(key)
+        count = limiter.limiter.storage.incr(storage_key, item.get_expiry())
+        allowed = count <= item.amount
+        remaining = max(0, item.amount - count)
+        reset_in = max(
+            int(limiter.limiter.storage.get_expiry(storage_key) - time.time()), 0
+        )
 
         if not allowed:
             return JSONResponse(
@@ -134,14 +144,14 @@ class GeneralRateLimitMiddleware(BaseHTTPMiddleware):
                 headers={
                     "Retry-After": str(max(reset_in, 1)),
                     "RateLimit-Limit": str(item.amount),
-                    "RateLimit-Remaining": str(stats.remaining),
+                    "RateLimit-Remaining": str(remaining),
                     "RateLimit-Reset": str(reset_in),
                 },
             )
 
         response = await call_next(request)
         response.headers["RateLimit-Limit"] = str(item.amount)
-        response.headers["RateLimit-Remaining"] = str(stats.remaining)
+        response.headers["RateLimit-Remaining"] = str(remaining)
         response.headers["RateLimit-Reset"] = str(reset_in)
         return response
 

--- a/api/hailhq/api/ratelimit.py
+++ b/api/hailhq/api/ratelimit.py
@@ -41,6 +41,7 @@ import hashlib
 import time
 from typing import Any
 
+from hailhq.api.route_prefixes import INTERNAL_PREFIX as _INTERNAL_PREFIX
 from hailhq.core.config import settings
 from limits import RateLimitItem, parse
 from slowapi import Limiter
@@ -76,15 +77,28 @@ def rate_limit_string() -> str:
 
 
 # Paths the general limiter never applies to: internal service-to-service
-# routes (HMAC-authenticated, not customer traffic — see routes/internal/)
-# and the health check. Matches on path shape, same convention as
-# deprecation.py's DeprecationHeaderMiddleware.
-_INTERNAL_PREFIX = "/internal/"
+# routes (HMAC-authenticated, not customer traffic — see routes/internal/),
+# the health check, and the 3 legitimate self-credentialed public routes
+# below. Matches on path shape, same convention as deprecation.py's
+# DeprecationHeaderMiddleware.
 _HEALTHZ_PATH = "/healthz"
+
+# Self-credentialed public routes with no Authorization header by design
+# (Twilio signature auth for the SMS webhooks; an HMAC token query param for
+# unsubscribe, RFC 8058). Without this exemption they fall back to the
+# remote-IP rate-limit key (_rate_limit_key below) — and in production every
+# anonymous caller resolves to the same upstream-proxy IP, so all anonymous
+# traffic would share one bucket with these legitimate routes. Listed
+# unprefixed; dual-mounted at both /v1/... and the legacy path (main.py), so
+# matching strips a leading /v1 before comparing.
+_EXEMPT_PATHS = frozenset({"/sms/inbound", "/sms/status", "/unsubscribe"})
 
 
 def _is_exempt(path: str) -> bool:
-    return path == _HEALTHZ_PATH or path.startswith(_INTERNAL_PREFIX)
+    if path == _HEALTHZ_PATH or path.startswith(_INTERNAL_PREFIX):
+        return True
+    unprefixed = path[len("/v1") :] if path.startswith("/v1/") else path
+    return unprefixed in _EXEMPT_PATHS
 
 
 class GeneralRateLimitMiddleware(BaseHTTPMiddleware):

--- a/api/hailhq/api/route_prefixes.py
+++ b/api/hailhq/api/route_prefixes.py
@@ -1,0 +1,29 @@
+"""Shared path-prefix constants for the /v1-vs-legacy dual mount.
+
+Customer routers are dual-mounted (main.py) at ``/v1/<resource>`` (canonical)
+and again at the unprefixed legacy path. Several independent modules
+(``deprecation.py``, ``ratelimit.py``, ``idempotency.py``, and the route
+handlers that build a ``Location`` header) all need to agree on the same
+prefix strings and the same "which mount did this request come in on" logic
+— this module is the single source of truth so they don't drift apart.
+"""
+
+from __future__ import annotations
+
+from starlette.requests import Request
+
+V1_PREFIX = "/v1/"
+INTERNAL_PREFIX = "/internal/"
+
+
+def request_mount_prefix(request: Request) -> str:
+    """Returns the /v1 mount prefix if this request used it, else "" (legacy).
+
+    Use to build a self-referential URL (e.g. a ``Location`` header) that
+    reflects whichever mount the request actually arrived on, rather than
+    hardcoding one.
+    """
+    return "/v1" if request.url.path.startswith(V1_PREFIX) else ""
+
+
+__all__ = ["INTERNAL_PREFIX", "V1_PREFIX", "request_mount_prefix"]

--- a/api/hailhq/api/routes/calls.py
+++ b/api/hailhq/api/routes/calls.py
@@ -163,6 +163,14 @@ async def create_call(
     lk: Annotated[LiveKitClient, Depends(get_livekit)],
     idem: Annotated[IdempotencyContext | None, Depends(idempotency_dep)] = None,
 ) -> CallResponse:
+    """Place an outbound AI voice call.
+
+    The call is placed asynchronously — this returns as soon as the call is
+    queued, not when it completes. Poll GET /calls/{call_id} or configure a
+    webhook to get the final status and transcript. Requires
+    recipient_consent=true on the request body; Hail does not verify lawful
+    basis to contact the recipient, the caller warrants it.
+    """
     # Replay before any DB or LiveKit work — a retry must not re-dispatch.
     if idem is not None and idem.is_replay:
         cached_id, cached = replay_cached(idem, response, resource_prefix="/calls")
@@ -563,6 +571,12 @@ async def get_call(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> CallResponse:
+    """Fetch one call by id, including its current status and end reason.
+
+    Org-scoped: returns 404 for a call belonging to a different organization
+    (not 403, to avoid confirming the id exists). Use this to poll for the
+    final outcome of a call placed with POST /calls.
+    """
     stmt = select(Call).where(
         Call.id == call_id,
         Call.organization_id == principal.organization_id,
@@ -594,6 +608,12 @@ async def list_calls(
     status: CallStatus | None = Query(default=None),
     to: str | None = Query(default=None),
 ) -> CallListResponse:
+    """List calls for the caller's organization, newest first.
+
+    Cursor-paginated: pass the returned next_cursor to fetch the next page;
+    a null next_cursor means there are no more results. Filter by status or
+    destination number (to) to narrow the list.
+    """
     stmt = select(Call).where(Call.organization_id == principal.organization_id)
     if status is not None:
         stmt = stmt.where(Call.status == status)

--- a/api/hailhq/api/routes/calls.py
+++ b/api/hailhq/api/routes/calls.py
@@ -69,7 +69,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/calls", tags=["calls"])
+router = APIRouter(
+    prefix="/calls", tags=["calls"], responses=GENERAL_RATE_LIMITED_RESPONSES
+)
 
 _DEFAULT_LIST_LIMIT = 50
 _MAX_LIST_LIMIT = 200
@@ -568,7 +570,6 @@ async def create_call(
 @router.get(
     "/{call_id}",
     response_model=CallResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def get_call(
     call_id: UUID,
@@ -602,7 +603,6 @@ async def get_call(
 @router.get(
     "",
     response_model=CallListResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def list_calls(
     principal: Annotated[Principal, Depends(get_current_principal)],

--- a/api/hailhq/api/routes/calls.py
+++ b/api/hailhq/api/routes/calls.py
@@ -33,6 +33,10 @@ from hailhq.api.idempotency import (
 )
 from hailhq.api.numbers import resolve_org_number
 from hailhq.api.pagination import fetch_cursor_page
+from hailhq.api.ratelimit import (
+    GENERAL_RATE_LIMITED_RESPONSES,
+    merge_rate_limited_responses,
+)
 from hailhq.core.agent_tools.registry import all_tools
 from hailhq.core.billing import CALL_META_BILLED
 from hailhq.core.call_end_reasons import CallEndReason
@@ -147,7 +151,9 @@ async def _cleanup_partial_livekit(
     "",
     response_model=CallResponse,
     status_code=http_status.HTTP_201_CREATED,
-    responses=RATE_LIMITED_RESPONSES,
+    responses=merge_rate_limited_responses(
+        RATE_LIMITED_RESPONSES, GENERAL_RATE_LIMITED_RESPONSES
+    ),
 )
 async def create_call(
     body: CallCreate,
@@ -547,7 +553,11 @@ async def create_call(
 # --------------------------------------------------------------------------- #
 
 
-@router.get("/{call_id}", response_model=CallResponse)
+@router.get(
+    "/{call_id}",
+    response_model=CallResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def get_call(
     call_id: UUID,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -571,7 +581,11 @@ async def get_call(
 # --------------------------------------------------------------------------- #
 
 
-@router.get("", response_model=CallListResponse)
+@router.get(
+    "",
+    response_model=CallListResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def list_calls(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],

--- a/api/hailhq/api/routes/calls.py
+++ b/api/hailhq/api/routes/calls.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi import status as http_status
 from hailhq.api.agent_gate import (
     RATE_LIMITED_RESPONSES,
@@ -37,6 +37,7 @@ from hailhq.api.ratelimit import (
     GENERAL_RATE_LIMITED_RESPONSES,
     merge_rate_limited_responses,
 )
+from hailhq.api.route_prefixes import request_mount_prefix
 from hailhq.core.agent_tools.registry import all_tools
 from hailhq.core.billing import CALL_META_BILLED
 from hailhq.core.call_end_reasons import CallEndReason
@@ -158,6 +159,7 @@ async def _cleanup_partial_livekit(
 async def create_call(
     body: CallCreate,
     response: Response,
+    request: Request,
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
     lk: Annotated[LiveKitClient, Depends(get_livekit)],
@@ -166,14 +168,16 @@ async def create_call(
     """Place an outbound AI voice call.
 
     The call is placed asynchronously — this returns as soon as the call is
-    queued, not when it completes. Poll GET /calls/{call_id} or configure a
+    queued, not when it completes. Poll GET /v1/calls/{call_id} or configure a
     webhook to get the final status and transcript. Requires
     recipient_consent=true on the request body; Hail does not verify lawful
     basis to contact the recipient, the caller warrants it.
     """
     # Replay before any DB or LiveKit work — a retry must not re-dispatch.
     if idem is not None and idem.is_replay:
-        cached_id, cached = replay_cached(idem, response, resource_prefix="/calls")
+        cached_id, cached = replay_cached(
+            idem, response, request, resource_prefix="/calls"
+        )
         await write_audit_log(
             organization_id=principal.organization_id,
             api_key_id=principal.api_key_id,
@@ -542,7 +546,7 @@ async def create_call(
     await db.commit()
     await db.refresh(call)
 
-    response.headers["Location"] = f"/calls/{call.id}"
+    response.headers["Location"] = f"{request_mount_prefix(request)}/calls/{call.id}"
     call_response = CallResponse.model_validate(call)
 
     if idem is not None:
@@ -575,7 +579,7 @@ async def get_call(
 
     Org-scoped: returns 404 for a call belonging to a different organization
     (not 403, to avoid confirming the id exists). Use this to poll for the
-    final outcome of a call placed with POST /calls.
+    final outcome of a call placed with POST /v1/calls.
     """
     stmt = select(Call).where(
         Call.id == call_id,

--- a/api/hailhq/api/routes/contacts.py
+++ b/api/hailhq/api/routes/contacts.py
@@ -34,7 +34,7 @@ from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-router = APIRouter(tags=["contacts"])
+router = APIRouter(tags=["contacts"], responses=GENERAL_RATE_LIMITED_RESPONSES)
 
 _MEMBER_ID_DETAIL = "member contacts are managed via membership"
 _DEFAULT_LIMIT = 100
@@ -85,7 +85,6 @@ async def _member_role(db: AsyncSession, org_id: UUID, user_id: UUID) -> str | N
 @router.get(
     "/contacts",
     response_model=ContactListResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def list_contacts(
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -130,7 +129,6 @@ async def list_contacts(
     "/contacts",
     response_model=ContactEntry,
     status_code=http_status.HTTP_201_CREATED,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def create_contact(
     body: ContactCreate,
@@ -166,7 +164,6 @@ async def create_contact(
 @router.patch(
     "/contacts/{contact_id}",
     response_model=ContactEntry,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def patch_contact(
     contact_id: str,
@@ -204,7 +201,6 @@ async def patch_contact(
 @router.delete(
     "/contacts/{contact_id}",
     status_code=http_status.HTTP_204_NO_CONTENT,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def delete_contact(
     contact_id: str,
@@ -261,7 +257,6 @@ async def _resolve_phone_target(
 
 @router.put(
     "/members/{user_id}/phone",
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def put_member_phone(
     user_id: str,
@@ -286,7 +281,6 @@ async def put_member_phone(
 @router.delete(
     "/members/{user_id}/phone",
     status_code=http_status.HTTP_204_NO_CONTENT,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def delete_member_phone(
     user_id: str,

--- a/api/hailhq/api/routes/contacts.py
+++ b/api/hailhq/api/routes/contacts.py
@@ -94,6 +94,14 @@ async def list_contacts(
     cursor: str | None = Query(default=None),
     limit: int = Query(default=_DEFAULT_LIMIT, ge=1, le=_MAX_LIMIT),
 ) -> ContactListResponse:
+    """List contacts for the caller's organization, newest first.
+
+    Merges two sources into one list: org members (kind="member", ids
+    prefixed "member:", managed via membership — not editable here) and
+    manually-created contacts (kind="manual", editable via PATCH/DELETE
+    /contacts/{contact_id}). Cursor-paginated; q does a substring search
+    over name/phone/email.
+    """
     u = contacts_union_stmt(principal.organization_id, q).subquery()
     rows, next_cursor = await fetch_cursor_page(
         db,
@@ -129,6 +137,12 @@ async def create_contact(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> ContactEntry:
+    """Create a manual contact with a phone and/or an email.
+
+    Requires at least one of phone_e164 or email. Fails with 409 if a
+    contact with the same phone or email already exists in this
+    organization.
+    """
     row = Contact(
         organization_id=principal.organization_id,
         name=body.name,
@@ -160,6 +174,13 @@ async def patch_contact(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> ContactEntry:
+    """Update a manual contact's fields. Only fields present in the body change.
+
+    Manual contacts only — a member: id (org members synced from
+    membership) returns 422; edit those via the membership APIs instead.
+    The contact must still have at least one of phone_e164 or email after
+    the update. Fails with 409 on a duplicate phone/email.
+    """
     row = await _get_manual_or_404(db, principal.organization_id, contact_id)
     data = body.model_dump(exclude_unset=True)
     next_phone = data.get("phone_e164", row.phone_e164)
@@ -190,6 +211,11 @@ async def delete_contact(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> Response:
+    """Permanently remove a manual contact.
+
+    Manual contacts only — a member: id returns 422; org members are
+    removed via the membership APIs, not this route. Irreversible.
+    """
     row = await _get_manual_or_404(db, principal.organization_id, contact_id)
     await db.delete(row)
     await db.commit()
@@ -243,6 +269,12 @@ async def put_member_phone(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> dict[str, str]:
+    """Set an org member's phone number.
+
+    Pass user_id="me" to set your own, or a member's user id — setting
+    another member's phone requires the caller to be an org owner or
+    admin. Returns 404 if the target is not a member of this organization.
+    """
     target = await _resolve_phone_target(db, principal, user_id)
     await db.execute(
         update(User).where(User.id == target).values(phone_number=body.phone_e164)
@@ -261,6 +293,12 @@ async def delete_member_phone(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> Response:
+    """Clear an org member's phone number.
+
+    Pass user_id="me" to clear your own, or a member's user id — clearing
+    another member's phone requires the caller to be an org owner or
+    admin. Returns 404 if the target is not a member of this organization.
+    """
     target = await _resolve_phone_target(db, principal, user_id)
     await db.execute(update(User).where(User.id == target).values(phone_number=None))
     await db.commit()

--- a/api/hailhq/api/routes/contacts.py
+++ b/api/hailhq/api/routes/contacts.py
@@ -19,6 +19,7 @@ from fastapi import status as http_status
 from hailhq.api.deps import Principal, get_current_principal
 from hailhq.api.errors import unprocessable
 from hailhq.api.pagination import fetch_cursor_page
+from hailhq.api.ratelimit import GENERAL_RATE_LIMITED_RESPONSES
 from hailhq.core.contacts import MEMBER_ID_PREFIX, contact_to_entry, contacts_union_stmt
 from hailhq.core.db import get_session
 from hailhq.core.models import Contact, OrganizationMember, User
@@ -81,7 +82,11 @@ async def _member_role(db: AsyncSession, org_id: UUID, user_id: UUID) -> str | N
     ).scalar_one_or_none()
 
 
-@router.get("/contacts", response_model=ContactListResponse)
+@router.get(
+    "/contacts",
+    response_model=ContactListResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def list_contacts(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
@@ -114,7 +119,10 @@ async def list_contacts(
 
 
 @router.post(
-    "/contacts", response_model=ContactEntry, status_code=http_status.HTTP_201_CREATED
+    "/contacts",
+    response_model=ContactEntry,
+    status_code=http_status.HTTP_201_CREATED,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def create_contact(
     body: ContactCreate,
@@ -141,7 +149,11 @@ async def create_contact(
     return contact_to_entry(row)
 
 
-@router.patch("/contacts/{contact_id}", response_model=ContactEntry)
+@router.patch(
+    "/contacts/{contact_id}",
+    response_model=ContactEntry,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def patch_contact(
     contact_id: str,
     body: ContactPatch,
@@ -168,7 +180,11 @@ async def patch_contact(
     return contact_to_entry(row)
 
 
-@router.delete("/contacts/{contact_id}", status_code=http_status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/contacts/{contact_id}",
+    status_code=http_status.HTTP_204_NO_CONTENT,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def delete_contact(
     contact_id: str,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -217,7 +233,10 @@ async def _resolve_phone_target(
     return target
 
 
-@router.put("/members/{user_id}/phone")
+@router.put(
+    "/members/{user_id}/phone",
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def put_member_phone(
     user_id: str,
     body: MemberPhonePut,
@@ -232,7 +251,11 @@ async def put_member_phone(
     return {"user_id": str(target), "phone_e164": body.phone_e164}
 
 
-@router.delete("/members/{user_id}/phone", status_code=http_status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/members/{user_id}/phone",
+    status_code=http_status.HTTP_204_NO_CONTENT,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def delete_member_phone(
     user_id: str,
     principal: Annotated[Principal, Depends(get_current_principal)],

--- a/api/hailhq/api/routes/email_attachments.py
+++ b/api/hailhq/api/routes/email_attachments.py
@@ -57,7 +57,7 @@ async def create_email_attachment(
     """Upload a file and get back a reusable attachment id.
 
     The returned id can be referenced from attachment_ids on many later
-    POST /emails calls until it is garbage-collected for being unused; it is
+    POST /v1/emails calls until it is garbage-collected for being unused; it is
     not deleted immediately after first use. Uploads are size-limited and
     scoped to the caller's organization.
     """

--- a/api/hailhq/api/routes/email_attachments.py
+++ b/api/hailhq/api/routes/email_attachments.py
@@ -28,7 +28,11 @@ from hailhq.core.s3_mail import S3MailClient
 from hailhq.core.schemas import EmailAttachmentUploadResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-router = APIRouter(prefix="/email-attachments", tags=["email-attachments"])
+router = APIRouter(
+    prefix="/email-attachments",
+    tags=["email-attachments"],
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 
 _READ_CHUNK_BYTES = 1024 * 1024  # 1MB
 
@@ -38,7 +42,6 @@ _READ_CHUNK_BYTES = 1024 * 1024  # 1MB
     response_model=EmailAttachmentUploadResponse,
     status_code=http_status.HTTP_201_CREATED,
     operation_id="upload_email_attachment",
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def create_email_attachment(
     principal: Annotated[Principal, Depends(get_current_principal)],

--- a/api/hailhq/api/routes/email_attachments.py
+++ b/api/hailhq/api/routes/email_attachments.py
@@ -46,6 +46,13 @@ async def create_email_attachment(
     s3: Annotated[S3MailClient, Depends(get_s3_mail)],
     file: Annotated[UploadFile, File()],
 ) -> EmailAttachmentUploadResponse:
+    """Upload a file and get back a reusable attachment id.
+
+    The returned id can be referenced from attachment_ids on many later
+    POST /emails calls until it is garbage-collected for being unused; it is
+    not deleted immediately after first use. Uploads are size-limited and
+    scoped to the caller's organization.
+    """
     # Read in bounded chunks so an oversize body is rejected without ever
     # buffering more than ~MAX_EMAIL_ATTACHMENT_BYTES in memory — no layer
     # in front of this endpoint (ASGI server, reverse proxy) caps request

--- a/api/hailhq/api/routes/email_attachments.py
+++ b/api/hailhq/api/routes/email_attachments.py
@@ -44,7 +44,15 @@ async def create_email_attachment(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
     s3: Annotated[S3MailClient, Depends(get_s3_mail)],
-    file: Annotated[UploadFile, File()],
+    file: Annotated[
+        UploadFile,
+        File(
+            description=(
+                "The file to upload, as multipart/form-data. Size-limited; "
+                "an oversize upload is rejected with 422."
+            )
+        ),
+    ],
 ) -> EmailAttachmentUploadResponse:
     """Upload a file and get back a reusable attachment id.
 

--- a/api/hailhq/api/routes/email_attachments.py
+++ b/api/hailhq/api/routes/email_attachments.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi import status as http_status
 from hailhq.api.deps import Principal, get_current_principal, get_s3_mail
+from hailhq.api.ratelimit import GENERAL_RATE_LIMITED_RESPONSES
 from hailhq.core.db import get_session
 from hailhq.core.email_attachment_limits import (
     ATTACHMENT_TOO_LARGE_DETAIL,
@@ -37,6 +38,7 @@ _READ_CHUNK_BYTES = 1024 * 1024  # 1MB
     response_model=EmailAttachmentUploadResponse,
     status_code=http_status.HTTP_201_CREATED,
     operation_id="upload_email_attachment",
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def create_email_attachment(
     principal: Annotated[Principal, Depends(get_current_principal)],

--- a/api/hailhq/api/routes/email_domains.py
+++ b/api/hailhq/api/routes/email_domains.py
@@ -59,7 +59,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/email-domains", tags=["email-domains"])
+router = APIRouter(
+    prefix="/email-domains",
+    tags=["email-domains"],
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 
 _DEFAULT_LIST_LIMIT = 50
 _MAX_LIST_LIMIT = 200
@@ -269,7 +273,6 @@ async def _unminted_hail_mail(db: AsyncSession, organization_id: UUID) -> str | 
     "",
     response_model=EmailDomainResponse,
     status_code=http_status.HTTP_201_CREATED,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def create_email_domain(
     body: EmailDomainCreate,
@@ -395,7 +398,6 @@ async def create_email_domain(
 @router.get(
     "",
     response_model=EmailDomainListResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def list_email_domains(
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -439,7 +441,6 @@ async def list_email_domains(
 @router.get(
     "/check-domain",
     response_model=DomainCheckResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def check_domain(
     domain: str,
@@ -465,7 +466,6 @@ async def check_domain(
 @router.get(
     "/{domain_id}",
     response_model=EmailDomainResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def get_email_domain(
     domain_id: UUID,
@@ -499,7 +499,6 @@ async def get_email_domain(
 @router.patch(
     "/{domain_id}",
     response_model=EmailDomainResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def patch_email_domain(
     domain_id: UUID,
@@ -593,7 +592,6 @@ async def patch_email_domain(
 @router.post(
     "/{domain_id}/verify",
     response_model=EmailDomainResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def verify_email_domain(
     domain_id: UUID,
@@ -714,7 +712,6 @@ async def verify_email_domain(
 @router.delete(
     "/{domain_id}",
     status_code=http_status.HTTP_204_NO_CONTENT,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def delete_email_domain(
     domain_id: UUID,

--- a/api/hailhq/api/routes/email_domains.py
+++ b/api/hailhq/api/routes/email_domains.py
@@ -277,6 +277,14 @@ async def create_email_domain(
     db: Annotated[AsyncSession, Depends(get_session)],
     email_provider: Annotated[EmailProvider, Depends(get_email_provider)],
 ) -> EmailDomainResponse:
+    """Register a sender identity to send outbound email through.
+
+    kind="hail_mail" mints an address on the shared hail-mail domain and is
+    immediately verified — no DNS work needed. kind="custom" registers your
+    own domain with SES and returns DKIM records; the domain stays
+    unverified (POST /email-domains/{domain_id}/verify) until you publish
+    those DNS records and Hail confirms them.
+    """
     if body.kind == "hail_mail":
         user_prefix, org_prefix = resolve_hail_mail_prefixes(
             body.local_prefix_user,
@@ -389,6 +397,12 @@ async def list_email_domains(
     cursor: str | None = Query(default=None),
     limit: int = Query(default=_DEFAULT_LIST_LIMIT, ge=1, le=_MAX_LIST_LIMIT),
 ) -> EmailDomainListResponse:
+    """List sender domains/identities for the caller's organization.
+
+    Cursor-paginated, newest first. The response also includes
+    default_from — the address a from-less POST /emails would use right
+    now given the org's current verified senders.
+    """
     stmt = select(EmailDomain).where(
         EmailDomain.organization_id == principal.organization_id
     )
@@ -452,6 +466,12 @@ async def get_email_domain(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> EmailDomainResponse:
+    """Fetch one sender domain/identity by id, including its DNS records.
+
+    Org-scoped: returns 404 for a domain belonging to a different
+    organization. For a pending custom domain, dns_records lists the DKIM
+    records still to publish.
+    """
     stmt = select(EmailDomain).where(
         EmailDomain.id == domain_id,
         EmailDomain.organization_id == principal.organization_id,
@@ -696,6 +716,13 @@ async def delete_email_domain(
     db: Annotated[AsyncSession, Depends(get_session)],
     email_provider: Annotated[EmailProvider, Depends(get_email_provider)],
 ) -> Response:
+    """Permanently remove a sender domain/identity.
+
+    Irreversible — for a custom domain, also deletes the SES identity, so
+    the domain can no longer send until re-registered and re-verified.
+    Fails with 409 if any Email rows still reference this domain; delete
+    or wait for those to age out first.
+    """
     stmt = select(EmailDomain).where(
         EmailDomain.id == domain_id,
         EmailDomain.organization_id == principal.organization_id,

--- a/api/hailhq/api/routes/email_domains.py
+++ b/api/hailhq/api/routes/email_domains.py
@@ -36,6 +36,7 @@ from hailhq.api.audit import write_audit_log
 from hailhq.api.deps import Principal, get_current_principal
 from hailhq.api.errors import unprocessable
 from hailhq.api.pagination import fetch_cursor_page
+from hailhq.api.ratelimit import GENERAL_RATE_LIMITED_RESPONSES
 from hailhq.core.config import settings
 from hailhq.core.db import get_session
 from hailhq.core.dns_lookup import custom_dns_records, resolve_mx, ses_inbound_host
@@ -267,6 +268,7 @@ async def _unminted_hail_mail(db: AsyncSession, organization_id: UUID) -> str | 
     "",
     response_model=EmailDomainResponse,
     status_code=http_status.HTTP_201_CREATED,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def create_email_domain(
     body: EmailDomainCreate,
@@ -376,7 +378,11 @@ async def create_email_domain(
 # --------------------------------------------------------------------------- #
 
 
-@router.get("", response_model=EmailDomainListResponse)
+@router.get(
+    "",
+    response_model=EmailDomainListResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def list_email_domains(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
@@ -410,7 +416,11 @@ async def list_email_domains(
 # --------------------------------------------------------------------------- #
 
 
-@router.get("/check-domain", response_model=DomainCheckResponse)
+@router.get(
+    "/check-domain",
+    response_model=DomainCheckResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def check_domain(
     domain: str,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -432,7 +442,11 @@ async def check_domain(
 # --------------------------------------------------------------------------- #
 
 
-@router.get("/{domain_id}", response_model=EmailDomainResponse)
+@router.get(
+    "/{domain_id}",
+    response_model=EmailDomainResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def get_email_domain(
     domain_id: UUID,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -456,7 +470,11 @@ async def get_email_domain(
 # --------------------------------------------------------------------------- #
 
 
-@router.patch("/{domain_id}", response_model=EmailDomainResponse)
+@router.patch(
+    "/{domain_id}",
+    response_model=EmailDomainResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def patch_email_domain(
     domain_id: UUID,
     body: EmailDomainPatch,
@@ -546,7 +564,11 @@ async def patch_email_domain(
 # --------------------------------------------------------------------------- #
 
 
-@router.post("/{domain_id}/verify", response_model=EmailDomainResponse)
+@router.post(
+    "/{domain_id}/verify",
+    response_model=EmailDomainResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def verify_email_domain(
     domain_id: UUID,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -663,7 +685,11 @@ async def verify_email_domain(
 # --------------------------------------------------------------------------- #
 
 
-@router.delete("/{domain_id}", status_code=http_status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{domain_id}",
+    status_code=http_status.HTTP_204_NO_CONTENT,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def delete_email_domain(
     domain_id: UUID,
     principal: Annotated[Principal, Depends(get_current_principal)],

--- a/api/hailhq/api/routes/email_domains.py
+++ b/api/hailhq/api/routes/email_domains.py
@@ -30,13 +30,14 @@ from datetime import datetime, timezone
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi import status as http_status
 from hailhq.api.audit import write_audit_log
 from hailhq.api.deps import Principal, get_current_principal
 from hailhq.api.errors import unprocessable
 from hailhq.api.pagination import fetch_cursor_page
 from hailhq.api.ratelimit import GENERAL_RATE_LIMITED_RESPONSES
+from hailhq.api.route_prefixes import request_mount_prefix
 from hailhq.core.config import settings
 from hailhq.core.db import get_session
 from hailhq.core.dns_lookup import custom_dns_records, resolve_mx, ses_inbound_host
@@ -273,6 +274,7 @@ async def _unminted_hail_mail(db: AsyncSession, organization_id: UUID) -> str | 
 async def create_email_domain(
     body: EmailDomainCreate,
     response: Response,
+    request: Request,
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
     email_provider: Annotated[EmailProvider, Depends(get_email_provider)],
@@ -282,7 +284,7 @@ async def create_email_domain(
     kind="hail_mail" mints an address on the shared hail-mail domain and is
     immediately verified — no DNS work needed. kind="custom" registers your
     own domain with SES and returns DKIM records; the domain stays
-    unverified (POST /email-domains/{domain_id}/verify) until you publish
+    unverified (POST /v1/email-domains/{domain_id}/verify) until you publish
     those DNS records and Hail confirms them.
     """
     if body.kind == "hail_mail":
@@ -326,7 +328,9 @@ async def create_email_domain(
             resource_id=sd.id,
             payload={"kind": "hail_mail", "domain": sd.domain},
         )
-        response.headers["Location"] = f"/email-domains/{sd.id}"
+        response.headers["Location"] = (
+            f"{request_mount_prefix(request)}/email-domains/{sd.id}"
+        )
         return EmailDomainResponse.model_validate(sd)
 
     # kind == 'custom' — call SES, persist DKIM records, ask the tenant to
@@ -377,7 +381,9 @@ async def create_email_domain(
         resource_id=sd.id,
         payload={"kind": "custom", "domain": sd.domain},
     )
-    response.headers["Location"] = f"/email-domains/{sd.id}"
+    response.headers["Location"] = (
+        f"{request_mount_prefix(request)}/email-domains/{sd.id}"
+    )
     return EmailDomainResponse.model_validate(sd)
 
 
@@ -400,7 +406,7 @@ async def list_email_domains(
     """List sender domains/identities for the caller's organization.
 
     Cursor-paginated, newest first. The response also includes
-    default_from — the address a from-less POST /emails would use right
+    default_from — the address a from-less POST /v1/emails would use right
     now given the org's current verified senders.
     """
     stmt = select(EmailDomain).where(

--- a/api/hailhq/api/routes/emails.py
+++ b/api/hailhq/api/routes/emails.py
@@ -460,6 +460,15 @@ async def create_email(
     email_provider: Annotated[EmailProvider, Depends(get_email_provider)],
     idem: Annotated[IdempotencyContext | None, Depends(idempotency_dep)] = None,
 ) -> EmailResponse:
+    """Send an outbound email through SES.
+
+    Sends synchronously — the response reports the final status (sent or
+    failed), not a queued placeholder; no separate poll is needed for the
+    happy path, though a bounce or complaint can still arrive later as a
+    webhook or GET /emails/{email_id}/events entry. Requires
+    recipient_consent=true on the request body; Hail does not verify lawful
+    basis to contact the recipient, the caller warrants it.
+    """
     # Idempotency replay first — never re-send.
     if idem is not None and idem.is_replay:
         _, cached = replay_cached(idem, response, resource_prefix="/emails")
@@ -733,6 +742,12 @@ async def get_email_stats(
     to: Annotated[datetime | None, Query()] = None,
     bucket: Literal["hour", "day"] = Query(default="day"),
 ) -> EmailStatsResponse:
+    """Aggregate send/delivery/open/click/bounce counts and rates over a range.
+
+    Defaults to the last 7 days, bucketed by day. bucket=hour is limited to
+    an 8-day range; any bucket size is limited to a 92-day range. Registered
+    above GET /{email_id} so "stats" is not swallowed by the id path param.
+    """
     to_ts = to or datetime.now(timezone.utc)
     from_ts = from_ or to_ts - timedelta(days=7)
     if from_ts.tzinfo is None or to_ts.tzinfo is None:
@@ -827,6 +842,12 @@ async def get_email(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> EmailResponse:
+    """Fetch one email by id, including attachments and last event time.
+
+    Org-scoped: returns 404 for an email belonging to a different
+    organization. For an inbound email with a stored raw MIME, raw_url
+    points at GET /emails/{email_id}/raw.
+    """
     last_event_at = (
         select(func.max(EmailEvent.occurred_at))
         .where(EmailEvent.email_id == Email.id)
@@ -940,6 +961,13 @@ async def list_emails(
     status: EmailStatus | None = Query(default=None),
     direction: Literal["outbound", "inbound"] | None = Query(default=None),
 ) -> EmailListResponse:
+    """List emails for the caller's organization, newest first.
+
+    Cursor-paginated: pass the returned next_cursor to fetch the next page;
+    a null next_cursor means there are no more results. Filter by status or
+    direction (outbound/inbound). List entries omit body_text/body_html —
+    fetch GET /emails/{email_id} for the full body.
+    """
     stmt = (
         select(Email)
         .options(defer(Email.body_text), defer(Email.body_html))

--- a/api/hailhq/api/routes/emails.py
+++ b/api/hailhq/api/routes/emails.py
@@ -50,6 +50,7 @@ from hailhq.api.ratelimit import (
     GENERAL_RATE_LIMITED_RESPONSES,
     merge_rate_limited_responses,
 )
+from hailhq.api.route_prefixes import request_mount_prefix
 from hailhq.api.routes.email_domains import (
     compose_hail_mail_address,
     first_pending_custom,
@@ -455,6 +456,7 @@ async def deliver_email(
 async def create_email(
     body: EmailCreate,
     response: Response,
+    request: Request,
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
     email_provider: Annotated[EmailProvider, Depends(get_email_provider)],
@@ -465,13 +467,13 @@ async def create_email(
     Sends synchronously — the response reports the final status (sent or
     failed), not a queued placeholder; no separate poll is needed for the
     happy path, though a bounce or complaint can still arrive later as a
-    webhook or GET /emails/{email_id}/events entry. Requires
+    webhook or GET /v1/emails/{email_id}/events entry. Requires
     recipient_consent=true on the request body; Hail does not verify lawful
     basis to contact the recipient, the caller warrants it.
     """
     # Idempotency replay first — never re-send.
     if idem is not None and idem.is_replay:
-        _, cached = replay_cached(idem, response, resource_prefix="/emails")
+        _, cached = replay_cached(idem, response, request, resource_prefix="/emails")
         return EmailResponse.model_validate(cached)
 
     # Consent attestation gate — reject before any Email row is created.
@@ -628,7 +630,7 @@ async def create_email(
             detail=_SEND_FAILED_DETAIL,
         )
 
-    response.headers["Location"] = f"/emails/{email.id}"
+    response.headers["Location"] = f"{request_mount_prefix(request)}/emails/{email.id}"
     email_response = EmailResponse.model_validate(email)
 
     if idem is not None:
@@ -746,7 +748,7 @@ async def get_email_stats(
 
     Defaults to the last 7 days, bucketed by day. bucket=hour is limited to
     an 8-day range; any bucket size is limited to a 92-day range. Registered
-    above GET /{email_id} so "stats" is not swallowed by the id path param.
+    above GET /v1/emails/{email_id} so "stats" is not swallowed by the id path param.
     """
     to_ts = to or datetime.now(timezone.utc)
     from_ts = from_ or to_ts - timedelta(days=7)
@@ -846,7 +848,7 @@ async def get_email(
 
     Org-scoped: returns 404 for an email belonging to a different
     organization. For an inbound email with a stored raw MIME, raw_url
-    points at GET /emails/{email_id}/raw.
+    points at GET /v1/emails/{email_id}/raw.
     """
     last_event_at = (
         select(func.max(EmailEvent.occurred_at))
@@ -966,7 +968,7 @@ async def list_emails(
     Cursor-paginated: pass the returned next_cursor to fetch the next page;
     a null next_cursor means there are no more results. Filter by status or
     direction (outbound/inbound). List entries omit body_text/body_html —
-    fetch GET /emails/{email_id} for the full body.
+    fetch GET /v1/emails/{email_id} for the full body.
     """
     stmt = (
         select(Email)

--- a/api/hailhq/api/routes/emails.py
+++ b/api/hailhq/api/routes/emails.py
@@ -103,7 +103,9 @@ from sqlalchemy.orm import defer
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/emails", tags=["emails"])
+router = APIRouter(
+    prefix="/emails", tags=["emails"], responses=GENERAL_RATE_LIMITED_RESPONSES
+)
 
 _DEFAULT_LIST_LIMIT = 50
 _MAX_LIST_LIMIT = 200
@@ -654,7 +656,6 @@ _MAX_EVENTS_LIMIT = 1000
 @router.get(
     "/{email_id}/events",
     response_model=EmailEventListResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def list_email_events(
     email_id: UUID,
@@ -735,7 +736,6 @@ def _truncate(ts: datetime, bucket: str) -> datetime:
 @router.get(
     "/stats",
     response_model=EmailStatsResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def get_email_stats(
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -836,7 +836,6 @@ async def get_email_stats(
 @router.get(
     "/{email_id}",
     response_model=EmailResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def get_email(
     email_id: UUID,
@@ -899,7 +898,7 @@ async def get_email(
 # --------------------------------------------------------------------------- #
 
 
-@router.get("/{email_id}/raw", responses=GENERAL_RATE_LIMITED_RESPONSES)
+@router.get("/{email_id}/raw")
 async def get_email_raw(
     email_id: UUID,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -923,7 +922,6 @@ async def get_email_raw(
 
 @router.get(
     "/{email_id}/attachments/{attachment_id}",
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def get_email_attachment(
     email_id: UUID,
@@ -953,7 +951,6 @@ async def get_email_attachment(
 @router.get(
     "",
     response_model=EmailListResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def list_emails(
     principal: Annotated[Principal, Depends(get_current_principal)],

--- a/api/hailhq/api/routes/emails.py
+++ b/api/hailhq/api/routes/emails.py
@@ -46,6 +46,10 @@ from hailhq.api.idempotency import (
     replay_cached,
 )
 from hailhq.api.pagination import fetch_cursor_page
+from hailhq.api.ratelimit import (
+    GENERAL_RATE_LIMITED_RESPONSES,
+    merge_rate_limited_responses,
+)
 from hailhq.api.routes.email_domains import (
     compose_hail_mail_address,
     first_pending_custom,
@@ -444,7 +448,9 @@ async def deliver_email(
     "",
     response_model=EmailResponse,
     status_code=http_status.HTTP_201_CREATED,
-    responses=RATE_LIMITED_RESPONSES,
+    responses=merge_rate_limited_responses(
+        RATE_LIMITED_RESPONSES, GENERAL_RATE_LIMITED_RESPONSES
+    ),
 )
 async def create_email(
     body: EmailCreate,
@@ -634,7 +640,11 @@ _DEFAULT_EVENTS_LIMIT = 100
 _MAX_EVENTS_LIMIT = 1000
 
 
-@router.get("/{email_id}/events", response_model=EmailEventListResponse)
+@router.get(
+    "/{email_id}/events",
+    response_model=EmailEventListResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def list_email_events(
     email_id: UUID,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -711,7 +721,11 @@ def _truncate(ts: datetime, bucket: str) -> datetime:
     return ts.replace(hour=0, minute=0, second=0, microsecond=0)
 
 
-@router.get("/stats", response_model=EmailStatsResponse)
+@router.get(
+    "/stats",
+    response_model=EmailStatsResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def get_email_stats(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
@@ -802,7 +816,11 @@ async def get_email_stats(
 # --------------------------------------------------------------------------- #
 
 
-@router.get("/{email_id}", response_model=EmailResponse)
+@router.get(
+    "/{email_id}",
+    response_model=EmailResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def get_email(
     email_id: UUID,
     request: Request,
@@ -858,7 +876,7 @@ async def get_email(
 # --------------------------------------------------------------------------- #
 
 
-@router.get("/{email_id}/raw")
+@router.get("/{email_id}/raw", responses=GENERAL_RATE_LIMITED_RESPONSES)
 async def get_email_raw(
     email_id: UUID,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -880,7 +898,10 @@ async def get_email_raw(
     return RedirectResponse(url=url, status_code=http_status.HTTP_302_FOUND)
 
 
-@router.get("/{email_id}/attachments/{attachment_id}")
+@router.get(
+    "/{email_id}/attachments/{attachment_id}",
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def get_email_attachment(
     email_id: UUID,
     attachment_id: UUID,
@@ -906,7 +927,11 @@ async def get_email_attachment(
     return RedirectResponse(url=url, status_code=http_status.HTTP_302_FOUND)
 
 
-@router.get("", response_model=EmailListResponse)
+@router.get(
+    "",
+    response_model=EmailListResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def list_emails(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],

--- a/api/hailhq/api/routes/events.py
+++ b/api/hailhq/api/routes/events.py
@@ -157,6 +157,13 @@ async def list_events(
     id: str | None = Query(default=None),
     kind: str | None = Query(default=None),
 ) -> EventStreamResponse:
+    """Cursor-paginated forward stream of call, email, and SMS events.
+
+    Scoped to the caller's organization. Pass id (typed "<type>:<uuid>",
+    e.g. "call:<uuid>") to narrow to one resource's events, or kind to
+    narrow to one event kind. Walks forward in time — pass the returned
+    next_cursor to continue tailing where you left off.
+    """
     # Org scoping is the security-critical bit. We always join through Call so
     # the principal can never see another org's events, even by guessing a
     # call_id. The kind filter is a passthrough (no enum validation): event

--- a/api/hailhq/api/routes/events.py
+++ b/api/hailhq/api/routes/events.py
@@ -24,6 +24,7 @@ from fastapi import status as http_status
 from hailhq.api.deps import Principal, get_current_principal
 from hailhq.api.errors import unprocessable
 from hailhq.api.pagination import fetch_cursor_page
+from hailhq.api.ratelimit import GENERAL_RATE_LIMITED_RESPONSES
 from hailhq.core.db import get_session
 from hailhq.core.models import Call, CallEvent, Email, EmailEvent, Sms, SmsEvent
 from hailhq.core.schemas import (
@@ -143,7 +144,11 @@ async def _require_owned(
 # --------------------------------------------------------------------------- #
 
 
-@router.get("", response_model=EventStreamResponse)
+@router.get(
+    "",
+    response_model=EventStreamResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def list_events(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],

--- a/api/hailhq/api/routes/events.py
+++ b/api/hailhq/api/routes/events.py
@@ -37,7 +37,9 @@ from sqlalchemy import literal, select, union_all
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
-router = APIRouter(prefix="/events", tags=["events"])
+router = APIRouter(
+    prefix="/events", tags=["events"], responses=GENERAL_RATE_LIMITED_RESPONSES
+)
 
 
 # Typed NULL for the id columns a source doesn't own. An untyped
@@ -147,7 +149,6 @@ async def _require_owned(
 @router.get(
     "",
     response_model=EventStreamResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def list_events(
     principal: Annotated[Principal, Depends(get_current_principal)],

--- a/api/hailhq/api/routes/numbers.py
+++ b/api/hailhq/api/routes/numbers.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi import status as http_status
 from hailhq.api.audit import write_audit_log
 from hailhq.api.deps import Principal, get_current_principal
@@ -29,6 +29,7 @@ from hailhq.api.idempotency import (
 )
 from hailhq.api.pagination import fetch_cursor_page
 from hailhq.api.ratelimit import GENERAL_RATE_LIMITED_RESPONSES
+from hailhq.api.route_prefixes import request_mount_prefix
 from hailhq.api.routes.sms import get_sms_provider
 from hailhq.core import telephony_catalog
 from hailhq.core.db import get_session
@@ -94,6 +95,7 @@ async def _get_org_number_or_404(
 async def acquire_number(
     body: NumberAcquireRequest,
     response: Response,
+    request: Request,
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
     provider: Annotated[VoiceProvider, Depends(get_voice_provider)],
@@ -107,7 +109,9 @@ async def acquire_number(
     what the carrier offers for the given country_code/number_type.
     """
     if idem is not None and idem.is_replay:
-        _cached_id, cached = replay_cached(idem, response, resource_prefix="/numbers")
+        _cached_id, cached = replay_cached(
+            idem, response, request, resource_prefix="/numbers"
+        )
         return PhoneNumberResponse.model_validate(cached)
 
     # Acquiring buys a real number at the carrier and starts a monthly fee —
@@ -195,7 +199,9 @@ async def acquire_number(
     # and expire_on_commit=False keeps it live; PhoneNumberResponse reads no
     # other server-generated column.
 
-    response.headers["Location"] = f"/numbers/{number.id}"
+    response.headers["Location"] = (
+        f"{request_mount_prefix(request)}/numbers/{number.id}"
+    )
     number_response = PhoneNumberResponse.model_validate(number)
     if idem is not None:
         await idem.store(

--- a/api/hailhq/api/routes/numbers.py
+++ b/api/hailhq/api/routes/numbers.py
@@ -28,6 +28,7 @@ from hailhq.api.idempotency import (
     replay_cached,
 )
 from hailhq.api.pagination import fetch_cursor_page
+from hailhq.api.ratelimit import GENERAL_RATE_LIMITED_RESPONSES
 from hailhq.api.routes.sms import get_sms_provider
 from hailhq.core import telephony_catalog
 from hailhq.core.db import get_session
@@ -85,7 +86,10 @@ async def _get_org_number_or_404(
 
 
 @router.post(
-    "", response_model=PhoneNumberResponse, status_code=http_status.HTTP_201_CREATED
+    "",
+    response_model=PhoneNumberResponse,
+    status_code=http_status.HTTP_201_CREATED,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def acquire_number(
     body: NumberAcquireRequest,
@@ -248,7 +252,11 @@ async def release_org_number(
     return number
 
 
-@router.delete("/{number_id}", status_code=http_status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{number_id}",
+    status_code=http_status.HTTP_204_NO_CONTENT,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def release_number(
     number_id: UUID,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -274,7 +282,11 @@ async def release_number(
         )
 
 
-@router.get("/{number_id}", response_model=PhoneNumberResponse)
+@router.get(
+    "/{number_id}",
+    response_model=PhoneNumberResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def get_number(
     number_id: UUID,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -284,7 +296,11 @@ async def get_number(
     return PhoneNumberResponse.model_validate(number)
 
 
-@router.get("", response_model=PhoneNumberListResponse)
+@router.get(
+    "",
+    response_model=PhoneNumberListResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def list_numbers(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
@@ -310,7 +326,11 @@ async def list_numbers(
     )
 
 
-@router.post("/{number_id}/enable-sms", response_model=PhoneNumberResponse)
+@router.post(
+    "/{number_id}/enable-sms",
+    response_model=PhoneNumberResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def enable_sms(
     number_id: UUID,
     principal: Annotated[Principal, Depends(get_current_principal)],

--- a/api/hailhq/api/routes/numbers.py
+++ b/api/hailhq/api/routes/numbers.py
@@ -46,7 +46,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/numbers", tags=["numbers"])
+router = APIRouter(
+    prefix="/numbers", tags=["numbers"], responses=GENERAL_RATE_LIMITED_RESPONSES
+)
 
 _DEFAULT_LIST_LIMIT = 50
 _MAX_LIST_LIMIT = 200
@@ -90,7 +92,6 @@ async def _get_org_number_or_404(
     "",
     response_model=PhoneNumberResponse,
     status_code=http_status.HTTP_201_CREATED,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def acquire_number(
     body: NumberAcquireRequest,
@@ -268,7 +269,6 @@ async def release_org_number(
 @router.delete(
     "/{number_id}",
     status_code=http_status.HTTP_204_NO_CONTENT,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def release_number(
     number_id: UUID,
@@ -298,7 +298,6 @@ async def release_number(
 @router.get(
     "/{number_id}",
     response_model=PhoneNumberResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def get_number(
     number_id: UUID,
@@ -317,7 +316,6 @@ async def get_number(
 @router.get(
     "",
     response_model=PhoneNumberListResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def list_numbers(
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -352,7 +350,6 @@ async def list_numbers(
 @router.post(
     "/{number_id}/enable-sms",
     response_model=PhoneNumberResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def enable_sms(
     number_id: UUID,

--- a/api/hailhq/api/routes/numbers.py
+++ b/api/hailhq/api/routes/numbers.py
@@ -99,6 +99,13 @@ async def acquire_number(
     provider: Annotated[VoiceProvider, Depends(get_voice_provider)],
     idem: Annotated[IdempotencyContext | None, Depends(idempotency_dep)] = None,
 ) -> PhoneNumberResponse:
+    """Buy a dedicated phone number for the caller's organization.
+
+    This purchases a real number at the carrier and starts a recurring
+    monthly fee immediately — it is not a reservation. The number is usable
+    for voice, SMS, or both depending on the requested capabilities and
+    what the carrier offers for the given country_code/number_type.
+    """
     if idem is not None and idem.is_replay:
         _cached_id, cached = replay_cached(idem, response, resource_prefix="/numbers")
         return PhoneNumberResponse.model_validate(cached)
@@ -292,6 +299,11 @@ async def get_number(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> PhoneNumberResponse:
+    """Fetch one dedicated number by id, including its capabilities and state.
+
+    Org-scoped: returns 404 for a number belonging to a different
+    organization.
+    """
     number = await _get_org_number_or_404(db, number_id, principal.organization_id)
     return PhoneNumberResponse.model_validate(number)
 
@@ -307,6 +319,11 @@ async def list_numbers(
     cursor: str | None = Query(default=None),
     limit: int = Query(default=_DEFAULT_LIST_LIMIT, ge=1, le=_MAX_LIST_LIMIT),
 ) -> PhoneNumberListResponse:
+    """List dedicated numbers owned by the caller's organization.
+
+    Cursor-paginated, newest first. Only org-owned numbers are listed —
+    shared pool numbers used for outbound calls never appear here.
+    """
     stmt = select(PhoneNumber).where(
         PhoneNumber.organization_id == principal.organization_id,
         PhoneNumber.is_pool.is_(False),
@@ -337,6 +354,14 @@ async def enable_sms(
     db: Annotated[AsyncSession, Depends(get_session)],
     provider: Annotated[SmsProvider, Depends(get_sms_provider)],
 ) -> PhoneNumberResponse:
+    """Attach a dedicated number to the org's shared SMS Messaging Service.
+
+    Required once per number before it can send/receive SMS; the number
+    must already have been acquired with sms capability. Idempotent —
+    calling this again on an already-enabled number just returns its
+    current state. Fails with 422 for a released number or one that lacks
+    sms capability.
+    """
     number = await _get_org_number_or_404(db, number_id, principal.organization_id)
 
     _reject_if_released(number)

--- a/api/hailhq/api/routes/providers.py
+++ b/api/hailhq/api/routes/providers.py
@@ -66,14 +66,15 @@ from hailhq.core.schemas import (
 )
 from sqlalchemy.ext.asyncio import AsyncSession
 
-router = APIRouter(prefix="/providers", tags=["providers"])
+router = APIRouter(
+    prefix="/providers", tags=["providers"], responses=GENERAL_RATE_LIMITED_RESPONSES
+)
 
 
 @router.get(
     "",
     response_model=ProviderConfigListResponse,
     operation_id="list_providers",
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def list_providers(
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -87,7 +88,6 @@ async def list_providers(
     "/{layer}",
     response_model=ProviderConfigEntry,
     operation_id="upsert_provider",
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def upsert_provider(
     layer: str,
@@ -141,7 +141,6 @@ async def upsert_provider(
     "/{layer}/{provider}",
     status_code=204,
     operation_id="delete_provider",
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def delete_provider(
     layer: str,
@@ -159,7 +158,6 @@ async def delete_provider(
     "/{layer}/activate",
     response_model=ProviderConfigEntry,
     operation_id="activate_provider",
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def activate_provider(
     layer: str,
@@ -178,7 +176,6 @@ async def activate_provider(
     "/{layer}/validate",
     response_model=ProviderValidateResult,
     operation_id="validate_provider",
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def validate_provider(
     layer: str,

--- a/api/hailhq/api/routes/providers.py
+++ b/api/hailhq/api/routes/providers.py
@@ -33,6 +33,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from hailhq.api.deps import Principal, get_current_principal
+from hailhq.api.ratelimit import GENERAL_RATE_LIMITED_RESPONSES
 from hailhq.api.routes.internal.provider_config import (
     ActivateIn,
     ProviderConfigIn,
@@ -69,7 +70,10 @@ router = APIRouter(prefix="/providers", tags=["providers"])
 
 
 @router.get(
-    "", response_model=ProviderConfigListResponse, operation_id="list_providers"
+    "",
+    response_model=ProviderConfigListResponse,
+    operation_id="list_providers",
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def list_providers(
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -80,7 +84,10 @@ async def list_providers(
 
 
 @router.put(
-    "/{layer}", response_model=ProviderConfigEntry, operation_id="upsert_provider"
+    "/{layer}",
+    response_model=ProviderConfigEntry,
+    operation_id="upsert_provider",
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def upsert_provider(
     layer: str,
@@ -130,7 +137,12 @@ async def upsert_provider(
     )
 
 
-@router.delete("/{layer}/{provider}", status_code=204, operation_id="delete_provider")
+@router.delete(
+    "/{layer}/{provider}",
+    status_code=204,
+    operation_id="delete_provider",
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def delete_provider(
     layer: str,
     provider: str,
@@ -147,6 +159,7 @@ async def delete_provider(
     "/{layer}/activate",
     response_model=ProviderConfigEntry,
     operation_id="activate_provider",
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def activate_provider(
     layer: str,
@@ -165,6 +178,7 @@ async def activate_provider(
     "/{layer}/validate",
     response_model=ProviderValidateResult,
     operation_id="validate_provider",
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def validate_provider(
     layer: str,

--- a/api/hailhq/api/routes/sms.py
+++ b/api/hailhq/api/routes/sms.py
@@ -204,6 +204,17 @@ async def create_sms(
     provider: Annotated[SmsProvider, Depends(get_sms_provider)],
     idem: Annotated[IdempotencyContext | None, Depends(idempotency_dep)] = None,
 ) -> SmsResponse:
+    """Send an outbound SMS.
+
+    Sends synchronously — the response reports the final status (sent or
+    failed), not a queued placeholder, though delivery confirmation from
+    the carrier can still arrive later as a webhook or GET /sms/{sms_id}
+    update. An explicit from resolves a dedicated number; otherwise Hail
+    picks an alphanumeric sender ID where the destination corridor allows
+    it, or requires a dedicated SMS-capable number otherwise. Requires
+    recipient_consent=true on the request body; Hail does not verify
+    lawful basis to contact the recipient, the caller warrants it.
+    """
     if idem is not None and idem.is_replay:
         cached_id, cached = replay_cached(idem, response, resource_prefix="/sms")
         await write_audit_log(
@@ -471,6 +482,11 @@ async def list_sms_suppressions(
     cursor: str | None = Query(default=None),
     limit: int = Query(default=_DEFAULT_LIST_LIMIT, ge=1, le=_MAX_LIST_LIMIT),
 ) -> SuppressionListResponse:
+    """List SMS numbers suppressed from receiving messages, newest first.
+
+    Cursor-paginated. A suppressed number blocks POST /sms sends to it
+    with a 403 until removed via DELETE /sms/suppressions/{number}.
+    """
     stmt = select(Suppression).where(
         Suppression.organization_id == principal.organization_id,
         Suppression.channel == "sms",
@@ -500,6 +516,12 @@ async def delete_sms_suppression(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> None:
+    """Remove one number from the SMS suppression list, re-allowing sends to it.
+
+    Does not itself constitute renewed consent — the caller is responsible
+    for having a lawful basis (e.g. a fresh opt-in) before sending again.
+    Returns 404 if the number was not suppressed.
+    """
     removed = await remove_suppression(
         db, organization_id=principal.organization_id, recipient=number, channel="sms"
     )
@@ -519,6 +541,11 @@ async def get_sender_id(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> SenderIdResponse:
+    """Get the org's custom alphanumeric SMS sender ID, if any is set.
+
+    effective_default is the platform sender id used for
+    alphanumeric-eligible corridors when custom_sender_id is null.
+    """
     stmt = select(SmsSenderIdentity).where(
         SmsSenderIdentity.organization_id == principal.organization_id
     )
@@ -539,6 +566,12 @@ async def patch_sender_id(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> SenderIdResponse:
+    """Set or clear the org's custom alphanumeric SMS sender ID.
+
+    Pass custom_sender_id=null to clear it and fall back to the platform
+    default sender id. Only affects alphanumeric-eligible corridors — a
+    corridor requiring a dedicated number is unaffected.
+    """
     if body.custom_sender_id is None:
         # Clear: unconditional delete (a no-op when no row exists), so there is
         # no read-then-delete window.
@@ -583,6 +616,11 @@ async def get_sms(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> SmsResponse:
+    """Fetch one SMS by id, including its current status.
+
+    Org-scoped: returns 404 for an SMS belonging to a different
+    organization.
+    """
     stmt = select(Sms).where(
         Sms.id == sms_id,
         Sms.organization_id == principal.organization_id,
@@ -608,6 +646,12 @@ async def list_sms(
     status: SmsStatus | None = Query(default=None),
     to: str | None = Query(default=None),
 ) -> SmsListResponse:
+    """List SMS messages for the caller's organization, newest first.
+
+    Cursor-paginated: pass the returned next_cursor to fetch the next page;
+    a null next_cursor means there are no more results. Filter by status or
+    destination number (to) to narrow the list.
+    """
     stmt = select(Sms).where(Sms.organization_id == principal.organization_id)
     if status is not None:
         stmt = stmt.where(Sms.status == status)

--- a/api/hailhq/api/routes/sms.py
+++ b/api/hailhq/api/routes/sms.py
@@ -39,6 +39,7 @@ from hailhq.api.ratelimit import (
     GENERAL_RATE_LIMITED_RESPONSES,
     merge_rate_limited_responses,
 )
+from hailhq.api.route_prefixes import request_mount_prefix
 from hailhq.api.usage import write_usage_event
 from hailhq.core.compliance_gate import check_sms_allowed, remove_suppression
 from hailhq.core.config import settings
@@ -199,6 +200,7 @@ async def deliver_sms(db: AsyncSession, provider: SmsProvider, sms: Sms) -> str 
 async def create_sms(
     body: SmsCreate,
     response: Response,
+    request: Request,
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
     provider: Annotated[SmsProvider, Depends(get_sms_provider)],
@@ -208,7 +210,7 @@ async def create_sms(
 
     Sends synchronously — the response reports the final status (sent or
     failed), not a queued placeholder, though delivery confirmation from
-    the carrier can still arrive later as a webhook or GET /sms/{sms_id}
+    the carrier can still arrive later as a webhook or GET /v1/sms/{sms_id}
     update. An explicit from resolves a dedicated number; otherwise Hail
     picks an alphanumeric sender ID where the destination corridor allows
     it, or requires a dedicated SMS-capable number otherwise. Requires
@@ -216,7 +218,9 @@ async def create_sms(
     lawful basis to contact the recipient, the caller warrants it.
     """
     if idem is not None and idem.is_replay:
-        cached_id, cached = replay_cached(idem, response, resource_prefix="/sms")
+        cached_id, cached = replay_cached(
+            idem, response, request, resource_prefix="/sms"
+        )
         await write_audit_log(
             organization_id=principal.organization_id,
             api_key_id=principal.api_key_id,
@@ -348,7 +352,7 @@ async def create_sms(
     # carrier rejection: row already reconciled to failed; fall through and
     # return the SmsResponse exactly as before.
 
-    response.headers["Location"] = f"/sms/{sms.id}"
+    response.headers["Location"] = f"{request_mount_prefix(request)}/sms/{sms.id}"
     sms_response = SmsResponse.model_validate(sms)
 
     if idem is not None:
@@ -484,8 +488,8 @@ async def list_sms_suppressions(
 ) -> SuppressionListResponse:
     """List SMS numbers suppressed from receiving messages, newest first.
 
-    Cursor-paginated. A suppressed number blocks POST /sms sends to it
-    with a 403 until removed via DELETE /sms/suppressions/{number}.
+    Cursor-paginated. A suppressed number blocks POST /v1/sms sends to it
+    with a 403 until removed via DELETE /v1/sms/suppressions/{number}.
     """
     stmt = select(Suppression).where(
         Suppression.organization_id == principal.organization_id,

--- a/api/hailhq/api/routes/sms.py
+++ b/api/hailhq/api/routes/sms.py
@@ -69,7 +69,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/sms", tags=["sms"])
+router = APIRouter(
+    prefix="/sms", tags=["sms"], responses=GENERAL_RATE_LIMITED_RESPONSES
+)
 
 _DEFAULT_LIST_LIMIT = 50
 _MAX_LIST_LIMIT = 200
@@ -478,7 +480,6 @@ async def receive_sms_status(
 @router.get(
     "/suppressions",
     response_model=SuppressionListResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def list_sms_suppressions(
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -513,7 +514,6 @@ async def list_sms_suppressions(
 @router.delete(
     "/suppressions/{number}",
     status_code=http_status.HTTP_204_NO_CONTENT,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def delete_sms_suppression(
     number: str,
@@ -539,7 +539,6 @@ async def delete_sms_suppression(
 @router.get(
     "/sender-id",
     response_model=SenderIdResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def get_sender_id(
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -563,7 +562,6 @@ async def get_sender_id(
 @router.patch(
     "/sender-id",
     response_model=SenderIdResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def patch_sender_id(
     body: SenderIdPatch,
@@ -613,7 +611,6 @@ async def patch_sender_id(
 @router.get(
     "/{sms_id}",
     response_model=SmsResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def get_sms(
     sms_id: UUID,
@@ -640,7 +637,6 @@ async def get_sms(
 @router.get(
     "",
     response_model=SmsListResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def list_sms(
     principal: Annotated[Principal, Depends(get_current_principal)],

--- a/api/hailhq/api/routes/sms.py
+++ b/api/hailhq/api/routes/sms.py
@@ -35,6 +35,10 @@ from hailhq.api.idempotency import (
 )
 from hailhq.api.numbers import resolve_org_number
 from hailhq.api.pagination import fetch_cursor_page
+from hailhq.api.ratelimit import (
+    GENERAL_RATE_LIMITED_RESPONSES,
+    merge_rate_limited_responses,
+)
 from hailhq.api.usage import write_usage_event
 from hailhq.core.compliance_gate import check_sms_allowed, remove_suppression
 from hailhq.core.config import settings
@@ -188,7 +192,9 @@ async def deliver_sms(db: AsyncSession, provider: SmsProvider, sms: Sms) -> str 
     "",
     response_model=SmsResponse,
     status_code=http_status.HTTP_201_CREATED,
-    responses=RATE_LIMITED_RESPONSES,
+    responses=merge_rate_limited_responses(
+        RATE_LIMITED_RESPONSES, GENERAL_RATE_LIMITED_RESPONSES
+    ),
 )
 async def create_sms(
     body: SmsCreate,
@@ -454,7 +460,11 @@ async def receive_sms_status(
     return {"status": "applied"}
 
 
-@router.get("/suppressions", response_model=SuppressionListResponse)
+@router.get(
+    "/suppressions",
+    response_model=SuppressionListResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def list_sms_suppressions(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
@@ -480,7 +490,11 @@ async def list_sms_suppressions(
     )
 
 
-@router.delete("/suppressions/{number}", status_code=http_status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/suppressions/{number}",
+    status_code=http_status.HTTP_204_NO_CONTENT,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def delete_sms_suppression(
     number: str,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -496,7 +510,11 @@ async def delete_sms_suppression(
     await db.commit()
 
 
-@router.get("/sender-id", response_model=SenderIdResponse)
+@router.get(
+    "/sender-id",
+    response_model=SenderIdResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def get_sender_id(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
@@ -511,7 +529,11 @@ async def get_sender_id(
     )
 
 
-@router.patch("/sender-id", response_model=SenderIdResponse)
+@router.patch(
+    "/sender-id",
+    response_model=SenderIdResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def patch_sender_id(
     body: SenderIdPatch,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -551,7 +573,11 @@ async def patch_sender_id(
     )
 
 
-@router.get("/{sms_id}", response_model=SmsResponse)
+@router.get(
+    "/{sms_id}",
+    response_model=SmsResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def get_sms(
     sms_id: UUID,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -569,7 +595,11 @@ async def get_sms(
     return SmsResponse.model_validate(sms)
 
 
-@router.get("", response_model=SmsListResponse)
+@router.get(
+    "",
+    response_model=SmsListResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def list_sms(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],

--- a/api/hailhq/api/routes/unsubscribe.py
+++ b/api/hailhq/api/routes/unsubscribe.py
@@ -15,6 +15,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import HTMLResponse
+from hailhq.api.ratelimit import GENERAL_RATE_LIMITED_RESPONSES
 from hailhq.core.compliance_gate import add_suppression
 from hailhq.core.db import get_session
 from hailhq.core.unsubscribe import InvalidUnsubscribeToken, verify_unsubscribe_token
@@ -25,7 +26,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["unsubscribe"])
 
 
-@router.get("/unsubscribe", response_class=HTMLResponse)
+@router.get(
+    "/unsubscribe",
+    response_class=HTMLResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def unsubscribe(
     db: Annotated[AsyncSession, Depends(get_session)],
     token: Annotated[str, Query()],

--- a/api/hailhq/api/routes/unsubscribe.py
+++ b/api/hailhq/api/routes/unsubscribe.py
@@ -35,6 +35,13 @@ async def unsubscribe(
     db: Annotated[AsyncSession, Depends(get_session)],
     token: Annotated[str, Query()],
 ) -> HTMLResponse:
+    """One-click email opt-out (RFC 8058), reached by clicking a link in a sent email.
+
+    Public and unauthenticated — the signed token query param is the sole
+    credential, proving the caller holds a link Hail sent to that address.
+    On success, the address is added to the org's suppression list and all
+    future outbound email to it is blocked. Returns an HTML page, not JSON.
+    """
     try:
         email, organization_id = verify_unsubscribe_token(token)
     except InvalidUnsubscribeToken:

--- a/api/hailhq/api/routes/unsubscribe.py
+++ b/api/hailhq/api/routes/unsubscribe.py
@@ -15,7 +15,6 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import HTMLResponse
-from hailhq.api.ratelimit import GENERAL_RATE_LIMITED_RESPONSES
 from hailhq.core.compliance_gate import add_suppression
 from hailhq.core.db import get_session
 from hailhq.core.unsubscribe import InvalidUnsubscribeToken, verify_unsubscribe_token
@@ -29,7 +28,6 @@ router = APIRouter(tags=["unsubscribe"])
 @router.get(
     "/unsubscribe",
     response_class=HTMLResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def unsubscribe(
     db: Annotated[AsyncSession, Depends(get_session)],

--- a/api/hailhq/api/routes/webhooks.py
+++ b/api/hailhq/api/routes/webhooks.py
@@ -45,7 +45,9 @@ from hailhq.core.secret_cipher import SecretCipher
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-router = APIRouter(prefix="/webhooks", tags=["webhooks"])
+router = APIRouter(
+    prefix="/webhooks", tags=["webhooks"], responses=GENERAL_RATE_LIMITED_RESPONSES
+)
 
 _DEFAULT_LIMIT = 50
 _MAX_LIMIT = 200
@@ -84,7 +86,6 @@ async def _load_owned(
     "",
     response_model=WebhookSubscriptionResponse,
     status_code=http_status.HTTP_201_CREATED,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def create_subscription(
     body: WebhookSubscriptionCreate,
@@ -130,7 +131,6 @@ async def create_subscription(
 @router.get(
     "",
     response_model=WebhookSubscriptionListResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def list_subscriptions(
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -163,7 +163,6 @@ async def list_subscriptions(
 @router.get(
     "/{sub_id}",
     response_model=WebhookSubscriptionResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def get_subscription(
     sub_id: UUID,
@@ -178,7 +177,6 @@ async def get_subscription(
 @router.patch(
     "/{sub_id}",
     response_model=WebhookSubscriptionResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def patch_subscription(
     sub_id: UUID,
@@ -235,7 +233,6 @@ async def patch_subscription(
 @router.delete(
     "/{sub_id}",
     status_code=http_status.HTTP_204_NO_CONTENT,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def delete_subscription(
     sub_id: UUID,
@@ -264,7 +261,6 @@ async def delete_subscription(
 @router.post(
     "/{sub_id}/rotate-secret",
     response_model=WebhookSubscriptionResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def rotate_secret(
     sub_id: UUID,
@@ -305,7 +301,6 @@ async def rotate_secret(
 @router.get(
     "/{sub_id}/deliveries",
     response_model=WebhookDeliveryListResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def list_deliveries(
     sub_id: UUID,
@@ -340,7 +335,6 @@ async def list_deliveries(
 @router.post(
     "/{sub_id}/deliveries/{delivery_id}/redeliver",
     response_model=WebhookDeliveryResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def redeliver(
     sub_id: UUID,

--- a/api/hailhq/api/routes/webhooks.py
+++ b/api/hailhq/api/routes/webhooks.py
@@ -28,6 +28,7 @@ from hailhq.api.audit import write_audit_log
 from hailhq.api.deps import Principal, get_current_principal
 from hailhq.api.errors import unprocessable
 from hailhq.api.pagination import fetch_cursor_page
+from hailhq.api.ratelimit import GENERAL_RATE_LIMITED_RESPONSES
 from hailhq.core.config import settings
 from hailhq.core.db import get_session
 from hailhq.core.http_post import validate_webhook_target
@@ -83,6 +84,7 @@ async def _load_owned(
     "",
     response_model=WebhookSubscriptionResponse,
     status_code=http_status.HTTP_201_CREATED,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def create_subscription(
     body: WebhookSubscriptionCreate,
@@ -118,7 +120,11 @@ async def create_subscription(
     return _to_response(sub, secret=secret)
 
 
-@router.get("", response_model=WebhookSubscriptionListResponse)
+@router.get(
+    "",
+    response_model=WebhookSubscriptionListResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def list_subscriptions(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
@@ -142,7 +148,11 @@ async def list_subscriptions(
     )
 
 
-@router.get("/{sub_id}", response_model=WebhookSubscriptionResponse)
+@router.get(
+    "/{sub_id}",
+    response_model=WebhookSubscriptionResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def get_subscription(
     sub_id: UUID,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -152,7 +162,11 @@ async def get_subscription(
     return _to_response(sub)
 
 
-@router.patch("/{sub_id}", response_model=WebhookSubscriptionResponse)
+@router.patch(
+    "/{sub_id}",
+    response_model=WebhookSubscriptionResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def patch_subscription(
     sub_id: UUID,
     body: WebhookSubscriptionPatch,
@@ -198,7 +212,11 @@ async def patch_subscription(
     return _to_response(sub)
 
 
-@router.delete("/{sub_id}", status_code=http_status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{sub_id}",
+    status_code=http_status.HTTP_204_NO_CONTENT,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def delete_subscription(
     sub_id: UUID,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -218,7 +236,11 @@ async def delete_subscription(
     return Response(status_code=http_status.HTTP_204_NO_CONTENT)
 
 
-@router.post("/{sub_id}/rotate-secret", response_model=WebhookSubscriptionResponse)
+@router.post(
+    "/{sub_id}/rotate-secret",
+    response_model=WebhookSubscriptionResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def rotate_secret(
     sub_id: UUID,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -249,7 +271,11 @@ async def rotate_secret(
     return _to_response(sub, secret=secret)
 
 
-@router.get("/{sub_id}/deliveries", response_model=WebhookDeliveryListResponse)
+@router.get(
+    "/{sub_id}/deliveries",
+    response_model=WebhookDeliveryListResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def list_deliveries(
     sub_id: UUID,
     principal: Annotated[Principal, Depends(get_current_principal)],
@@ -277,6 +303,7 @@ async def list_deliveries(
 @router.post(
     "/{sub_id}/deliveries/{delivery_id}/redeliver",
     response_model=WebhookDeliveryResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def redeliver(
     sub_id: UUID,

--- a/api/hailhq/api/routes/webhooks.py
+++ b/api/hailhq/api/routes/webhooks.py
@@ -95,7 +95,7 @@ async def create_subscription(
 
     The response includes the plaintext signing secret — this is the only
     time it is ever returned; store it now. Every later GET omits it. Use
-    POST /webhooks/{sub_id}/rotate-secret to get a new plaintext secret if
+    POST /v1/webhooks/{sub_id}/rotate-secret to get a new plaintext secret if
     it is lost or compromised.
     """
     try:
@@ -141,7 +141,7 @@ async def list_subscriptions(
     """List webhook subscriptions for the caller's organization.
 
     Cursor-paginated, newest first. The signing secret is never included —
-    only POST /webhooks and POST /webhooks/{sub_id}/rotate-secret return it.
+    only POST /v1/webhooks and POST /v1/webhooks/{sub_id}/rotate-secret return it.
     """
     stmt = select(WebhookSubscription).where(
         WebhookSubscription.organization_id == principal.organization_id
@@ -317,7 +317,7 @@ async def list_deliveries(
     """List delivery attempts for one webhook subscription, newest first.
 
     Cursor-paginated. Each entry shows the attempt count, response status,
-    and response body Hail recorded — use POST /webhooks/{sub_id}/
+    and response body Hail recorded — use POST /v1/webhooks/{sub_id}/
     deliveries/{delivery_id}/redeliver to retry a failed one.
     """
     await _load_owned(db, sub_id, principal.organization_id)  # auth gate

--- a/api/hailhq/api/routes/webhooks.py
+++ b/api/hailhq/api/routes/webhooks.py
@@ -91,6 +91,13 @@ async def create_subscription(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> WebhookSubscriptionResponse:
+    """Create a webhook subscription for one or more event types.
+
+    The response includes the plaintext signing secret — this is the only
+    time it is ever returned; store it now. Every later GET omits it. Use
+    POST /webhooks/{sub_id}/rotate-secret to get a new plaintext secret if
+    it is lost or compromised.
+    """
     try:
         validate_webhook_target(
             body.target_url,
@@ -131,6 +138,11 @@ async def list_subscriptions(
     cursor: str | None = Query(default=None),
     limit: int = Query(default=_DEFAULT_LIMIT, ge=1, le=_MAX_LIMIT),
 ) -> WebhookSubscriptionListResponse:
+    """List webhook subscriptions for the caller's organization.
+
+    Cursor-paginated, newest first. The signing secret is never included —
+    only POST /webhooks and POST /webhooks/{sub_id}/rotate-secret return it.
+    """
     stmt = select(WebhookSubscription).where(
         WebhookSubscription.organization_id == principal.organization_id
     )
@@ -158,6 +170,7 @@ async def get_subscription(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> WebhookSubscriptionResponse:
+    """Fetch one webhook subscription by id. The signing secret is omitted."""
     sub = await _load_owned(db, sub_id, principal.organization_id)
     return _to_response(sub)
 
@@ -173,6 +186,13 @@ async def patch_subscription(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> WebhookSubscriptionResponse:
+    """Update a webhook subscription's target_url, event_types, and/or status.
+
+    Only fields present in the request body are changed. Setting
+    status="active" resets the consecutive-failure counter, so a
+    subscription that was auto-disabled after 50 straight delivery
+    failures does not immediately re-disable itself.
+    """
     sub = await _load_owned(db, sub_id, principal.organization_id)
     updates: dict = {}
     if body.target_url is not None:
@@ -222,6 +242,11 @@ async def delete_subscription(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> Response:
+    """Permanently remove a webhook subscription.
+
+    Irreversible — no further events are delivered to it, and its
+    delivery history is deleted with it.
+    """
     sub = await _load_owned(db, sub_id, principal.organization_id)
     await db.delete(sub)
     await db.commit()
@@ -246,6 +271,12 @@ async def rotate_secret(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> WebhookSubscriptionResponse:
+    """Generate a new signing secret and immediately invalidate the old one.
+
+    The response includes the new plaintext secret — this is the only
+    time it is returned; update your verification code with it right away,
+    since the old secret stops validating new deliveries immediately.
+    """
     sub = await _load_owned(db, sub_id, principal.organization_id)
     secret = _new_secret()
     cipher = SecretCipher(settings.hail_webhook_secret_key)
@@ -283,6 +314,12 @@ async def list_deliveries(
     cursor: str | None = Query(default=None),
     limit: int = Query(default=_DEFAULT_LIMIT, ge=1, le=_MAX_LIMIT),
 ) -> WebhookDeliveryListResponse:
+    """List delivery attempts for one webhook subscription, newest first.
+
+    Cursor-paginated. Each entry shows the attempt count, response status,
+    and response body Hail recorded — use POST /webhooks/{sub_id}/
+    deliveries/{delivery_id}/redeliver to retry a failed one.
+    """
     await _load_owned(db, sub_id, principal.organization_id)  # auth gate
     stmt = select(WebhookDelivery).where(WebhookDelivery.subscription_id == sub_id)
     rows, next_cursor = await fetch_cursor_page(
@@ -311,6 +348,13 @@ async def redeliver(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> WebhookDeliveryResponse:
+    """Retry one webhook delivery attempt.
+
+    Resets it to pending with a fresh attempt counter — the delivery
+    worker picks it up and re-sends the same event payload to target_url
+    shortly after. Useful after fixing an endpoint that was returning
+    errors.
+    """
     await _load_owned(db, sub_id, principal.organization_id)
     stmt = select(WebhookDelivery).where(
         WebhookDelivery.id == delivery_id,

--- a/api/hailhq/api/routes/whoami.py
+++ b/api/hailhq/api/routes/whoami.py
@@ -23,13 +23,12 @@ from hailhq.core.schemas import WhoamiResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-router = APIRouter(tags=["whoami"])
+router = APIRouter(tags=["whoami"], responses=GENERAL_RATE_LIMITED_RESPONSES)
 
 
 @router.get(
     "/whoami",
     response_model=WhoamiResponse,
-    responses=GENERAL_RATE_LIMITED_RESPONSES,
 )
 async def get_whoami(
     principal: Annotated[Principal, Depends(get_current_principal)],

--- a/api/hailhq/api/routes/whoami.py
+++ b/api/hailhq/api/routes/whoami.py
@@ -16,6 +16,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from hailhq.api.deps import Principal, get_current_principal
+from hailhq.api.ratelimit import GENERAL_RATE_LIMITED_RESPONSES
 from hailhq.core.db import get_session
 from hailhq.core.models import User
 from hailhq.core.schemas import WhoamiResponse
@@ -25,7 +26,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 router = APIRouter(tags=["whoami"])
 
 
-@router.get("/whoami", response_model=WhoamiResponse)
+@router.get(
+    "/whoami",
+    response_model=WhoamiResponse,
+    responses=GENERAL_RATE_LIMITED_RESPONSES,
+)
 async def get_whoami(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],

--- a/api/hailhq/api/routes/whoami.py
+++ b/api/hailhq/api/routes/whoami.py
@@ -35,6 +35,13 @@ async def get_whoami(
     principal: Annotated[Principal, Depends(get_current_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> WhoamiResponse:
+    """Identify the caller: auth kind, organization, and (if resolvable) user.
+
+    Useful for an agent that needs the human's address to put in
+    Reply-To, since the bearer token itself only carries an organization.
+    user_id/email/name come back null for a shared-key
+    (HAIL_API_KEY) call, which has no individual user behind it.
+    """
     if principal.user_id is None:
         return WhoamiResponse(
             auth_kind=principal.auth_kind,

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     # Required by Starlette to parse the application/x-www-form-urlencoded
     # bodies Twilio POSTs to the inbound SMS webhook (request.form()).
     "python-multipart>=0.0.9",
+    "slowapi>=0.1.10",
 ]
 
 [project.optional-dependencies]

--- a/api/tests/test_calls_api.py
+++ b/api/tests/test_calls_api.py
@@ -312,6 +312,35 @@ async def test_post_calls_happy_path_201(
     assert events[0].payload == {"from": "queued", "to": "dialing"}
 
 
+async def test_post_v1_calls_location_header_is_v1_prefixed(
+    client: httpx.AsyncClient,
+    async_session: AsyncSession,
+    org_and_key: tuple[str, ApiKey, str],
+    livekit_mock: AsyncMock,
+    add_phone_number,
+) -> None:
+    """A client that POSTs to the canonical /v1/calls mount must get back a
+    /v1/-prefixed Location, not the deprecated legacy path — the legacy
+    mount (test_post_calls_happy_path_201 above) still gets an unprefixed
+    one."""
+    org_id, _, plain = org_and_key
+    await add_phone_number(async_session, org_id, e164="+14155551234")
+
+    resp = await client.post(
+        "/v1/calls",
+        json={
+            "to": "+14155559999",
+            "system_prompt": "Be brief.",
+            "recipient_consent": True,
+        },
+        headers={"Authorization": f"Bearer {plain}"},
+    )
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert resp.headers["location"] == f"/v1/calls/{body['id']}"
+
+
 async def test_post_calls_ai_disclosure_opt_out_reaches_dispatch_and_audit(
     client: httpx.AsyncClient,
     async_session: AsyncSession,

--- a/api/tests/test_idempotency.py
+++ b/api/tests/test_idempotency.py
@@ -144,6 +144,34 @@ async def test_post_calls_idempotency_replay_returns_cached(
     # Same Location header.
     assert second.headers["location"] == f"/calls/{first.json()['id']}"
 
+
+async def test_post_v1_calls_idempotency_replay_location_is_v1_prefixed(
+    client: httpx.AsyncClient,
+    async_session: AsyncSession,
+    org_and_key: tuple[str, ApiKey, str],
+    livekit_mock: AsyncMock,
+    add_phone_number,
+) -> None:
+    """A replay through the /v1/calls mount must get back a /v1/-prefixed
+    Location too — replay_cached derives the prefix from the request that
+    triggered the replay, not a hardcoded legacy path."""
+    org_id, _, plain = org_and_key
+    await add_phone_number(async_session, org_id)
+
+    headers = {
+        "Authorization": f"Bearer {plain}",
+        "Idempotency-Key": "rerun-me-v1",
+    }
+    body = {"to": "+14155559999", "system_prompt": "hi", "recipient_consent": True}
+
+    first = await client.post("/v1/calls", json=body, headers=headers)
+    assert first.status_code == 201
+
+    second = await client.post("/v1/calls", json=body, headers=headers)
+    assert second.status_code == 201
+    assert second.headers.get("idempotency-replay") == "true"
+    assert second.headers["location"] == f"/v1/calls/{first.json()['id']}"
+
     # The LiveKit pipeline ran exactly once across both requests.
     assert livekit_mock.create_room.await_count == 1
     assert livekit_mock.dispatch_agent.await_count == 1

--- a/api/tests/test_idempotency.py
+++ b/api/tests/test_idempotency.py
@@ -144,6 +144,11 @@ async def test_post_calls_idempotency_replay_returns_cached(
     # Same Location header.
     assert second.headers["location"] == f"/calls/{first.json()['id']}"
 
+    # The LiveKit pipeline ran exactly once across both requests.
+    assert livekit_mock.create_room.await_count == 1
+    assert livekit_mock.dispatch_agent.await_count == 1
+    assert livekit_mock.create_sip_participant.await_count == 1
+
 
 async def test_post_v1_calls_idempotency_replay_location_is_v1_prefixed(
     client: httpx.AsyncClient,

--- a/api/tests/test_openapi_descriptions.py
+++ b/api/tests/test_openapi_descriptions.py
@@ -1,0 +1,18 @@
+from hailhq.api.main import app
+
+
+def test_every_public_operation_has_a_real_description() -> None:
+    schema = app.openapi()
+    missing = []
+    for path, methods in schema["paths"].items():
+        if path.startswith(("/internal", "/v1/internal")):
+            continue
+        for method, op in methods.items():
+            if method not in ("get", "post", "put", "patch", "delete"):
+                continue
+            desc = (op.get("description") or "").strip()
+            if len(desc) < 20:
+                missing.append(f"{method.upper()} {path}")
+    assert (
+        not missing
+    ), f"{len(missing)} operations still lack a real description: {missing}"

--- a/api/tests/test_openapi_descriptions.py
+++ b/api/tests/test_openapi_descriptions.py
@@ -16,3 +16,63 @@ def test_every_public_operation_has_a_real_description() -> None:
     assert (
         not missing
     ), f"{len(missing)} operations still lack a real description: {missing}"
+
+
+def _collect_schema_refs(node: object, found: set[str]) -> None:
+    """Recursively collect every #/components/schemas/<Name> reference
+    reachable from `node` — handles direct $ref, array `items`, and the
+    `anyOf` shape Pydantic v2 uses for `X | None` fields."""
+    if isinstance(node, dict):
+        ref = node.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/components/schemas/"):
+            found.add(ref.removeprefix("#/components/schemas/"))
+        for key in ("items", "requestBody", "schema"):
+            if key in node:
+                _collect_schema_refs(node[key], found)
+        for key in ("anyOf", "oneOf", "allOf"):
+            for sub in node.get(key, []):
+                _collect_schema_refs(sub, found)
+        content = node.get("content")
+        if isinstance(content, dict):
+            for media in content.values():
+                _collect_schema_refs(media, found)
+    elif isinstance(node, list):
+        for item in node:
+            _collect_schema_refs(item, found)
+
+
+def test_every_public_schema_field_has_a_description() -> None:
+    schema = app.openapi()
+    referenced_schemas: set[str] = set()
+    for path, methods in schema["paths"].items():
+        if path.startswith(("/internal", "/v1/internal")):
+            continue
+        for method, op in methods.items():
+            if method not in ("get", "post", "put", "patch", "delete"):
+                continue
+            if "requestBody" in op:
+                _collect_schema_refs(op["requestBody"], referenced_schemas)
+            for resp in op.get("responses", {}).values():
+                _collect_schema_refs(resp, referenced_schemas)
+
+    # Referenced schemas can themselves reference further schemas (e.g. a
+    # response wraps a list of another model) — expand transitively until
+    # the set stops growing.
+    frontier = set(referenced_schemas)
+    while frontier:
+        new_refs: set[str] = set()
+        for name in frontier:
+            model = schema["components"]["schemas"].get(name, {})
+            _collect_schema_refs(model, new_refs)
+        frontier = new_refs - referenced_schemas
+        referenced_schemas |= new_refs
+
+    missing = []
+    for name in sorted(referenced_schemas):
+        model = schema["components"]["schemas"].get(name, {})
+        for field_name, field_schema in model.get("properties", {}).items():
+            if not field_schema.get("description"):
+                missing.append(f"{name}.{field_name}")
+    assert (
+        not missing
+    ), f"{len(missing)} public schema fields still lack a description: {missing}"

--- a/api/tests/test_openapi_descriptions.py
+++ b/api/tests/test_openapi_descriptions.py
@@ -36,6 +36,10 @@ def _collect_schema_refs(node: object, found: set[str]) -> None:
         if isinstance(content, dict):
             for media in content.values():
                 _collect_schema_refs(media, found)
+        properties = node.get("properties")
+        if isinstance(properties, dict):
+            for prop_schema in properties.values():
+                _collect_schema_refs(prop_schema, found)
     elif isinstance(node, list):
         for item in node:
             _collect_schema_refs(item, found)

--- a/api/tests/test_ratelimit.py
+++ b/api/tests/test_ratelimit.py
@@ -109,6 +109,57 @@ async def test_healthz_is_not_rate_limited(
         assert "ratelimit-limit" not in resp.headers
 
 
+@pytest.mark.parametrize("mount_prefix", ["", "/v1"])
+async def test_sms_inbound_is_not_rate_limited(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch, mount_prefix: str
+) -> None:
+    # POST /sms/inbound has no Authorization header by design (Twilio
+    # signature auth). Without the exemption every anonymous caller falls
+    # into the shared remote-IP bucket in production. Bad signature -> 403,
+    # never 429, regardless of the ceiling or how many times it's called.
+    monkeypatch.setattr(settings, "api_rate_limit_per_minute", 1)
+    for _ in range(3):
+        resp = await client.post(
+            f"{mount_prefix}/sms/inbound",
+            data={"From": "+14155551234", "To": "+14155559999", "Body": "hi"},
+            headers={"X-Twilio-Signature": "sha1=bogus"},
+        )
+        assert resp.status_code == 403
+        assert "ratelimit-limit" not in resp.headers
+
+
+@pytest.mark.parametrize("mount_prefix", ["", "/v1"])
+async def test_sms_status_is_not_rate_limited(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch, mount_prefix: str
+) -> None:
+    # POST /sms/status — same rationale as /sms/inbound above.
+    monkeypatch.setattr(settings, "api_rate_limit_per_minute", 1)
+    for _ in range(3):
+        resp = await client.post(
+            f"{mount_prefix}/sms/status",
+            data={"MessageSid": "SM1", "MessageStatus": "delivered"},
+            headers={"X-Twilio-Signature": "sha1=bogus"},
+        )
+        assert resp.status_code == 403
+        assert "ratelimit-limit" not in resp.headers
+
+
+@pytest.mark.parametrize("mount_prefix", ["", "/v1"])
+async def test_unsubscribe_is_not_rate_limited(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch, mount_prefix: str
+) -> None:
+    # GET /unsubscribe has no Authorization header by design (HMAC token
+    # query param per RFC 8058, legally required to keep working). An
+    # invalid/garbage token must never draw a 429 no matter the ceiling.
+    monkeypatch.setattr(settings, "api_rate_limit_per_minute", 1)
+    for _ in range(3):
+        resp = await client.get(
+            f"{mount_prefix}/unsubscribe", params={"token": "bogus"}
+        )
+        assert resp.status_code != 429
+        assert "ratelimit-limit" not in resp.headers
+
+
 @pytest.mark.parametrize("path", ["/v1/calls", "/v1/sms", "/v1/emails"])
 def test_create_routes_merge_agent_gate_and_general_429_docs(path: str) -> None:
     # calls.py/sms.py/emails.py's create routes already documented

--- a/api/tests/test_ratelimit.py
+++ b/api/tests/test_ratelimit.py
@@ -12,6 +12,9 @@ import uuid
 
 import httpx
 import pytest
+from hailhq.api.agent_gate import RATE_LIMITED_RESPONSES
+from hailhq.api.main import app
+from hailhq.api.ratelimit import GENERAL_RATE_LIMITED_RESPONSES
 from hailhq.core.config import settings
 from hailhq.core.models import ApiKey
 
@@ -24,7 +27,13 @@ async def test_response_carries_ratelimit_headers(
         "/v1/whoami", headers={"Authorization": f"Bearer {plain_key}"}
     )
     assert resp.status_code == 200
-    assert "ratelimit-limit" in resp.headers or "x-ratelimit-limit" in resp.headers
+    # Exact IETF-draft header name only — GeneralRateLimitMiddleware sets
+    # these itself (see ratelimit.py), it does not go through slowapi's own
+    # header injection, which defaults to X-RateLimit-*. A regression to
+    # that default must fail this assertion, not slide past an "or".
+    assert "ratelimit-limit" in resp.headers
+    assert "ratelimit-remaining" in resp.headers
+    assert "ratelimit-reset" in resp.headers
 
 
 async def test_exceeding_the_limit_returns_429_with_retry_after(
@@ -98,3 +107,39 @@ async def test_healthz_is_not_rate_limited(
         resp = await client.get("/healthz")
         assert resp.status_code == 200
         assert "ratelimit-limit" not in resp.headers
+
+
+@pytest.mark.parametrize("path", ["/v1/calls", "/v1/sms", "/v1/emails"])
+def test_create_routes_merge_agent_gate_and_general_429_docs(path: str) -> None:
+    # calls.py/sms.py/emails.py's create routes already documented
+    # agent_gate.py's RATE_LIMITED_RESPONSES (the agent-abuse velocity-cap
+    # 429) before this task. This task must MERGE its own
+    # GENERAL_RATE_LIMITED_RESPONSES into that 429, not clobber it — both
+    # causes are real and independently reachable on these 3 routes. Assert
+    # against the live app.openapi() output (not the ratelimit.py helper in
+    # isolation), so a Task 3 edit to these same decorators that
+    # accidentally drops one side's responses= would fail this test.
+    schema = app.openapi()
+    responses = schema["paths"][path]["post"]["responses"]
+    assert "429" in responses
+    entry = responses["429"]
+
+    # Both real 429 causes are represented in the merged description —
+    # checked against the actual source strings, not a hardcoded guess.
+    agent_gate_description = RATE_LIMITED_RESPONSES[429]["description"]
+    general_description = GENERAL_RATE_LIMITED_RESPONSES[429]["description"]
+    assert agent_gate_description in entry["description"]
+    assert general_description in entry["description"]
+    assert "velocity cap" in entry["description"]
+    assert "general request-rate" in entry["description"]
+
+    # All 4 headers survive the merge (Retry-After is declared by both
+    # source dicts and collapses to one entry; the general limiter's other
+    # 3 headers are additive).
+    header_names = set(entry["headers"].keys())
+    assert header_names == {
+        "Retry-After",
+        "RateLimit-Limit",
+        "RateLimit-Remaining",
+        "RateLimit-Reset",
+    }

--- a/api/tests/test_ratelimit.py
+++ b/api/tests/test_ratelimit.py
@@ -1,0 +1,100 @@
+"""Tests for the general per-caller HTTP request-rate limiter (ratelimit.py).
+
+Distinct from tests/test_agent_gate_api.py (the agent-abuse velocity cap) —
+this limiter applies to every customer-facing route, for every caller, keyed
+on the raw bearer (or remote address when there is none), not on org/channel
+send velocity.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+from hailhq.core.config import settings
+from hailhq.core.models import ApiKey
+
+
+async def test_response_carries_ratelimit_headers(
+    client: httpx.AsyncClient, org_and_key: tuple[uuid.UUID, ApiKey, str]
+) -> None:
+    _, _, plain_key = org_and_key
+    resp = await client.get(
+        "/v1/whoami", headers={"Authorization": f"Bearer {plain_key}"}
+    )
+    assert resp.status_code == 200
+    assert "ratelimit-limit" in resp.headers or "x-ratelimit-limit" in resp.headers
+
+
+async def test_exceeding_the_limit_returns_429_with_retry_after(
+    client: httpx.AsyncClient,
+    org_and_key: tuple[uuid.UUID, ApiKey, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, plain_key = org_and_key
+    # Drop the ceiling to something trivially exceedable within one test,
+    # rather than firing 300+ real requests. The middleware reads
+    # settings.api_rate_limit_per_minute fresh on every request (it is not
+    # captured once at app-startup/import time), so this monkeypatch takes
+    # effect immediately.
+    monkeypatch.setattr(settings, "api_rate_limit_per_minute", 2)
+    headers = {"Authorization": f"Bearer {plain_key}"}
+    for _ in range(2):
+        resp = await client.get("/v1/whoami", headers=headers)
+        assert resp.status_code == 200
+    resp = await client.get("/v1/whoami", headers=headers)
+    assert resp.status_code == 429
+    assert "retry-after" in resp.headers
+
+
+async def test_both_mounts_of_the_same_route_share_one_bucket(
+    client: httpx.AsyncClient,
+    org_and_key: tuple[uuid.UUID, ApiKey, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Task 1 dual-mounts every customer router at /v1/<resource> and the
+    # legacy unprefixed path. The limiter is keyed on the raw bearer, not
+    # the matched route, so hitting both mounts of the same caller must
+    # draw from the same bucket.
+    monkeypatch.setattr(settings, "api_rate_limit_per_minute", 2)
+    _, _, plain_key = org_and_key
+    headers = {"Authorization": f"Bearer {plain_key}"}
+    resp = await client.get("/v1/whoami", headers=headers)
+    assert resp.status_code == 200
+    resp = await client.get("/whoami", headers=headers)
+    assert resp.status_code == 200
+    resp = await client.get("/v1/whoami", headers=headers)
+    assert resp.status_code == 429
+    assert "retry-after" in resp.headers
+
+
+async def test_internal_routes_are_not_rate_limited(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Internal routes are called by internal services on a trusted,
+    # HMAC-signed path, not customer API keys — no Authorization header at
+    # all. Confirm the general limiter's key_func doesn't apply to (or
+    # crash on) an unauthenticated internal request, by dropping the
+    # ceiling low and firing more than that many requests without ever
+    # seeing a 429.
+    monkeypatch.setattr(settings, "api_rate_limit_per_minute", 1)
+    for _ in range(3):
+        resp = await client.post(
+            "/internal/numbers/release",
+            content=b"{}",
+            headers={"Content-Type": "application/json"},
+        )
+        # No valid HMAC signature -> auth failure, never a 429 from the
+        # general limiter (which isn't applied to /internal/* at all).
+        assert resp.status_code != 429
+
+
+async def test_healthz_is_not_rate_limited(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "api_rate_limit_per_minute", 1)
+    for _ in range(3):
+        resp = await client.get("/healthz")
+        assert resp.status_code == 200
+        assert "ratelimit-limit" not in resp.headers

--- a/api/tests/test_versioning.py
+++ b/api/tests/test_versioning.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import uuid
+
+import httpx
+from hailhq.core.models import ApiKey
+
+
+async def test_v1_prefix_reaches_whoami(
+    client: httpx.AsyncClient, org_and_key: tuple[uuid.UUID, ApiKey, str]
+) -> None:
+    _, _, plain_key = org_and_key
+    resp = await client.get(
+        "/v1/whoami", headers={"Authorization": f"Bearer {plain_key}"}
+    )
+    assert resp.status_code == 200
+
+
+async def test_unprefixed_path_still_works_and_is_marked_deprecated(
+    client: httpx.AsyncClient, org_and_key: tuple[uuid.UUID, ApiKey, str]
+) -> None:
+    _, _, plain_key = org_and_key
+    resp = await client.get("/whoami", headers={"Authorization": f"Bearer {plain_key}"})
+    assert resp.status_code == 200
+    assert resp.headers["deprecation"] == "true"
+    assert 'rel="successor-version"' in resp.headers["link"]
+    assert "/v1/whoami" in resp.headers["link"]
+
+
+async def test_v1_path_is_not_marked_deprecated(
+    client: httpx.AsyncClient, org_and_key: tuple[uuid.UUID, ApiKey, str]
+) -> None:
+    _, _, plain_key = org_and_key
+    resp = await client.get(
+        "/v1/whoami", headers={"Authorization": f"Bearer {plain_key}"}
+    )
+    assert "deprecation" not in resp.headers
+
+
+def test_legacy_unprefixed_paths_are_not_in_the_openapi_schema() -> None:
+    from hailhq.api.main import app
+
+    schema = app.openapi()
+    paths = schema["paths"]
+    assert "/v1/whoami" in paths
+    assert "/whoami" not in paths
+
+
+async def test_internal_routes_are_not_dual_mounted(client: httpx.AsyncClient) -> None:
+    # /internal/... must not also exist at /v1/internal/... — internal routers
+    # were never versioned; a bare-string prefix match on "/v1" + internal's
+    # own "/internal" prefix would be a real path if this task's loop is too
+    # broad. hailhq/api/routes/internal/ses_events.py only registers
+    # POST /internal/ses-events (no "healthz" sub-path exists). If the dual
+    # mount loop wrongly included the internal routers, GET /v1/internal/
+    # ses-events would resolve to a route that only accepts POST and 405;
+    # since it isn't mounted at all under /v1, it 404s instead.
+    resp = await client.get("/v1/internal/ses-events")
+    assert resp.status_code == 404

--- a/cli/internal/client/client.gen.go
+++ b/cli/internal/client/client.gen.go
@@ -876,86 +876,86 @@ func (e WhoamiResponseAuthKind) Valid() bool {
 	}
 }
 
-// Defines values for ListCallsCallsGetParamsStatus.
+// Defines values for ListCallsV1CallsGetParamsStatus.
 const (
-	ListCallsCallsGetParamsStatusBusy       ListCallsCallsGetParamsStatus = "busy"
-	ListCallsCallsGetParamsStatusCanceled   ListCallsCallsGetParamsStatus = "canceled"
-	ListCallsCallsGetParamsStatusCompleted  ListCallsCallsGetParamsStatus = "completed"
-	ListCallsCallsGetParamsStatusDialing    ListCallsCallsGetParamsStatus = "dialing"
-	ListCallsCallsGetParamsStatusFailed     ListCallsCallsGetParamsStatus = "failed"
-	ListCallsCallsGetParamsStatusInProgress ListCallsCallsGetParamsStatus = "in_progress"
-	ListCallsCallsGetParamsStatusNoAnswer   ListCallsCallsGetParamsStatus = "no_answer"
-	ListCallsCallsGetParamsStatusQueued     ListCallsCallsGetParamsStatus = "queued"
-	ListCallsCallsGetParamsStatusRinging    ListCallsCallsGetParamsStatus = "ringing"
+	ListCallsV1CallsGetParamsStatusBusy       ListCallsV1CallsGetParamsStatus = "busy"
+	ListCallsV1CallsGetParamsStatusCanceled   ListCallsV1CallsGetParamsStatus = "canceled"
+	ListCallsV1CallsGetParamsStatusCompleted  ListCallsV1CallsGetParamsStatus = "completed"
+	ListCallsV1CallsGetParamsStatusDialing    ListCallsV1CallsGetParamsStatus = "dialing"
+	ListCallsV1CallsGetParamsStatusFailed     ListCallsV1CallsGetParamsStatus = "failed"
+	ListCallsV1CallsGetParamsStatusInProgress ListCallsV1CallsGetParamsStatus = "in_progress"
+	ListCallsV1CallsGetParamsStatusNoAnswer   ListCallsV1CallsGetParamsStatus = "no_answer"
+	ListCallsV1CallsGetParamsStatusQueued     ListCallsV1CallsGetParamsStatus = "queued"
+	ListCallsV1CallsGetParamsStatusRinging    ListCallsV1CallsGetParamsStatus = "ringing"
 )
 
-// Valid indicates whether the value is a known member of the ListCallsCallsGetParamsStatus enum.
-func (e ListCallsCallsGetParamsStatus) Valid() bool {
+// Valid indicates whether the value is a known member of the ListCallsV1CallsGetParamsStatus enum.
+func (e ListCallsV1CallsGetParamsStatus) Valid() bool {
 	switch e {
-	case ListCallsCallsGetParamsStatusBusy:
+	case ListCallsV1CallsGetParamsStatusBusy:
 		return true
-	case ListCallsCallsGetParamsStatusCanceled:
+	case ListCallsV1CallsGetParamsStatusCanceled:
 		return true
-	case ListCallsCallsGetParamsStatusCompleted:
+	case ListCallsV1CallsGetParamsStatusCompleted:
 		return true
-	case ListCallsCallsGetParamsStatusDialing:
+	case ListCallsV1CallsGetParamsStatusDialing:
 		return true
-	case ListCallsCallsGetParamsStatusFailed:
+	case ListCallsV1CallsGetParamsStatusFailed:
 		return true
-	case ListCallsCallsGetParamsStatusInProgress:
+	case ListCallsV1CallsGetParamsStatusInProgress:
 		return true
-	case ListCallsCallsGetParamsStatusNoAnswer:
+	case ListCallsV1CallsGetParamsStatusNoAnswer:
 		return true
-	case ListCallsCallsGetParamsStatusQueued:
+	case ListCallsV1CallsGetParamsStatusQueued:
 		return true
-	case ListCallsCallsGetParamsStatusRinging:
+	case ListCallsV1CallsGetParamsStatusRinging:
 		return true
 	default:
 		return false
 	}
 }
 
-// Defines values for ListEmailsEmailsGetParamsStatus.
+// Defines values for ListEmailsV1EmailsGetParamsStatus.
 const (
-	ListEmailsEmailsGetParamsStatusBounced    ListEmailsEmailsGetParamsStatus = "bounced"
-	ListEmailsEmailsGetParamsStatusComplained ListEmailsEmailsGetParamsStatus = "complained"
-	ListEmailsEmailsGetParamsStatusDelivered  ListEmailsEmailsGetParamsStatus = "delivered"
-	ListEmailsEmailsGetParamsStatusFailed     ListEmailsEmailsGetParamsStatus = "failed"
-	ListEmailsEmailsGetParamsStatusQueued     ListEmailsEmailsGetParamsStatus = "queued"
-	ListEmailsEmailsGetParamsStatusReceived   ListEmailsEmailsGetParamsStatus = "received"
-	ListEmailsEmailsGetParamsStatusSent       ListEmailsEmailsGetParamsStatus = "sent"
+	ListEmailsV1EmailsGetParamsStatusBounced    ListEmailsV1EmailsGetParamsStatus = "bounced"
+	ListEmailsV1EmailsGetParamsStatusComplained ListEmailsV1EmailsGetParamsStatus = "complained"
+	ListEmailsV1EmailsGetParamsStatusDelivered  ListEmailsV1EmailsGetParamsStatus = "delivered"
+	ListEmailsV1EmailsGetParamsStatusFailed     ListEmailsV1EmailsGetParamsStatus = "failed"
+	ListEmailsV1EmailsGetParamsStatusQueued     ListEmailsV1EmailsGetParamsStatus = "queued"
+	ListEmailsV1EmailsGetParamsStatusReceived   ListEmailsV1EmailsGetParamsStatus = "received"
+	ListEmailsV1EmailsGetParamsStatusSent       ListEmailsV1EmailsGetParamsStatus = "sent"
 )
 
-// Valid indicates whether the value is a known member of the ListEmailsEmailsGetParamsStatus enum.
-func (e ListEmailsEmailsGetParamsStatus) Valid() bool {
+// Valid indicates whether the value is a known member of the ListEmailsV1EmailsGetParamsStatus enum.
+func (e ListEmailsV1EmailsGetParamsStatus) Valid() bool {
 	switch e {
-	case ListEmailsEmailsGetParamsStatusBounced:
+	case ListEmailsV1EmailsGetParamsStatusBounced:
 		return true
-	case ListEmailsEmailsGetParamsStatusComplained:
+	case ListEmailsV1EmailsGetParamsStatusComplained:
 		return true
-	case ListEmailsEmailsGetParamsStatusDelivered:
+	case ListEmailsV1EmailsGetParamsStatusDelivered:
 		return true
-	case ListEmailsEmailsGetParamsStatusFailed:
+	case ListEmailsV1EmailsGetParamsStatusFailed:
 		return true
-	case ListEmailsEmailsGetParamsStatusQueued:
+	case ListEmailsV1EmailsGetParamsStatusQueued:
 		return true
-	case ListEmailsEmailsGetParamsStatusReceived:
+	case ListEmailsV1EmailsGetParamsStatusReceived:
 		return true
-	case ListEmailsEmailsGetParamsStatusSent:
+	case ListEmailsV1EmailsGetParamsStatusSent:
 		return true
 	default:
 		return false
 	}
 }
 
-// Defines values for ListEmailsEmailsGetParamsDirection.
+// Defines values for ListEmailsV1EmailsGetParamsDirection.
 const (
-	Inbound  ListEmailsEmailsGetParamsDirection = "inbound"
-	Outbound ListEmailsEmailsGetParamsDirection = "outbound"
+	Inbound  ListEmailsV1EmailsGetParamsDirection = "inbound"
+	Outbound ListEmailsV1EmailsGetParamsDirection = "outbound"
 )
 
-// Valid indicates whether the value is a known member of the ListEmailsEmailsGetParamsDirection enum.
-func (e ListEmailsEmailsGetParamsDirection) Valid() bool {
+// Valid indicates whether the value is a known member of the ListEmailsV1EmailsGetParamsDirection enum.
+func (e ListEmailsV1EmailsGetParamsDirection) Valid() bool {
 	switch e {
 	case Inbound:
 		return true
@@ -966,36 +966,36 @@ func (e ListEmailsEmailsGetParamsDirection) Valid() bool {
 	}
 }
 
-// Defines values for GetEmailStatsEmailsStatsGetParamsBucket.
+// Defines values for GetEmailStatsV1EmailsStatsGetParamsBucket.
 const (
-	GetEmailStatsEmailsStatsGetParamsBucketDay  GetEmailStatsEmailsStatsGetParamsBucket = "day"
-	GetEmailStatsEmailsStatsGetParamsBucketHour GetEmailStatsEmailsStatsGetParamsBucket = "hour"
+	GetEmailStatsV1EmailsStatsGetParamsBucketDay  GetEmailStatsV1EmailsStatsGetParamsBucket = "day"
+	GetEmailStatsV1EmailsStatsGetParamsBucketHour GetEmailStatsV1EmailsStatsGetParamsBucket = "hour"
 )
 
-// Valid indicates whether the value is a known member of the GetEmailStatsEmailsStatsGetParamsBucket enum.
-func (e GetEmailStatsEmailsStatsGetParamsBucket) Valid() bool {
+// Valid indicates whether the value is a known member of the GetEmailStatsV1EmailsStatsGetParamsBucket enum.
+func (e GetEmailStatsV1EmailsStatsGetParamsBucket) Valid() bool {
 	switch e {
-	case GetEmailStatsEmailsStatsGetParamsBucketDay:
+	case GetEmailStatsV1EmailsStatsGetParamsBucketDay:
 		return true
-	case GetEmailStatsEmailsStatsGetParamsBucketHour:
+	case GetEmailStatsV1EmailsStatsGetParamsBucketHour:
 		return true
 	default:
 		return false
 	}
 }
 
-// Defines values for ListSmsSmsGetParamsStatus.
+// Defines values for ListSmsV1SmsGetParamsStatus.
 const (
-	Delivered   ListSmsSmsGetParamsStatus = "delivered"
-	Failed      ListSmsSmsGetParamsStatus = "failed"
-	Queued      ListSmsSmsGetParamsStatus = "queued"
-	Received    ListSmsSmsGetParamsStatus = "received"
-	Sent        ListSmsSmsGetParamsStatus = "sent"
-	Undelivered ListSmsSmsGetParamsStatus = "undelivered"
+	Delivered   ListSmsV1SmsGetParamsStatus = "delivered"
+	Failed      ListSmsV1SmsGetParamsStatus = "failed"
+	Queued      ListSmsV1SmsGetParamsStatus = "queued"
+	Received    ListSmsV1SmsGetParamsStatus = "received"
+	Sent        ListSmsV1SmsGetParamsStatus = "sent"
+	Undelivered ListSmsV1SmsGetParamsStatus = "undelivered"
 )
 
-// Valid indicates whether the value is a known member of the ListSmsSmsGetParamsStatus enum.
-func (e ListSmsSmsGetParamsStatus) Valid() bool {
+// Valid indicates whether the value is a known member of the ListSmsV1SmsGetParamsStatus enum.
+func (e ListSmsV1SmsGetParamsStatus) Valid() bool {
 	switch e {
 	case Delivered:
 		return true
@@ -1016,6 +1016,7 @@ func (e ListSmsSmsGetParamsStatus) Valid() bool {
 
 // BodyUploadEmailAttachment defines model for Body_upload_email_attachment.
 type BodyUploadEmailAttachment struct {
+	// File The file to upload, as multipart/form-data. Size-limited; an oversize upload is rejected with 422.
 	File string `json:"file"`
 }
 
@@ -1028,20 +1029,34 @@ type CallCreate struct {
 	ConsentObtainedAt *time.Time `json:"consent_obtained_at,omitempty"`
 
 	// ConsentSource Where/how consent was obtained (e.g. 'signup form', 'prior customer relationship'). Required (non-empty) when message_type is 'marketing'.
-	ConsentSource  *string             `json:"consent_source,omitempty"`
+	ConsentSource *string `json:"consent_source,omitempty"`
+
+	// ConversationId Groups this call with other calls/emails/SMS into one conversation thread. Omitted: the call is not linked to a conversation.
 	ConversationId *openapi_types.UUID `json:"conversation_id,omitempty"`
-	FirstMessage   *string             `json:"first_message,omitempty"`
-	From           *string             `json:"from,omitempty"`
-	Llm            *LLMConfig          `json:"llm,omitempty"`
+
+	// FirstMessage Opening line the agent speaks first. Omitted: the agent waits for the callee to speak first.
+	FirstMessage *string `json:"first_message,omitempty"`
+
+	// From Caller-id phone number, E.164 format. Must be a number owned by the organization with the voice capability. Omitted: an active org-owned number is used if one exists, else a number is claimed from the shared pool.
+	From *string `json:"from,omitempty"`
+
+	// Llm BYO LLM endpoint the call runs on instead of Hail's default model. At least one of system_prompt or llm is required; both together is also valid.
+	Llm *LLMConfig `json:"llm,omitempty"`
 
 	// MessageType 'marketing' additionally requires a non-empty consent_source. Use 'informational' for transactional/service communications.
-	MessageType *CallCreateMessageType  `json:"message_type,omitempty"`
-	Metadata    *map[string]interface{} `json:"metadata,omitempty"`
+	MessageType *CallCreateMessageType `json:"message_type,omitempty"`
+
+	// Metadata Free-form JSON object attached to the call and echoed back on reads. Not interpreted by Hail.
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
 
 	// RecipientConsent Attestation that you have obtained the lawful consent required to contact this recipient. Hail does not verify consent itself — you are responsible for a lawful basis under TCPA/ePrivacy/PECR/CAN-SPAM/GDPR as applicable. Rejected (422) if not true.
-	RecipientConsent bool    `json:"recipient_consent"`
-	SystemPrompt     *string `json:"system_prompt,omitempty"`
-	To               string  `json:"to"`
+	RecipientConsent bool `json:"recipient_consent"`
+
+	// SystemPrompt Task instructions for the agent, sent as its leading system message. At least one of system_prompt or llm is required; both together is also valid.
+	SystemPrompt *string `json:"system_prompt,omitempty"`
+
+	// To Recipient phone number, E.164 format (e.g. +14155551234).
+	To string `json:"to"`
 
 	// Tools Agent tools to allow on this call. Omitted: every tool the organization's configured channels support (new channels appear automatically). Empty list: no tools. Tool names are validated against the server's registry.
 	Tools       *[]string    `json:"tools,omitempty"`
@@ -1053,40 +1068,79 @@ type CallCreateMessageType string
 
 // CallListResponse defines model for CallListResponse.
 type CallListResponse struct {
-	Items      []CallResponse `json:"items"`
-	NextCursor *string        `json:"next_cursor,omitempty"`
+	// Items Calls in this page, newest first.
+	Items []CallResponse `json:"items"`
+
+	// NextCursor Opaque cursor for the next page. Null when there are no more results.
+	NextCursor *string `json:"next_cursor,omitempty"`
 }
 
 // CallResponse defines model for CallResponse.
 type CallResponse struct {
-	AnsweredAt      *time.Time            `json:"answered_at"`
-	ConversationId  *openapi_types.UUID   `json:"conversation_id"`
-	Direction       CallResponseDirection `json:"direction"`
-	EndReason       *string               `json:"end_reason"`
-	EndedAt         *time.Time            `json:"ended_at"`
-	FromE164        string                `json:"from_e164"`
-	Id              openapi_types.UUID    `json:"id"`
-	InitialPrompt   *string               `json:"initial_prompt"`
-	LivekitRoom     *string               `json:"livekit_room"`
-	OrganizationId  openapi_types.UUID    `json:"organization_id"`
-	ProviderCallSid *string               `json:"provider_call_sid"`
-	RecordingS3Key  *string               `json:"recording_s3_key"`
-	RequestedAt     time.Time             `json:"requested_at"`
-	StartedAt       *time.Time            `json:"started_at"`
-	Status          CallResponseStatus    `json:"status"`
-	ToE164          string                `json:"to_e164"`
+	// AnsweredAt When the callee answered, ISO 8601 timestamp. Null if never answered.
+	AnsweredAt *time.Time `json:"answered_at"`
+
+	// ConversationId Conversation thread this call is grouped into, if any. Null when the call was not linked to a conversation.
+	ConversationId *openapi_types.UUID `json:"conversation_id"`
+
+	// Direction 'outbound' for calls Hail placed, 'inbound' for calls received.
+	Direction CallResponseDirection `json:"direction"`
+
+	// EndReason Machine-readable reason the call reached a terminal status (e.g. 'normal_hangup', 'user_rejected', 'sip_trunk_failure'). Null while the call is still in progress.
+	EndReason *string `json:"end_reason"`
+
+	// EndedAt When the call ended, ISO 8601 timestamp. Null while still in progress.
+	EndedAt *time.Time `json:"ended_at"`
+
+	// FromE164 Caller-id phone number used, E.164 format.
+	FromE164 string `json:"from_e164"`
+
+	// Id Unique identifier for this call.
+	Id openapi_types.UUID `json:"id"`
+
+	// InitialPrompt The system_prompt this call was created with, if any.
+	InitialPrompt *string `json:"initial_prompt"`
+
+	// LivekitRoom Name of the LiveKit room hosting this call's media session, if one was created.
+	LivekitRoom *string `json:"livekit_room"`
+
+	// OrganizationId Organization that placed or received this call.
+	OrganizationId openapi_types.UUID `json:"organization_id"`
+
+	// ProviderCallSid The telephony provider's identifier for this call leg, if assigned.
+	ProviderCallSid *string `json:"provider_call_sid"`
+
+	// RecordingS3Key Internal storage key for the call recording. Not a directly fetchable URL.
+	RecordingS3Key *string `json:"recording_s3_key"`
+
+	// RequestedAt When the call was requested, ISO 8601 timestamp.
+	RequestedAt time.Time `json:"requested_at"`
+
+	// StartedAt When dialing began, ISO 8601 timestamp. Null until the call starts.
+	StartedAt *time.Time `json:"started_at"`
+
+	// Status Current call-progress state: 'queued', 'dialing', 'ringing', 'in_progress', or one of the terminal states 'completed', 'failed', 'busy', 'no_answer', 'canceled'.
+	Status CallResponseStatus `json:"status"`
+
+	// ToE164 Recipient phone number, E.164 format.
+	ToE164 string `json:"to_e164"`
 }
 
-// CallResponseDirection defines model for CallResponse.Direction.
+// CallResponseDirection 'outbound' for calls Hail placed, 'inbound' for calls received.
 type CallResponseDirection string
 
-// CallResponseStatus defines model for CallResponse.Status.
+// CallResponseStatus Current call-progress state: 'queued', 'dialing', 'ringing', 'in_progress', or one of the terminal states 'completed', 'failed', 'busy', 'no_answer', 'canceled'.
 type CallResponseStatus string
 
 // ContactCreate defines model for ContactCreate.
 type ContactCreate struct {
-	Email     *string `json:"email,omitempty"`
-	Name      string  `json:"name"`
+	// Email Email address, stored lowercased. At least one of phone_e164 or email is required.
+	Email *string `json:"email,omitempty"`
+
+	// Name Display name for the contact.
+	Name string `json:"name"`
+
+	// PhoneE164 Phone number, E.164 format. At least one of phone_e164 or email is required.
 	PhoneE164 *string `json:"phone_e164,omitempty"`
 }
 
@@ -1094,27 +1148,46 @@ type ContactCreate struct {
 // contact. “id“ is “member:<user_id>“ for members, the contact row's
 // UUID (as str) for manual rows.
 type ContactEntry struct {
-	Email     *string          `json:"email,omitempty"`
-	Id        string           `json:"id"`
-	Kind      ContactEntryKind `json:"kind"`
-	Name      string           `json:"name"`
-	PhoneE164 *string          `json:"phone_e164,omitempty"`
-	Role      *string          `json:"role,omitempty"`
+	// Email Email address. Null if none on file.
+	Email *string `json:"email,omitempty"`
+
+	// Id 'member:<user_id>' for an org member, or the contact row's UUID (as a string) for a manual contact.
+	Id string `json:"id"`
+
+	// Kind 'member' if this row is a member of the organization, 'manual' if it was added as a contact.
+	Kind ContactEntryKind `json:"kind"`
+
+	// Name Display name.
+	Name string `json:"name"`
+
+	// PhoneE164 Phone number, E.164 format. Null if none on file.
+	PhoneE164 *string `json:"phone_e164,omitempty"`
+
+	// Role Organization role (e.g. 'owner', 'admin', 'member') for kind='member'. Always null for kind='manual'.
+	Role *string `json:"role,omitempty"`
 }
 
-// ContactEntryKind defines model for ContactEntry.Kind.
+// ContactEntryKind 'member' if this row is a member of the organization, 'manual' if it was added as a contact.
 type ContactEntryKind string
 
 // ContactListResponse defines model for ContactListResponse.
 type ContactListResponse struct {
-	Items      []ContactEntry `json:"items"`
-	NextCursor *string        `json:"next_cursor,omitempty"`
+	// Items Contacts in this page.
+	Items []ContactEntry `json:"items"`
+
+	// NextCursor Opaque cursor for the next page. Null when there are no more results.
+	NextCursor *string `json:"next_cursor,omitempty"`
 }
 
 // ContactPatch defines model for ContactPatch.
 type ContactPatch struct {
-	Email     *string `json:"email,omitempty"`
-	Name      *string `json:"name,omitempty"`
+	// Email New email address, stored lowercased. Omit to leave unchanged; explicit null clears it. The contact must keep at least one of phone_e164 or email.
+	Email *string `json:"email,omitempty"`
+
+	// Name New display name. Omit to leave unchanged; cannot be set to null.
+	Name *string `json:"name,omitempty"`
+
+	// PhoneE164 New phone number, E.164 format. Omit to leave unchanged; explicit null clears it. The contact must keep at least one of phone_e164 or email.
 	PhoneE164 *string `json:"phone_e164,omitempty"`
 }
 
@@ -1122,22 +1195,36 @@ type ContactPatch struct {
 //
 // Covers DKIM CNAMEs, MAIL FROM MX, and SPF TXT records.
 type DnsRecordSchema struct {
-	Name                 string                 `json:"name"`
-	Priority             *int                   `json:"priority,omitempty"`
-	Type                 *DnsRecordSchemaType   `json:"type,omitempty"`
+	// Name DNS record name/host to publish (e.g. a CNAME's subdomain).
+	Name string `json:"name"`
+
+	// Priority MX priority. Only present for type='MX'; null otherwise.
+	Priority *int `json:"priority,omitempty"`
+
+	// Type DNS record type: 'CNAME' (DKIM), 'MX' (MAIL FROM), or 'TXT' (SPF).
+	Type *DnsRecordSchemaType `json:"type,omitempty"`
+
+	// Value DNS record value to publish (e.g. a CNAME target or TXT content).
 	Value                string                 `json:"value"`
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
-// DnsRecordSchemaType defines model for DnsRecordSchema.Type.
+// DnsRecordSchemaType DNS record type: 'CNAME' (DKIM), 'MX' (MAIL FROM), or 'TXT' (SPF).
 type DnsRecordSchemaType string
 
 // DomainCheckResponse defines model for DomainCheckResponse.
 type DomainCheckResponse struct {
-	Domain          string   `json:"domain"`
-	ExistingMx      []string `json:"existing_mx"`
-	InUse           bool     `json:"in_use"`
-	SuggestedDomain string   `json:"suggested_domain"`
+	// Domain The apex domain that was checked, lowercased.
+	Domain string `json:"domain"`
+
+	// ExistingMx MX hostnames currently published for the domain. Empty when in_use is false.
+	ExistingMx []string `json:"existing_mx"`
+
+	// InUse True if the domain already has MX records — it receives mail elsewhere.
+	InUse bool `json:"in_use"`
+
+	// SuggestedDomain Domain to use for a custom sending identity: the apex domain if it is not already receiving mail, or an 'inbox.' subdomain if it is (so setup doesn't collide with existing mail).
+	SuggestedDomain string `json:"suggested_domain"`
 }
 
 // EmailAttachmentResponse One inbound MIME attachment as exposed to API consumers.
@@ -1145,12 +1232,23 @@ type DomainCheckResponse struct {
 // “url“ is the stable Hail API endpoint that 302-redirects to a
 // presigned S3 URL on access — see GET /emails/{id}/attachments/{aid}.
 type EmailAttachmentResponse struct {
-	ContentId   *string            `json:"content_id,omitempty"`
-	ContentType string             `json:"content_type"`
-	Filename    string             `json:"filename"`
-	Id          openapi_types.UUID `json:"id"`
-	SizeBytes   int                `json:"size_bytes"`
-	Url         string             `json:"url"`
+	// ContentId MIME Content-ID, present when this attachment is referenced inline (cid:) from the HTML body. Null otherwise.
+	ContentId *string `json:"content_id,omitempty"`
+
+	// ContentType MIME type of the attachment.
+	ContentType string `json:"content_type"`
+
+	// Filename Original filename of the attachment.
+	Filename string `json:"filename"`
+
+	// Id Unique identifier for this attachment.
+	Id openapi_types.UUID `json:"id"`
+
+	// SizeBytes Size of the attachment in bytes.
+	SizeBytes int `json:"size_bytes"`
+
+	// Url API endpoint that 302-redirects to a presigned download URL for this attachment.
+	Url string `json:"url"`
 }
 
 // EmailAttachmentUploadResponse Returned by POST /email-attachments.
@@ -1159,38 +1257,68 @@ type EmailAttachmentResponse struct {
 // “EmailCreate.attachment_ids“ until Hail garbage-collects it (24h
 // if never referenced by a send).
 type EmailAttachmentUploadResponse struct {
-	ContentType string             `json:"content_type"`
-	Filename    string             `json:"filename"`
-	Id          openapi_types.UUID `json:"id"`
-	SizeBytes   int                `json:"size_bytes"`
+	// ContentType MIME type of the uploaded file.
+	ContentType string `json:"content_type"`
+
+	// Filename Original filename of the uploaded file.
+	Filename string `json:"filename"`
+
+	// Id Reusable attachment id — pass it in EmailCreate.attachment_ids to attach it to a send.
+	Id openapi_types.UUID `json:"id"`
+
+	// SizeBytes Size of the uploaded file in bytes.
+	SizeBytes int `json:"size_bytes"`
 }
 
 // EmailCreate defines model for EmailCreate.
 type EmailCreate struct {
+	// AttachmentIds Ids returned by POST /email-attachments to attach to this send. Omitted: no attachments.
 	AttachmentIds *[]openapi_types.UUID `json:"attachment_ids,omitempty"`
-	Bcc           *[]string             `json:"bcc,omitempty"`
-	BodyHtml      *string               `json:"body_html,omitempty"`
-	BodyText      *string               `json:"body_text,omitempty"`
-	Cc            *[]string             `json:"cc,omitempty"`
+
+	// Bcc BCC recipient email addresses.
+	Bcc *[]string `json:"bcc,omitempty"`
+
+	// BodyHtml HTML body. Either body_text or body_html (or both) is required.
+	BodyHtml *string `json:"body_html,omitempty"`
+
+	// BodyText Plain-text body. Either body_text or body_html (or both) is required.
+	BodyText *string `json:"body_text,omitempty"`
+
+	// Cc CC recipient email addresses.
+	Cc *[]string `json:"cc,omitempty"`
 
 	// ConsentObtainedAt When consent was obtained, if known.
 	ConsentObtainedAt *time.Time `json:"consent_obtained_at,omitempty"`
 
 	// ConsentSource Where/how consent was obtained (e.g. 'signup form', 'prior customer relationship'). Required (non-empty) when message_type is 'marketing'.
-	ConsentSource  *string             `json:"consent_source,omitempty"`
+	ConsentSource *string `json:"consent_source,omitempty"`
+
+	// ConversationId Groups this email with other calls/emails/SMS into one conversation thread. Omitted: the email is not linked to a conversation.
 	ConversationId *openapi_types.UUID `json:"conversation_id,omitempty"`
-	From           *string             `json:"from,omitempty"`
-	FromName       *string             `json:"from_name,omitempty"`
+
+	// From Sender email address. Must be a verified identity on the organization's email domains. Omitted: the org's resolved default sending address, if one exists.
+	From *string `json:"from,omitempty"`
+
+	// FromName Display name for the From: header (e.g. 'Acme Billing'). Omitted: no display name.
+	FromName *string `json:"from_name,omitempty"`
 
 	// MessageType 'marketing' additionally requires a non-empty consent_source. Use 'informational' for transactional/service communications.
 	MessageType *EmailCreateMessageType `json:"message_type,omitempty"`
-	Metadata    *map[string]interface{} `json:"metadata,omitempty"`
+
+	// Metadata Free-form JSON object attached to the email and echoed back on reads. Not interpreted by Hail.
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
 
 	// RecipientConsent Attestation that you have obtained the lawful consent required to contact this recipient. Hail does not verify consent itself — you are responsible for a lawful basis under TCPA/ePrivacy/PECR/CAN-SPAM/GDPR as applicable. Rejected (422) if not true.
-	RecipientConsent bool     `json:"recipient_consent"`
-	ReplyTo          *string  `json:"reply_to,omitempty"`
-	Subject          string   `json:"subject"`
-	To               []string `json:"to"`
+	RecipientConsent bool `json:"recipient_consent"`
+
+	// ReplyTo Reply-To email address. Omitted: replies go to the From address.
+	ReplyTo *string `json:"reply_to,omitempty"`
+
+	// Subject Email subject line.
+	Subject string `json:"subject"`
+
+	// To Recipient email addresses. At least one required.
+	To []string `json:"to"`
 }
 
 // EmailCreateMessageType 'marketing' additionally requires a non-empty consent_source. Use 'informational' for transactional/service communications.
@@ -1205,20 +1333,32 @@ type EmailCreateMessageType string
 // neither is supplied. For “kind='custom'“ “domain“ is required and
 // the prefix fields must be omitted.
 type EmailDomainCreate struct {
-	Domain          *string               `json:"domain,omitempty"`
-	Kind            EmailDomainCreateKind `json:"kind"`
-	LocalPrefixOrg  *string               `json:"local_prefix_org,omitempty"`
-	LocalPrefixUser *string               `json:"local_prefix_user,omitempty"`
+	// Domain DNS domain to send from (e.g. 'acme.com'). Required for kind='custom'; must be omitted for kind='hail_mail'.
+	Domain *string `json:"domain,omitempty"`
+
+	// Kind 'hail_mail' for a Hail-hosted address (domain omitted, composed from the prefix fields), or 'custom' to send from your own domain (domain required, prefix fields omitted).
+	Kind EmailDomainCreateKind `json:"kind"`
+
+	// LocalPrefixOrg Org-chosen local-part prefix for a hail_mail address. Only valid for kind='hail_mail'. Falls back to HAIL_MAIL_DEFAULT_ORG_PREFIX if omitted.
+	LocalPrefixOrg *string `json:"local_prefix_org,omitempty"`
+
+	// LocalPrefixUser User-chosen local-part prefix for a hail_mail address. Only valid for kind='hail_mail'. Falls back to HAIL_MAIL_DEFAULT_USER_PREFIX if omitted.
+	LocalPrefixUser *string `json:"local_prefix_user,omitempty"`
 }
 
-// EmailDomainCreateKind defines model for EmailDomainCreate.Kind.
+// EmailDomainCreateKind 'hail_mail' for a Hail-hosted address (domain omitted, composed from the prefix fields), or 'custom' to send from your own domain (domain required, prefix fields omitted).
 type EmailDomainCreateKind string
 
 // EmailDomainListResponse defines model for EmailDomainListResponse.
 type EmailDomainListResponse struct {
-	DefaultFrom *string               `json:"default_from,omitempty"`
-	Items       []EmailDomainResponse `json:"items"`
-	NextCursor  *string               `json:"next_cursor,omitempty"`
+	// DefaultFrom The From address used when a send omits 'from'. Null when no such default can be resolved (e.g. multiple verified identities, or none that can send yet). Computed across the whole organization, not just this page.
+	DefaultFrom *string `json:"default_from,omitempty"`
+
+	// Items Email domains in this page.
+	Items []EmailDomainResponse `json:"items"`
+
+	// NextCursor Opaque cursor for the next page. Null when there are no more results.
+	NextCursor *string `json:"next_cursor,omitempty"`
 }
 
 // EmailDomainPatch Body for PATCH /email-domains/{id}.
@@ -1240,11 +1380,20 @@ type EmailDomainListResponse struct {
 // re-implement it here because the patch may merge with existing row
 // state to satisfy the invariant.
 type EmailDomainPatch struct {
-	ForwardRatePerHour *int      `json:"forward_rate_per_hour,omitempty"`
-	ForwardTo          *[]string `json:"forward_to,omitempty"`
-	InboundEnabled     *bool     `json:"inbound_enabled,omitempty"`
-	LocalPrefixOrg     *string   `json:"local_prefix_org,omitempty"`
-	LocalPrefixUser    *string   `json:"local_prefix_user,omitempty"`
+	// ForwardRatePerHour Cap on forwarded messages per hour. Omit to leave unchanged.
+	ForwardRatePerHour *int `json:"forward_rate_per_hour,omitempty"`
+
+	// ForwardTo Email addresses to forward inbound mail to. Omit to leave unchanged.
+	ForwardTo *[]string `json:"forward_to,omitempty"`
+
+	// InboundEnabled Whether to accept inbound mail on this domain. Requires forward_to (or an existing one) when true. Omit to leave unchanged.
+	InboundEnabled *bool `json:"inbound_enabled,omitempty"`
+
+	// LocalPrefixOrg New org local-part prefix. Only valid on kind='hail_mail' rows. Omit to leave unchanged.
+	LocalPrefixOrg *string `json:"local_prefix_org,omitempty"`
+
+	// LocalPrefixUser New user local-part prefix. Only valid on kind='hail_mail' rows. Omit to leave unchanged.
+	LocalPrefixUser *string `json:"local_prefix_user,omitempty"`
 }
 
 // EmailDomainResponse Read view for an email domain.
@@ -1253,152 +1402,327 @@ type EmailDomainPatch struct {
 // “forward_rate_per_hour“) surface what the row has configured for
 // incoming mail.
 type EmailDomainResponse struct {
-	CreatedAt          time.Time                             `json:"created_at"`
-	DnsRecords         []DnsRecordSchema                     `json:"dns_records"`
-	Domain             string                                `json:"domain"`
-	ForwardRatePerHour *int                                  `json:"forward_rate_per_hour,omitempty"`
-	ForwardTo          *[]string                             `json:"forward_to,omitempty"`
-	Id                 openapi_types.UUID                    `json:"id"`
-	InboundEnabled     *bool                                 `json:"inbound_enabled,omitempty"`
-	Kind               EmailDomainResponseKind               `json:"kind"`
-	LocalPrefixOrg     *string                               `json:"local_prefix_org"`
-	LocalPrefixUser    *string                               `json:"local_prefix_user"`
-	MailFromDomain     *string                               `json:"mail_from_domain"`
-	MailFromStatus     *string                               `json:"mail_from_status,omitempty"`
-	OrganizationId     openapi_types.UUID                    `json:"organization_id"`
-	Provider           string                                `json:"provider"`
-	ReceiveReady       *bool                                 `json:"receive_ready,omitempty"`
-	UpdatedAt          time.Time                             `json:"updated_at"`
+	// CreatedAt When this domain was added, ISO 8601 timestamp.
+	CreatedAt time.Time `json:"created_at"`
+
+	// DnsRecords DNS records (DKIM, MAIL FROM MX, SPF) the tenant must publish to verify this domain.
+	DnsRecords []DnsRecordSchema `json:"dns_records"`
+
+	// Domain The DNS domain mail is sent from.
+	Domain string `json:"domain"`
+
+	// ForwardRatePerHour Configured cap on forwarded messages per hour, if set.
+	ForwardRatePerHour *int `json:"forward_rate_per_hour,omitempty"`
+
+	// ForwardTo Email addresses inbound mail is forwarded to, if inbound is enabled.
+	ForwardTo *[]string `json:"forward_to,omitempty"`
+
+	// Id Unique identifier for this email domain.
+	Id openapi_types.UUID `json:"id"`
+
+	// InboundEnabled Whether this domain accepts and forwards inbound mail.
+	InboundEnabled *bool `json:"inbound_enabled,omitempty"`
+
+	// Kind 'hail_mail' (Hail-hosted address) or 'custom' (your own domain).
+	Kind EmailDomainResponseKind `json:"kind"`
+
+	// LocalPrefixOrg Org local-part prefix for a hail_mail address. Null for kind='custom'.
+	LocalPrefixOrg *string `json:"local_prefix_org"`
+
+	// LocalPrefixUser User local-part prefix for a hail_mail address. Null for kind='custom'.
+	LocalPrefixUser *string `json:"local_prefix_user"`
+
+	// MailFromDomain Custom MAIL FROM domain, if configured. Null when using the provider default.
+	MailFromDomain *string `json:"mail_from_domain"`
+
+	// MailFromStatus Verification status of the custom MAIL FROM domain, if one is configured. Secondary to verification_status.
+	MailFromStatus *string `json:"mail_from_status,omitempty"`
+
+	// OrganizationId Organization that owns this domain.
+	OrganizationId openapi_types.UUID `json:"organization_id"`
+
+	// Provider Email sending provider for this domain (currently always 'ses').
+	Provider string `json:"provider"`
+
+	// ReceiveReady True when the domain's published MX points at Hail's inbound host. Only populated by POST /{id}/verify on custom domains; null everywhere else.
+	ReceiveReady *bool `json:"receive_ready,omitempty"`
+
+	// UpdatedAt When this domain was last modified, ISO 8601 timestamp.
+	UpdatedAt time.Time `json:"updated_at"`
+
+	// VerificationStatus 'pending' (not yet verified), 'verified' (ready to send), or 'failed'.
 	VerificationStatus EmailDomainResponseVerificationStatus `json:"verification_status"`
-	VerifiedAt         *time.Time                            `json:"verified_at"`
+
+	// VerifiedAt When the domain became verified, ISO 8601 timestamp. Null until it is.
+	VerifiedAt *time.Time `json:"verified_at"`
 }
 
-// EmailDomainResponseKind defines model for EmailDomainResponse.Kind.
+// EmailDomainResponseKind 'hail_mail' (Hail-hosted address) or 'custom' (your own domain).
 type EmailDomainResponseKind string
 
-// EmailDomainResponseVerificationStatus defines model for EmailDomainResponse.VerificationStatus.
+// EmailDomainResponseVerificationStatus 'pending' (not yet verified), 'verified' (ready to send), or 'failed'.
 type EmailDomainResponseVerificationStatus string
 
 // EmailEventListResponse defines model for EmailEventListResponse.
 type EmailEventListResponse struct {
-	Items      []EmailEventResponse `json:"items"`
-	NextCursor *string              `json:"next_cursor,omitempty"`
+	// Items Events for this email, oldest first.
+	Items []EmailEventResponse `json:"items"`
+
+	// NextCursor Opaque cursor for the next page. Null when there are no more results.
+	NextCursor *string `json:"next_cursor,omitempty"`
 }
 
 // EmailEventResponse defines model for EmailEventResponse.
 type EmailEventResponse struct {
-	EmailId    openapi_types.UUID     `json:"email_id"`
-	Id         openapi_types.UUID     `json:"id"`
-	Kind       EmailEventResponseKind `json:"kind"`
-	OccurredAt time.Time              `json:"occurred_at"`
-	Payload    map[string]interface{} `json:"payload"`
+	// EmailId The email this event belongs to.
+	EmailId openapi_types.UUID `json:"email_id"`
+
+	// Id Unique identifier for this event.
+	Id openapi_types.UUID `json:"id"`
+
+	// Kind Event kind: 'sent', 'delivered', 'delivery_delayed', 'bounced', 'complained', 'rejected', 'opened', or 'clicked'.
+	Kind EmailEventResponseKind `json:"kind"`
+
+	// OccurredAt When this event occurred, ISO 8601 timestamp.
+	OccurredAt time.Time `json:"occurred_at"`
+
+	// Payload Event-kind-specific detail, as a free-form JSON object.
+	Payload map[string]interface{} `json:"payload"`
 }
 
-// EmailEventResponseKind defines model for EmailEventResponse.Kind.
+// EmailEventResponseKind Event kind: 'sent', 'delivered', 'delivery_delayed', 'bounced', 'complained', 'rejected', 'opened', or 'clicked'.
 type EmailEventResponseKind string
 
 // EmailListResponse defines model for EmailListResponse.
 type EmailListResponse struct {
-	Items      []EmailSummary `json:"items"`
-	NextCursor *string        `json:"next_cursor,omitempty"`
+	// Items Emails in this page, newest first.
+	Items []EmailSummary `json:"items"`
+
+	// NextCursor Opaque cursor for the next page. Null when there are no more results.
+	NextCursor *string `json:"next_cursor,omitempty"`
 }
 
 // EmailResponse defines model for EmailResponse.
 type EmailResponse struct {
-	Attachments        *[]EmailAttachmentResponse `json:"attachments,omitempty"`
-	BccAddresses       *[]string                  `json:"bcc_addresses"`
-	BodyHtml           *string                    `json:"body_html"`
-	BodyText           *string                    `json:"body_text"`
-	CcAddresses        *[]string                  `json:"cc_addresses"`
-	ConversationId     *openapi_types.UUID        `json:"conversation_id"`
-	Direction          *EmailResponseDirection    `json:"direction,omitempty"`
-	DkimVerdict        *string                    `json:"dkim_verdict,omitempty"`
-	DmarcVerdict       *string                    `json:"dmarc_verdict,omitempty"`
-	EmailDomainId      *openapi_types.UUID        `json:"email_domain_id"`
-	EndReason          *string                    `json:"end_reason"`
-	FailedAt           *time.Time                 `json:"failed_at"`
-	FromAddress        string                     `json:"from_address"`
-	FromName           *string                    `json:"from_name,omitempty"`
-	Id                 openapi_types.UUID         `json:"id"`
-	InReplyTo          *string                    `json:"in_reply_to,omitempty"`
-	LastEventAt        *time.Time                 `json:"last_event_at,omitempty"`
-	MessageId          *string                    `json:"message_id,omitempty"`
-	Metadata           *map[string]interface{}    `json:"metadata,omitempty"`
-	OrganizationId     openapi_types.UUID         `json:"organization_id"`
-	ProviderMessageId  *string                    `json:"provider_message_id"`
-	ProviderReceivedAt *time.Time                 `json:"provider_received_at,omitempty"`
-	RawUrl             *string                    `json:"raw_url,omitempty"`
-	ReferencesIds      *[]string                  `json:"references_ids,omitempty"`
-	ReplyTo            *string                    `json:"reply_to"`
-	RequestedAt        time.Time                  `json:"requested_at"`
-	SentAt             *time.Time                 `json:"sent_at"`
-	SpamVerdict        *string                    `json:"spam_verdict,omitempty"`
-	SpfVerdict         *string                    `json:"spf_verdict,omitempty"`
-	Status             EmailResponseStatus        `json:"status"`
-	Subject            string                     `json:"subject"`
-	ToAddresses        []string                   `json:"to_addresses"`
-	VirusVerdict       *string                    `json:"virus_verdict,omitempty"`
+	// Attachments Inbound MIME attachments on this email. Empty on outbound rows.
+	Attachments *[]EmailAttachmentResponse `json:"attachments,omitempty"`
+
+	// BccAddresses BCC recipient email addresses, if any.
+	BccAddresses *[]string `json:"bcc_addresses"`
+
+	// BodyHtml HTML body, if any.
+	BodyHtml *string `json:"body_html"`
+
+	// BodyText Plain-text body, if any.
+	BodyText *string `json:"body_text"`
+
+	// CcAddresses CC recipient email addresses, if any.
+	CcAddresses *[]string `json:"cc_addresses"`
+
+	// ConversationId Conversation thread this email is grouped into, if any. Null when it was not linked to a conversation.
+	ConversationId *openapi_types.UUID `json:"conversation_id"`
+
+	// Direction 'outbound' for emails Hail sent, 'inbound' for emails received.
+	Direction *EmailResponseDirection `json:"direction,omitempty"`
+
+	// DkimVerdict Provider DKIM-authentication verdict (e.g. 'PASS'/'FAIL'). Inbound emails only; null on outbound rows.
+	DkimVerdict *string `json:"dkim_verdict,omitempty"`
+
+	// DmarcVerdict Provider DMARC-authentication verdict (e.g. 'PASS'/'FAIL'). Inbound emails only; null on outbound rows.
+	DmarcVerdict *string `json:"dmarc_verdict,omitempty"`
+
+	// EmailDomainId The sending domain used, if from_address belongs to one of the org's configured domains.
+	EmailDomainId *openapi_types.UUID `json:"email_domain_id"`
+
+	// EndReason Reason delivery failed or bounced, if applicable. Null on success or while pending.
+	EndReason *string `json:"end_reason"`
+
+	// FailedAt When the send failed, ISO 8601 timestamp. Null unless it failed.
+	FailedAt *time.Time `json:"failed_at"`
+
+	// FromAddress Sender email address.
+	FromAddress string `json:"from_address"`
+
+	// FromName Display name used on the From: header, when the sender supplied one. Always null on inbound rows.
+	FromName *string `json:"from_name,omitempty"`
+
+	// Id Unique identifier for this email.
+	Id openapi_types.UUID `json:"id"`
+
+	// InReplyTo RFC 5322 In-Reply-To header. Inbound emails only; null on outbound rows.
+	InReplyTo *string `json:"in_reply_to,omitempty"`
+
+	// LastEventAt When the most recent delivery event for this email occurred, ISO 8601 timestamp.
+	LastEventAt *time.Time `json:"last_event_at,omitempty"`
+
+	// MessageId RFC 5322 Message-ID header. Inbound emails only; null on outbound rows.
+	MessageId *string `json:"message_id,omitempty"`
+
+	// Metadata Free-form JSON object attached to the email, as sent on create. Not interpreted by Hail.
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+
+	// OrganizationId Organization that sent or received this email.
+	OrganizationId openapi_types.UUID `json:"organization_id"`
+
+	// ProviderMessageId The email provider's identifier for this message, if assigned.
+	ProviderMessageId *string `json:"provider_message_id"`
+
+	// ProviderReceivedAt When the provider received this email, ISO 8601 timestamp. Inbound emails only.
+	ProviderReceivedAt *time.Time `json:"provider_received_at,omitempty"`
+
+	// RawUrl API endpoint that redirects to the original MIME blob. Inbound emails only; null on outbound rows.
+	RawUrl *string `json:"raw_url,omitempty"`
+
+	// ReferencesIds RFC 5322 References header, split into ids. Inbound emails only; null on outbound rows.
+	ReferencesIds *[]string `json:"references_ids,omitempty"`
+
+	// ReplyTo Reply-To email address, if set.
+	ReplyTo *string `json:"reply_to"`
+
+	// RequestedAt When the send was requested, ISO 8601 timestamp.
+	RequestedAt time.Time `json:"requested_at"`
+
+	// SentAt When the message was handed to the provider, ISO 8601 timestamp. Null until sent.
+	SentAt *time.Time `json:"sent_at"`
+
+	// SpamVerdict Provider spam-scan verdict (e.g. 'PASS'/'FAIL'). Inbound emails only; null on outbound rows.
+	SpamVerdict *string `json:"spam_verdict,omitempty"`
+
+	// SpfVerdict Provider SPF-authentication verdict (e.g. 'PASS'/'FAIL'). Inbound emails only; null on outbound rows.
+	SpfVerdict *string `json:"spf_verdict,omitempty"`
+
+	// Status Delivery status: 'queued', 'sent', 'delivered', 'failed', 'bounced', 'complained', or 'received' (inbound emails).
+	Status EmailResponseStatus `json:"status"`
+
+	// Subject Email subject line.
+	Subject string `json:"subject"`
+
+	// ToAddresses Recipient email addresses.
+	ToAddresses []string `json:"to_addresses"`
+
+	// VirusVerdict Provider virus-scan verdict (e.g. 'PASS'/'FAIL'). Inbound emails only; null on outbound rows.
+	VirusVerdict *string `json:"virus_verdict,omitempty"`
 }
 
-// EmailResponseDirection defines model for EmailResponse.Direction.
+// EmailResponseDirection 'outbound' for emails Hail sent, 'inbound' for emails received.
 type EmailResponseDirection string
 
-// EmailResponseStatus defines model for EmailResponse.Status.
+// EmailResponseStatus Delivery status: 'queued', 'sent', 'delivered', 'failed', 'bounced', 'complained', or 'received' (inbound emails).
 type EmailResponseStatus string
 
 // EmailStatsBucket defines model for EmailStatsBucket.
 type EmailStatsBucket struct {
-	Bounced         *int      `json:"bounced,omitempty"`
-	BouncedHard     *int      `json:"bounced_hard,omitempty"`
-	BucketStart     time.Time `json:"bucket_start"`
-	Clicked         *int      `json:"clicked,omitempty"`
-	Complained      *int      `json:"complained,omitempty"`
-	Delivered       *int      `json:"delivered,omitempty"`
-	DeliveryDelayed *int      `json:"delivery_delayed,omitempty"`
-	Opened          *int      `json:"opened,omitempty"`
-	Rejected        *int      `json:"rejected,omitempty"`
-	Sent            *int      `json:"sent,omitempty"`
-	UniqueClicked   *int      `json:"unique_clicked,omitempty"`
-	UniqueOpened    *int      `json:"unique_opened,omitempty"`
+	// Bounced Emails bounced (soft or hard) in the window.
+	Bounced *int `json:"bounced,omitempty"`
+
+	// BouncedHard Emails hard-bounced in the window. Subset of bounced.
+	BouncedHard *int `json:"bounced_hard,omitempty"`
+
+	// BucketStart Start of this bucket, ISO 8601 timestamp.
+	BucketStart time.Time `json:"bucket_start"`
+
+	// Clicked Total click events in the window, including repeat clicks by the same recipient.
+	Clicked *int `json:"clicked,omitempty"`
+
+	// Complained Emails that received a spam complaint in the window.
+	Complained *int `json:"complained,omitempty"`
+
+	// Delivered Emails confirmed delivered in the window.
+	Delivered *int `json:"delivered,omitempty"`
+
+	// DeliveryDelayed Emails with a delivery-delayed event in the window.
+	DeliveryDelayed *int `json:"delivery_delayed,omitempty"`
+
+	// Opened Total open events in the window, including repeat opens by the same recipient.
+	Opened *int `json:"opened,omitempty"`
+
+	// Rejected Emails rejected by the provider before sending, in the window.
+	Rejected *int `json:"rejected,omitempty"`
+
+	// Sent Emails sent in the window.
+	Sent *int `json:"sent,omitempty"`
+
+	// UniqueClicked Distinct emails clicked at least once in the window.
+	UniqueClicked *int `json:"unique_clicked,omitempty"`
+
+	// UniqueOpened Distinct emails opened at least once in the window.
+	UniqueOpened *int `json:"unique_opened,omitempty"`
 }
 
 // EmailStatsCounts defines model for EmailStatsCounts.
 type EmailStatsCounts struct {
-	Bounced         *int `json:"bounced,omitempty"`
-	BouncedHard     *int `json:"bounced_hard,omitempty"`
-	Clicked         *int `json:"clicked,omitempty"`
-	Complained      *int `json:"complained,omitempty"`
-	Delivered       *int `json:"delivered,omitempty"`
+	// Bounced Emails bounced (soft or hard) in the window.
+	Bounced *int `json:"bounced,omitempty"`
+
+	// BouncedHard Emails hard-bounced in the window. Subset of bounced.
+	BouncedHard *int `json:"bounced_hard,omitempty"`
+
+	// Clicked Total click events in the window, including repeat clicks by the same recipient.
+	Clicked *int `json:"clicked,omitempty"`
+
+	// Complained Emails that received a spam complaint in the window.
+	Complained *int `json:"complained,omitempty"`
+
+	// Delivered Emails confirmed delivered in the window.
+	Delivered *int `json:"delivered,omitempty"`
+
+	// DeliveryDelayed Emails with a delivery-delayed event in the window.
 	DeliveryDelayed *int `json:"delivery_delayed,omitempty"`
-	Opened          *int `json:"opened,omitempty"`
-	Rejected        *int `json:"rejected,omitempty"`
-	Sent            *int `json:"sent,omitempty"`
-	UniqueClicked   *int `json:"unique_clicked,omitempty"`
-	UniqueOpened    *int `json:"unique_opened,omitempty"`
+
+	// Opened Total open events in the window, including repeat opens by the same recipient.
+	Opened *int `json:"opened,omitempty"`
+
+	// Rejected Emails rejected by the provider before sending, in the window.
+	Rejected *int `json:"rejected,omitempty"`
+
+	// Sent Emails sent in the window.
+	Sent *int `json:"sent,omitempty"`
+
+	// UniqueClicked Distinct emails clicked at least once in the window.
+	UniqueClicked *int `json:"unique_clicked,omitempty"`
+
+	// UniqueOpened Distinct emails opened at least once in the window.
+	UniqueOpened *int `json:"unique_opened,omitempty"`
 }
 
 // EmailStatsRates All None when sent == 0 in the window.
 type EmailStatsRates struct {
-	Bounce    *float32 `json:"bounce,omitempty"`
-	Click     *float32 `json:"click,omitempty"`
+	// Bounce bounced_hard / sent for the window. Null when sent == 0.
+	Bounce *float32 `json:"bounce,omitempty"`
+
+	// Click unique_clicked / sent for the window. Null when sent == 0.
+	Click *float32 `json:"click,omitempty"`
+
+	// Complaint complained / sent for the window. Null when sent == 0.
 	Complaint *float32 `json:"complaint,omitempty"`
-	Delivery  *float32 `json:"delivery,omitempty"`
-	Open      *float32 `json:"open,omitempty"`
+
+	// Delivery delivered / sent for the window. Null when sent == 0.
+	Delivery *float32 `json:"delivery,omitempty"`
+
+	// Open unique_opened / sent for the window. Null when sent == 0.
+	Open *float32 `json:"open,omitempty"`
 }
 
 // EmailStatsResponse defines model for EmailStatsResponse.
 type EmailStatsResponse struct {
+	// Bucket Time-bucket size used for the series.
 	Bucket EmailStatsResponseBucket `json:"bucket"`
-	From   time.Time                `json:"from"`
+
+	// From Start of the queried window, ISO 8601 timestamp (inclusive).
+	From time.Time `json:"from"`
 
 	// Rates All None when sent == 0 in the window.
-	Rates  EmailStatsRates    `json:"rates"`
+	Rates EmailStatsRates `json:"rates"`
+
+	// Series Per-bucket event counts across the window, in chronological order.
 	Series []EmailStatsBucket `json:"series"`
-	To     time.Time          `json:"to"`
-	Totals EmailStatsCounts   `json:"totals"`
+
+	// To End of the queried window, ISO 8601 timestamp (exclusive).
+	To     time.Time        `json:"to"`
+	Totals EmailStatsCounts `json:"totals"`
 }
 
-// EmailStatsResponseBucket defines model for EmailStatsResponse.Bucket.
+// EmailStatsResponseBucket Time-bucket size used for the series.
 type EmailStatsResponseBucket string
 
 // EmailSummary Trimmed view for list endpoints — drops the message bodies.
@@ -1407,104 +1731,190 @@ type EmailStatsResponseBucket string
 // shouldn't return every byte of every message just to render a list.
 // Use “EmailResponse“ (via “GET /emails/{id}“) for the full row.
 type EmailSummary struct {
-	BccAddresses      *[]string               `json:"bcc_addresses"`
-	CcAddresses       *[]string               `json:"cc_addresses"`
-	ConversationId    *openapi_types.UUID     `json:"conversation_id"`
-	Direction         *EmailSummaryDirection  `json:"direction,omitempty"`
-	EmailDomainId     *openapi_types.UUID     `json:"email_domain_id"`
-	EndReason         *string                 `json:"end_reason"`
-	FailedAt          *time.Time              `json:"failed_at"`
-	FromAddress       string                  `json:"from_address"`
-	FromName          *string                 `json:"from_name,omitempty"`
-	Id                openapi_types.UUID      `json:"id"`
-	Metadata          *map[string]interface{} `json:"metadata,omitempty"`
-	OrganizationId    openapi_types.UUID      `json:"organization_id"`
-	ProviderMessageId *string                 `json:"provider_message_id"`
-	ReplyTo           *string                 `json:"reply_to"`
-	RequestedAt       time.Time               `json:"requested_at"`
-	SentAt            *time.Time              `json:"sent_at"`
-	Status            EmailSummaryStatus      `json:"status"`
-	Subject           string                  `json:"subject"`
-	ToAddresses       []string                `json:"to_addresses"`
+	// BccAddresses BCC recipient email addresses, if any.
+	BccAddresses *[]string `json:"bcc_addresses"`
+
+	// CcAddresses CC recipient email addresses, if any.
+	CcAddresses *[]string `json:"cc_addresses"`
+
+	// ConversationId Conversation thread this email is grouped into, if any. Null when it was not linked to a conversation.
+	ConversationId *openapi_types.UUID `json:"conversation_id"`
+
+	// Direction 'outbound' for emails Hail sent, 'inbound' for emails received.
+	Direction *EmailSummaryDirection `json:"direction,omitempty"`
+
+	// EmailDomainId The sending domain used, if from_address belongs to one of the org's configured domains.
+	EmailDomainId *openapi_types.UUID `json:"email_domain_id"`
+
+	// EndReason Reason delivery failed or bounced, if applicable. Null on success or while pending.
+	EndReason *string `json:"end_reason"`
+
+	// FailedAt When the send failed, ISO 8601 timestamp. Null unless it failed.
+	FailedAt *time.Time `json:"failed_at"`
+
+	// FromAddress Sender email address.
+	FromAddress string `json:"from_address"`
+
+	// FromName Display name used on the From: header, when the sender supplied one. Always null on inbound rows.
+	FromName *string `json:"from_name,omitempty"`
+
+	// Id Unique identifier for this email.
+	Id openapi_types.UUID `json:"id"`
+
+	// Metadata Free-form JSON object attached to the email, as sent on create. Not interpreted by Hail.
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+
+	// OrganizationId Organization that sent or received this email.
+	OrganizationId openapi_types.UUID `json:"organization_id"`
+
+	// ProviderMessageId The email provider's identifier for this message, if assigned.
+	ProviderMessageId *string `json:"provider_message_id"`
+
+	// ReplyTo Reply-To email address, if set.
+	ReplyTo *string `json:"reply_to"`
+
+	// RequestedAt When the send was requested, ISO 8601 timestamp.
+	RequestedAt time.Time `json:"requested_at"`
+
+	// SentAt When the message was handed to the provider, ISO 8601 timestamp. Null until sent.
+	SentAt *time.Time `json:"sent_at"`
+
+	// Status Delivery status: 'queued', 'sent', 'delivered', 'failed', 'bounced', 'complained', or 'received' (inbound emails).
+	Status EmailSummaryStatus `json:"status"`
+
+	// Subject Email subject line.
+	Subject string `json:"subject"`
+
+	// ToAddresses Recipient email addresses.
+	ToAddresses []string `json:"to_addresses"`
 }
 
-// EmailSummaryDirection defines model for EmailSummary.Direction.
+// EmailSummaryDirection 'outbound' for emails Hail sent, 'inbound' for emails received.
 type EmailSummaryDirection string
 
-// EmailSummaryStatus defines model for EmailSummary.Status.
+// EmailSummaryStatus Delivery status: 'queued', 'sent', 'delivered', 'failed', 'bounced', 'complained', or 'received' (inbound emails).
 type EmailSummaryStatus string
 
 // EventResponse One event on the unified GET /events stream (call, email, or SMS).
 type EventResponse struct {
-	CallId     *openapi_types.UUID    `json:"call_id,omitempty"`
-	EmailId    *openapi_types.UUID    `json:"email_id,omitempty"`
-	Id         openapi_types.UUID     `json:"id"`
-	Kind       string                 `json:"kind"`
-	OccurredAt time.Time              `json:"occurred_at"`
-	Payload    map[string]interface{} `json:"payload"`
-	SmsId      *openapi_types.UUID    `json:"sms_id,omitempty"`
-	Source     EventResponseSource    `json:"source"`
+	// CallId The call this event belongs to. Set only when source='call'.
+	CallId *openapi_types.UUID `json:"call_id,omitempty"`
+
+	// EmailId The email this event belongs to. Set only when source='email'.
+	EmailId *openapi_types.UUID `json:"email_id,omitempty"`
+
+	// Id Unique identifier for this event.
+	Id openapi_types.UUID `json:"id"`
+
+	// Kind Event kind within the source (e.g. 'queued', 'delivered', 'bounced'). Vocabulary differs per source.
+	Kind string `json:"kind"`
+
+	// OccurredAt When this event occurred, ISO 8601 timestamp.
+	OccurredAt time.Time `json:"occurred_at"`
+
+	// Payload Event-kind-specific detail, as a free-form JSON object.
+	Payload map[string]interface{} `json:"payload"`
+
+	// SmsId The message this event belongs to. Set only when source='sms'.
+	SmsId *openapi_types.UUID `json:"sms_id,omitempty"`
+
+	// Source Which channel this event belongs to: 'call', 'email', or 'sms'.
+	Source EventResponseSource `json:"source"`
 }
 
-// EventResponseSource defines model for EventResponse.Source.
+// EventResponseSource Which channel this event belongs to: 'call', 'email', or 'sms'.
 type EventResponseSource string
 
 // EventStreamResponse defines model for EventStreamResponse.
 type EventStreamResponse struct {
+	// CallStatus Current status of the call named by the id filter (e.g. id=call:<uuid>). Null for org-wide tails and non-call filters, since there is no single call to report a status for.
 	CallStatus *EventStreamResponseCallStatus `json:"call_status,omitempty"`
-	Items      []EventResponse                `json:"items"`
-	NextCursor *string                        `json:"next_cursor,omitempty"`
+
+	// Items Events in this page, oldest first.
+	Items []EventResponse `json:"items"`
+
+	// NextCursor Opaque cursor for the next page. Null when there are no more results.
+	NextCursor *string `json:"next_cursor,omitempty"`
 }
 
-// EventStreamResponseCallStatus defines model for EventStreamResponse.CallStatus.
+// EventStreamResponseCallStatus Current status of the call named by the id filter (e.g. id=call:<uuid>). Null for org-wide tails and non-call filters, since there is no single call to report a status for.
 type EventStreamResponseCallStatus string
 
 // HTTPValidationError defines model for HTTPValidationError.
 type HTTPValidationError struct {
+	// Detail List of validation errors: each entry gives the field location (loc), the problem (msg), and the error type (type).
 	Detail *[]ValidationError `json:"detail,omitempty"`
 }
 
 // LLMConfig defines model for LLMConfig.
 type LLMConfig struct {
-	ApiKey  string `json:"api_key"`
+	// ApiKey API key sent to the BYO LLM endpoint. Write-only — never echoed back.
+	ApiKey string `json:"api_key"`
+
+	// BaseUrl Public HTTPS base URL of the BYO LLM endpoint the call runs on. Must resolve to a public address — private/internal hosts are rejected.
 	BaseUrl string `json:"base_url"`
-	Model   string `json:"model"`
+
+	// Model Model name to request from the BYO LLM endpoint.
+	Model string `json:"model"`
 }
 
 // MemberPhonePut defines model for MemberPhonePut.
 type MemberPhonePut struct {
+	// PhoneE164 Phone number to save for the caller, E.164 format.
 	PhoneE164 string `json:"phone_e164"`
 }
 
 // NumberAcquireRequest defines model for NumberAcquireRequest.
 type NumberAcquireRequest struct {
-	CountryCode string                          `json:"country_code"`
-	NumberType  *NumberAcquireRequestNumberType `json:"number_type,omitempty"`
+	// CountryCode ISO alpha-2 country code to acquire a number in (e.g. 'US'). Case-insensitive.
+	CountryCode string `json:"country_code"`
+
+	// NumberType Kind of number to acquire: 'local', 'mobile', 'toll_free', or 'national'.
+	NumberType *NumberAcquireRequestNumberType `json:"number_type,omitempty"`
 }
 
-// NumberAcquireRequestNumberType defines model for NumberAcquireRequest.NumberType.
+// NumberAcquireRequestNumberType Kind of number to acquire: 'local', 'mobile', 'toll_free', or 'national'.
 type NumberAcquireRequestNumberType string
 
 // PhoneNumberListResponse defines model for PhoneNumberListResponse.
 type PhoneNumberListResponse struct {
-	Items      []PhoneNumberResponse `json:"items"`
-	NextCursor *string               `json:"next_cursor,omitempty"`
+	// Items Numbers in this page.
+	Items []PhoneNumberResponse `json:"items"`
+
+	// NextCursor Opaque cursor for the next page. Null when there are no more results.
+	NextCursor *string `json:"next_cursor,omitempty"`
 }
 
 // PhoneNumberResponse defines model for PhoneNumberResponse.
 type PhoneNumberResponse struct {
-	Capabilities        []string           `json:"capabilities"`
-	CountryCode         string             `json:"country_code"`
-	E164                string             `json:"e164"`
-	Id                  openapi_types.UUID `json:"id"`
-	IsDedicated         bool               `json:"is_dedicated"`
-	MessagingServiceSid *string            `json:"messaging_service_sid,omitempty"`
-	NumberType          string             `json:"number_type"`
-	ProvisioningState   string             `json:"provisioning_state"`
+	// Capabilities Channels this number supports, e.g. ['voice'], ['sms'], or both.
+	Capabilities []string `json:"capabilities"`
+
+	// CountryCode ISO alpha-2 country code this number belongs to.
+	CountryCode string `json:"country_code"`
+
+	// E164 The phone number, E.164 format.
+	E164 string `json:"e164"`
+
+	// Id Unique identifier for this number.
+	Id openapi_types.UUID `json:"id"`
+
+	// IsDedicated True if this number is owned by the organization. False for shared-pool numbers.
+	IsDedicated bool `json:"is_dedicated"`
+
+	// MessagingServiceSid Provider messaging-service identifier once SMS has been enabled on this number. Null until then.
+	MessagingServiceSid *string `json:"messaging_service_sid,omitempty"`
+
+	// NumberType Kind of number: 'local', 'mobile', 'toll_free', or 'national'.
+	NumberType string `json:"number_type"`
+
+	// ProvisioningState 'pending', 'active', 'failed', or 'released'.
+	ProvisioningState string `json:"provisioning_state"`
 }
 
 // ProviderActivateRequest Body of “POST /providers/{layer}/activate“.
 type ProviderActivateRequest struct {
+	// Provider Previously saved provider to make active for this layer.
 	Provider string `json:"provider"`
 }
 
@@ -1515,20 +1925,34 @@ type ProviderActivateRequest struct {
 // serializer always emits all of them, and required response fields
 // generate plain values instead of pointers in the Go CLI's client.
 type ProviderConfigEntry struct {
-	FallbackEnabled bool                     `json:"fallback_enabled"`
-	IsActive        bool                     `json:"is_active"`
-	KeyLast4        *string                  `json:"key_last4"`
-	KeySetAt        *string                  `json:"key_set_at"`
-	Layer           ProviderConfigEntryLayer `json:"layer"`
-	Params          map[string]interface{}   `json:"params"`
-	Provider        string                   `json:"provider"`
+	// FallbackEnabled Whether Hail's default provider is used as a fallback if this one fails.
+	FallbackEnabled bool `json:"fallback_enabled"`
+
+	// IsActive True if this is the row currently used by calls on this layer.
+	IsActive bool `json:"is_active"`
+
+	// KeyLast4 Last 4 characters of the saved API key, for display. Null if no key is saved.
+	KeyLast4 *string `json:"key_last4"`
+
+	// KeySetAt When the API key was last set, ISO 8601 timestamp. Null if no key is saved.
+	KeySetAt *string `json:"key_set_at"`
+
+	// Layer Voice-pipeline layer this config applies to.
+	Layer ProviderConfigEntryLayer `json:"layer"`
+
+	// Params Saved provider-specific config for this row.
+	Params map[string]interface{} `json:"params"`
+
+	// Provider Provider name (e.g. 'openai', 'cartesia').
+	Provider string `json:"provider"`
 }
 
-// ProviderConfigEntryLayer defines model for ProviderConfigEntry.Layer.
+// ProviderConfigEntryLayer Voice-pipeline layer this config applies to.
 type ProviderConfigEntryLayer string
 
 // ProviderConfigListResponse defines model for ProviderConfigListResponse.
 type ProviderConfigListResponse struct {
+	// Providers Every saved provider row for the organization, across all layers.
 	Providers []ProviderConfigEntry `json:"providers"`
 }
 
@@ -1548,10 +1972,17 @@ type ProviderConfigListResponse struct {
 //
 // Keys are write-only: no response ever echoes one back.
 type ProviderConfigUpsert struct {
-	ApiKey          *string                 `json:"api_key,omitempty"`
-	FallbackEnabled *bool                   `json:"fallback_enabled,omitempty"`
-	Params          *map[string]interface{} `json:"params,omitempty"`
-	Provider        string                  `json:"provider"`
+	// ApiKey API key for this provider. Omit to edit params without resending the key. Write-only — never echoed back.
+	ApiKey *string `json:"api_key,omitempty"`
+
+	// FallbackEnabled Whether to fall back to Hail's default provider on failure. Omit to leave unchanged; defaults to false on a new row.
+	FallbackEnabled *bool `json:"fallback_enabled,omitempty"`
+
+	// Params Provider-specific config, validated against the layer's schema (LLMParams/TTSParams/STTParams). Only the keys you send are changed; other saved keys are kept.
+	Params *map[string]interface{} `json:"params,omitempty"`
+
+	// Provider Provider name to save/activate for this layer (e.g. 'openai', 'cartesia').
+	Provider string `json:"provider"`
 }
 
 // ProviderValidateRequest Body of “POST /providers/{layer}/validate“ — a live key probe.
@@ -1560,30 +1991,43 @@ type ProviderConfigUpsert struct {
 // its stored key are tested. “provider“ tests that provider's stored key
 // instead. “api_key“ tests a key that has not been saved yet.
 type ProviderValidateRequest struct {
-	ApiKey   *string                 `json:"api_key,omitempty"`
-	Params   *map[string]interface{} `json:"params,omitempty"`
-	Provider *string                 `json:"provider,omitempty"`
+	// ApiKey Key to test instead of the stored one. Not persisted.
+	ApiKey *string `json:"api_key,omitempty"`
+
+	// Params Provider-specific config to test alongside the key.
+	Params *map[string]interface{} `json:"params,omitempty"`
+
+	// Provider Provider to test. Omitted: the layer's currently active provider.
+	Provider *string `json:"provider,omitempty"`
 }
 
 // ProviderValidateResult Outcome of a live provider-key probe.
 type ProviderValidateResult struct {
+	// Message Human-readable detail about the outcome. 'ok' on success, an error description otherwise.
 	Message *string `json:"message"`
-	Status  string  `json:"status"`
+
+	// Status Probe outcome: 'valid', 'invalid', or 'indeterminate' (the provider could not be reached).
+	Status string `json:"status"`
 }
 
 // SenderIdPatch defines model for SenderIdPatch.
 type SenderIdPatch struct {
+	// CustomSenderId Alphanumeric sender id (2-11 characters, letters/digits only) to use on alphanumeric-eligible corridors instead of a phone number. Explicit null clears it, reverting to the platform default.
 	CustomSenderId *string `json:"custom_sender_id,omitempty"`
 }
 
 // SenderIdResponse defines model for SenderIdResponse.
 type SenderIdResponse struct {
-	CustomSenderId   *string `json:"custom_sender_id"`
+	// CustomSenderId The organization's configured alphanumeric sender id. Null if none is set.
+	CustomSenderId *string `json:"custom_sender_id"`
+
+	// EffectiveDefault The platform's alphanumeric sender id, used on eligible corridors when custom_sender_id is null.
 	EffectiveDefault *string `json:"effective_default,omitempty"`
 }
 
 // SmsCreate defines model for SmsCreate.
 type SmsCreate struct {
+	// Body Message text. Long bodies are split into multiple carrier segments.
 	Body string `json:"body"`
 
 	// ConsentObtainedAt When consent was obtained, if known.
@@ -1591,15 +2035,21 @@ type SmsCreate struct {
 
 	// ConsentSource Where/how consent was obtained (e.g. 'signup form', 'prior customer relationship'). Required (non-empty) when message_type is 'marketing'.
 	ConsentSource *string `json:"consent_source,omitempty"`
-	From          *string `json:"from,omitempty"`
+
+	// From Sender phone number, E.164 format. Must be a number owned by the organization with the SMS capability. Omitted: an active org-owned number is used if one exists, else a number is claimed from the shared pool.
+	From *string `json:"from,omitempty"`
 
 	// MessageType 'marketing' additionally requires a non-empty consent_source. Use 'informational' for transactional/service communications.
-	MessageType *SmsCreateMessageType   `json:"message_type,omitempty"`
-	Metadata    *map[string]interface{} `json:"metadata,omitempty"`
+	MessageType *SmsCreateMessageType `json:"message_type,omitempty"`
+
+	// Metadata Free-form JSON object attached to the message and echoed back on reads. Not interpreted by Hail.
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
 
 	// RecipientConsent Attestation that you have obtained the lawful consent required to contact this recipient. Hail does not verify consent itself — you are responsible for a lawful basis under TCPA/ePrivacy/PECR/CAN-SPAM/GDPR as applicable. Rejected (422) if not true.
-	RecipientConsent bool   `json:"recipient_consent"`
-	To               string `json:"to"`
+	RecipientConsent bool `json:"recipient_consent"`
+
+	// To Recipient phone number, E.164 format (e.g. +14155551234).
+	To string `json:"to"`
 }
 
 // SmsCreateMessageType 'marketing' additionally requires a non-empty consent_source. Use 'informational' for transactional/service communications.
@@ -1607,55 +2057,104 @@ type SmsCreateMessageType string
 
 // SmsListResponse defines model for SmsListResponse.
 type SmsListResponse struct {
-	Items      []SmsResponse `json:"items"`
-	NextCursor *string       `json:"next_cursor,omitempty"`
+	// Items Messages in this page, newest first.
+	Items []SmsResponse `json:"items"`
+
+	// NextCursor Opaque cursor for the next page. Null when there are no more results.
+	NextCursor *string `json:"next_cursor,omitempty"`
 }
 
 // SmsResponse defines model for SmsResponse.
 type SmsResponse struct {
-	Body               string               `json:"body"`
-	Direction          SmsResponseDirection `json:"direction"`
-	ErrorCode          *string              `json:"error_code"`
-	FromE164           string               `json:"from_e164"`
-	Id                 openapi_types.UUID   `json:"id"`
-	OrganizationId     openapi_types.UUID   `json:"organization_id"`
-	ProviderMessageSid *string              `json:"provider_message_sid"`
-	RequestedAt        time.Time            `json:"requested_at"`
-	SegmentCount       int                  `json:"segment_count"`
-	SentAt             *time.Time           `json:"sent_at"`
-	Status             SmsResponseStatus    `json:"status"`
-	ToE164             string               `json:"to_e164"`
+	// Body Message text.
+	Body string `json:"body"`
+
+	// Direction 'outbound' for messages Hail sent, 'inbound' for messages received.
+	Direction SmsResponseDirection `json:"direction"`
+
+	// ErrorCode Carrier error code if delivery failed. Null on success or while pending.
+	ErrorCode *string `json:"error_code"`
+
+	// FromE164 Sender phone number, E.164 format.
+	FromE164 string `json:"from_e164"`
+
+	// Id Unique identifier for this message.
+	Id openapi_types.UUID `json:"id"`
+
+	// OrganizationId Organization that sent or received this message.
+	OrganizationId openapi_types.UUID `json:"organization_id"`
+
+	// ProviderMessageSid The carrier/provider's identifier for this message, if assigned.
+	ProviderMessageSid *string `json:"provider_message_sid"`
+
+	// RequestedAt When the send was requested, ISO 8601 timestamp.
+	RequestedAt time.Time `json:"requested_at"`
+
+	// SegmentCount Number of carrier SMS segments the body was split into.
+	SegmentCount int `json:"segment_count"`
+
+	// SentAt When the message was handed to the carrier, ISO 8601 timestamp. Null until sent.
+	SentAt *time.Time `json:"sent_at"`
+
+	// Status Delivery status: 'queued', 'sent', 'delivered', 'failed', 'undelivered', or 'received' (inbound messages).
+	Status SmsResponseStatus `json:"status"`
+
+	// ToE164 Recipient phone number, E.164 format.
+	ToE164 string `json:"to_e164"`
 }
 
-// SmsResponseDirection defines model for SmsResponse.Direction.
+// SmsResponseDirection 'outbound' for messages Hail sent, 'inbound' for messages received.
 type SmsResponseDirection string
 
-// SmsResponseStatus defines model for SmsResponse.Status.
+// SmsResponseStatus Delivery status: 'queued', 'sent', 'delivered', 'failed', 'undelivered', or 'received' (inbound messages).
 type SmsResponseStatus string
 
 // SuppressionListResponse defines model for SuppressionListResponse.
 type SuppressionListResponse struct {
-	Items      []SuppressionResponse `json:"items"`
-	NextCursor *string               `json:"next_cursor,omitempty"`
+	// Items Suppressed recipients in this page.
+	Items []SuppressionResponse `json:"items"`
+
+	// NextCursor Opaque cursor for the next page. Null when there are no more results.
+	NextCursor *string `json:"next_cursor,omitempty"`
 }
 
 // SuppressionResponse defines model for SuppressionResponse.
 type SuppressionResponse struct {
-	Channel   string             `json:"channel"`
-	CreatedAt time.Time          `json:"created_at"`
-	Id        openapi_types.UUID `json:"id"`
-	Reason    string             `json:"reason"`
-	Recipient string             `json:"recipient"`
-	Source    string             `json:"source"`
+	// Channel Channel this entry blocks sends on: 'voice', 'email', 'sms', or 'all' (every channel).
+	Channel string `json:"channel"`
+
+	// CreatedAt When this entry was created, ISO 8601 timestamp.
+	CreatedAt time.Time `json:"created_at"`
+
+	// Id Unique identifier for this suppression entry.
+	Id openapi_types.UUID `json:"id"`
+
+	// Reason Why the recipient was suppressed (e.g. an unsubscribe or a bounce).
+	Reason string `json:"reason"`
+
+	// Recipient The suppressed recipient — E.164 phone number for voice/sms, lowercased email address for email.
+	Recipient string `json:"recipient"`
+
+	// Source How this entry was created: 'unsubscribe_link', 'manual' (an operator action), or 'bounce'.
+	Source string `json:"source"`
 }
 
 // ValidationError defines model for ValidationError.
 type ValidationError struct {
-	Ctx   *map[string]interface{}    `json:"ctx,omitempty"`
-	Input interface{}                `json:"input,omitempty"`
-	Loc   []ValidationError_Loc_Item `json:"loc"`
-	Msg   string                     `json:"msg"`
-	Type  string                     `json:"type"`
+	// Ctx Additional machine-readable context for the error, when the error type provides one.
+	Ctx *map[string]interface{} `json:"ctx,omitempty"`
+
+	// Input The value that was actually provided and failed validation.
+	Input interface{} `json:"input,omitempty"`
+
+	// Loc Path to the invalid field within the request, as a list of keys/indices (e.g. ['body', 'to']).
+	Loc []ValidationError_Loc_Item `json:"loc"`
+
+	// Msg Human-readable description of the validation failure.
+	Msg string `json:"msg"`
+
+	// Type Machine-readable error type code (e.g. 'missing', 'string_type').
+	Type string `json:"type"`
 }
 
 // ValidationErrorLoc0 defines model for .
@@ -1672,11 +2171,19 @@ type ValidationError_Loc_Item struct {
 // VoiceConfig defines model for VoiceConfig.
 type VoiceConfig struct {
 	// Language Spoken language for the call as a lowercase ISO 639-1 code (e.g. 'da'). One of the 39 supported codes — see docs/languages.md. Applied to STT, TTS, and turn detection. Omitted: the providers' defaults (English).
-	Language      *VoiceConfigLanguage `json:"language,omitempty"`
-	Tts           *string              `json:"tts,omitempty"`
-	TurnDetection *string              `json:"turn_detection,omitempty"`
-	Vad           *string              `json:"vad,omitempty"`
-	VoiceId       *string              `json:"voice_id,omitempty"`
+	Language *VoiceConfigLanguage `json:"language,omitempty"`
+
+	// Tts Text-to-speech provider. Currently only 'cartesia'.
+	Tts *string `json:"tts,omitempty"`
+
+	// TurnDetection Turn-detection engine. Currently only 'livekit'.
+	TurnDetection *string `json:"turn_detection,omitempty"`
+
+	// Vad Voice-activity-detection engine. Currently only 'silero'.
+	Vad *string `json:"vad,omitempty"`
+
+	// VoiceId Per-call TTS voice override, applied to whichever TTS provider serves the call. Omitted: the organization's or environment's default voice.
+	VoiceId *string `json:"voice_id,omitempty"`
 }
 
 // VoiceConfigLanguage Spoken language for the call as a lowercase ISO 639-1 code (e.g. 'da'). One of the 39 supported codes — see docs/languages.md. Applied to STT, TTS, and turn detection. Omitted: the providers' defaults (English).
@@ -1684,33 +2191,62 @@ type VoiceConfigLanguage string
 
 // WebhookDeliveryListResponse defines model for WebhookDeliveryListResponse.
 type WebhookDeliveryListResponse struct {
-	Items      []WebhookDeliveryResponse `json:"items"`
-	NextCursor *string                   `json:"next_cursor,omitempty"`
+	// Items Delivery attempts in this page.
+	Items []WebhookDeliveryResponse `json:"items"`
+
+	// NextCursor Opaque cursor for the next page. Null when there are no more results.
+	NextCursor *string `json:"next_cursor,omitempty"`
 }
 
 // WebhookDeliveryResponse defines model for WebhookDeliveryResponse.
 type WebhookDeliveryResponse struct {
-	Attempt        int                           `json:"attempt"`
-	CreatedAt      time.Time                     `json:"created_at"`
-	EmailDomainId  *openapi_types.UUID           `json:"email_domain_id"`
-	EventId        openapi_types.UUID            `json:"event_id"`
-	EventType      string                        `json:"event_type"`
-	Id             openapi_types.UUID            `json:"id"`
-	NextAttemptAt  time.Time                     `json:"next_attempt_at"`
-	ResponseBody   *string                       `json:"response_body,omitempty"`
-	ResponseStatus *int                          `json:"response_status,omitempty"`
-	Status         WebhookDeliveryResponseStatus `json:"status"`
-	SubscriptionId *openapi_types.UUID           `json:"subscription_id"`
-	SucceededAt    *time.Time                    `json:"succeeded_at,omitempty"`
+	// Attempt Number of delivery attempts made so far for this event, starting at 0.
+	Attempt int `json:"attempt"`
+
+	// CreatedAt When this delivery was queued, ISO 8601 timestamp.
+	CreatedAt time.Time `json:"created_at"`
+
+	// EmailDomainId Email domain the triggering event relates to, if any. Informational only (surfaced as the X-Hail-Email-Domain header) — not a routing target.
+	EmailDomainId *openapi_types.UUID `json:"email_domain_id"`
+
+	// EventId Identifier of the underlying event that triggered this delivery.
+	EventId openapi_types.UUID `json:"event_id"`
+
+	// EventType The event type being delivered (e.g. 'call.completed').
+	EventType string `json:"event_type"`
+
+	// Id Unique identifier for this delivery attempt.
+	Id openapi_types.UUID `json:"id"`
+
+	// NextAttemptAt When the next delivery attempt is scheduled, ISO 8601 timestamp.
+	NextAttemptAt time.Time `json:"next_attempt_at"`
+
+	// ResponseBody Response body returned by the target URL on the last attempt, if any. Null before any attempt.
+	ResponseBody *string `json:"response_body,omitempty"`
+
+	// ResponseStatus HTTP status code returned by the target URL on the last attempt. Null before any attempt.
+	ResponseStatus *int `json:"response_status,omitempty"`
+
+	// Status 'pending' (queued/retrying), 'succeeded', 'failed' (will retry), or 'dead' (retries exhausted).
+	Status WebhookDeliveryResponseStatus `json:"status"`
+
+	// SubscriptionId Subscription this delivery belongs to.
+	SubscriptionId *openapi_types.UUID `json:"subscription_id"`
+
+	// SucceededAt When this delivery succeeded, ISO 8601 timestamp. Null until it does.
+	SucceededAt *time.Time `json:"succeeded_at,omitempty"`
 }
 
-// WebhookDeliveryResponseStatus defines model for WebhookDeliveryResponse.Status.
+// WebhookDeliveryResponseStatus 'pending' (queued/retrying), 'succeeded', 'failed' (will retry), or 'dead' (retries exhausted).
 type WebhookDeliveryResponseStatus string
 
 // WebhookSubscriptionCreate defines model for WebhookSubscriptionCreate.
 type WebhookSubscriptionCreate struct {
+	// EventTypes Event types to subscribe to (e.g. 'call.completed', 'email.bounced'). At least one required.
 	EventTypes []WebhookSubscriptionCreateEventTypes `json:"event_types"`
-	TargetUrl  string                                `json:"target_url"`
+
+	// TargetUrl HTTPS URL Hail POSTs event payloads to.
+	TargetUrl string `json:"target_url"`
 }
 
 // WebhookSubscriptionCreateEventTypes defines model for WebhookSubscriptionCreate.EventTypes.
@@ -1718,21 +2254,29 @@ type WebhookSubscriptionCreateEventTypes string
 
 // WebhookSubscriptionListResponse defines model for WebhookSubscriptionListResponse.
 type WebhookSubscriptionListResponse struct {
-	Items      []WebhookSubscriptionResponse `json:"items"`
-	NextCursor *string                       `json:"next_cursor,omitempty"`
+	// Items Subscriptions in this page.
+	Items []WebhookSubscriptionResponse `json:"items"`
+
+	// NextCursor Opaque cursor for the next page. Null when there are no more results.
+	NextCursor *string `json:"next_cursor,omitempty"`
 }
 
 // WebhookSubscriptionPatch defines model for WebhookSubscriptionPatch.
 type WebhookSubscriptionPatch struct {
+	// EventTypes New set of subscribed event types. Omit to leave unchanged.
 	EventTypes *[]WebhookSubscriptionPatchEventTypes `json:"event_types,omitempty"`
-	Status     *WebhookSubscriptionPatchStatus       `json:"status,omitempty"`
-	TargetUrl  *string                               `json:"target_url,omitempty"`
+
+	// Status Set to 'disabled' to pause deliveries, or 'active' to resume. Omit to leave unchanged.
+	Status *WebhookSubscriptionPatchStatus `json:"status,omitempty"`
+
+	// TargetUrl New delivery URL. Omit to leave unchanged.
+	TargetUrl *string `json:"target_url,omitempty"`
 }
 
 // WebhookSubscriptionPatchEventTypes defines model for WebhookSubscriptionPatch.EventTypes.
 type WebhookSubscriptionPatchEventTypes string
 
-// WebhookSubscriptionPatchStatus defines model for WebhookSubscriptionPatch.Status.
+// WebhookSubscriptionPatchStatus Set to 'disabled' to pause deliveries, or 'active' to resume. Omit to leave unchanged.
 type WebhookSubscriptionPatchStatus string
 
 // WebhookSubscriptionResponse Subscription as returned by the API.
@@ -1740,20 +2284,41 @@ type WebhookSubscriptionPatchStatus string
 // “secret“ is populated **only** by create + rotate-secret responses;
 // later GETs return “None“ so the plaintext never round-trips.
 type WebhookSubscriptionResponse struct {
-	ConsecutiveFailures int                               `json:"consecutive_failures"`
-	CreatedAt           time.Time                         `json:"created_at"`
-	EventTypes          []string                          `json:"event_types"`
-	Id                  openapi_types.UUID                `json:"id"`
-	LastFailureAt       *time.Time                        `json:"last_failure_at,omitempty"`
-	LastSuccessAt       *time.Time                        `json:"last_success_at,omitempty"`
-	OrganizationId      openapi_types.UUID                `json:"organization_id"`
-	Secret              *string                           `json:"secret,omitempty"`
-	Status              WebhookSubscriptionResponseStatus `json:"status"`
-	TargetUrl           string                            `json:"target_url"`
-	UpdatedAt           time.Time                         `json:"updated_at"`
+	// ConsecutiveFailures Consecutive failed delivery attempts since the last success. Resets to 0 on success.
+	ConsecutiveFailures int `json:"consecutive_failures"`
+
+	// CreatedAt When this subscription was created, ISO 8601 timestamp.
+	CreatedAt time.Time `json:"created_at"`
+
+	// EventTypes Event types this subscription receives.
+	EventTypes []string `json:"event_types"`
+
+	// Id Unique identifier for this subscription.
+	Id openapi_types.UUID `json:"id"`
+
+	// LastFailureAt When a delivery last failed, ISO 8601 timestamp. Null if never.
+	LastFailureAt *time.Time `json:"last_failure_at,omitempty"`
+
+	// LastSuccessAt When a delivery last succeeded, ISO 8601 timestamp. Null if never.
+	LastSuccessAt *time.Time `json:"last_success_at,omitempty"`
+
+	// OrganizationId Organization that owns this subscription.
+	OrganizationId openapi_types.UUID `json:"organization_id"`
+
+	// Secret Plaintext signing secret for verifying delivery payloads. Only present in the create and rotate-secret responses; every later read returns null.
+	Secret *string `json:"secret,omitempty"`
+
+	// Status 'active' (delivering) or 'disabled' (paused).
+	Status WebhookSubscriptionResponseStatus `json:"status"`
+
+	// TargetUrl HTTPS URL event payloads are POSTed to.
+	TargetUrl string `json:"target_url"`
+
+	// UpdatedAt When this subscription was last modified, ISO 8601 timestamp.
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
-// WebhookSubscriptionResponseStatus defines model for WebhookSubscriptionResponse.Status.
+// WebhookSubscriptionResponseStatus 'active' (delivering) or 'disabled' (paused).
 type WebhookSubscriptionResponseStatus string
 
 // WhoamiResponse Who the caller is — the answer “GET /whoami“ gives.
@@ -1763,59 +2328,68 @@ type WebhookSubscriptionResponseStatus string
 // agent that wants to put the operator's address in “Reply-To“ reads
 // “email“ and skips the header when it is “None“.
 type WhoamiResponse struct {
-	AuthKind       WhoamiResponseAuthKind `json:"auth_kind"`
-	Email          *string                `json:"email,omitempty"`
-	Name           *string                `json:"name,omitempty"`
-	OrganizationId openapi_types.UUID     `json:"organization_id"`
-	UserId         *openapi_types.UUID    `json:"user_id,omitempty"`
+	// AuthKind How the caller authenticated: 'apikey' (org API key), 'jwt' (logged-in user session), or 'shared' (the shared HAIL_API_KEY, which carries no human identity).
+	AuthKind WhoamiResponseAuthKind `json:"auth_kind"`
+
+	// Email The authenticated user's email. Null for 'shared' callers.
+	Email *string `json:"email,omitempty"`
+
+	// Name The authenticated user's display name. Null for 'shared' callers.
+	Name *string `json:"name,omitempty"`
+
+	// OrganizationId Organization the caller belongs to.
+	OrganizationId openapi_types.UUID `json:"organization_id"`
+
+	// UserId The authenticated user's id. Null for 'shared' callers.
+	UserId *openapi_types.UUID `json:"user_id,omitempty"`
 }
 
-// WhoamiResponseAuthKind defines model for WhoamiResponse.AuthKind.
+// WhoamiResponseAuthKind How the caller authenticated: 'apikey' (org API key), 'jwt' (logged-in user session), or 'shared' (the shared HAIL_API_KEY, which carries no human identity).
 type WhoamiResponseAuthKind string
 
-// ListCallsCallsGetParams defines parameters for ListCallsCallsGet.
-type ListCallsCallsGetParams struct {
-	Cursor        *string                        `form:"cursor,omitempty" json:"cursor,omitempty"`
-	Limit         *int                           `form:"limit,omitempty" json:"limit,omitempty"`
-	Status        *ListCallsCallsGetParamsStatus `form:"status,omitempty" json:"status,omitempty"`
-	To            *string                        `form:"to,omitempty" json:"to,omitempty"`
-	Authorization *string                        `json:"authorization,omitempty"`
+// ListCallsV1CallsGetParams defines parameters for ListCallsV1CallsGet.
+type ListCallsV1CallsGetParams struct {
+	Cursor        *string                          `form:"cursor,omitempty" json:"cursor,omitempty"`
+	Limit         *int                             `form:"limit,omitempty" json:"limit,omitempty"`
+	Status        *ListCallsV1CallsGetParamsStatus `form:"status,omitempty" json:"status,omitempty"`
+	To            *string                          `form:"to,omitempty" json:"to,omitempty"`
+	Authorization *string                          `json:"authorization,omitempty"`
 }
 
-// ListCallsCallsGetParamsStatus defines parameters for ListCallsCallsGet.
-type ListCallsCallsGetParamsStatus string
+// ListCallsV1CallsGetParamsStatus defines parameters for ListCallsV1CallsGet.
+type ListCallsV1CallsGetParamsStatus string
 
-// CreateCallCallsPostParams defines parameters for CreateCallCallsPost.
-type CreateCallCallsPostParams struct {
+// CreateCallV1CallsPostParams defines parameters for CreateCallV1CallsPost.
+type CreateCallV1CallsPostParams struct {
 	Authorization  *string `json:"authorization,omitempty"`
 	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
 }
 
-// GetCallCallsCallIdGetParams defines parameters for GetCallCallsCallIdGet.
-type GetCallCallsCallIdGetParams struct {
+// GetCallV1CallsCallIdGetParams defines parameters for GetCallV1CallsCallIdGet.
+type GetCallV1CallsCallIdGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// ListContactsContactsGetParams defines parameters for ListContactsContactsGet.
-type ListContactsContactsGetParams struct {
+// ListContactsV1ContactsGetParams defines parameters for ListContactsV1ContactsGet.
+type ListContactsV1ContactsGetParams struct {
 	Q             *string `form:"q,omitempty" json:"q,omitempty"`
 	Cursor        *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 	Limit         *int    `form:"limit,omitempty" json:"limit,omitempty"`
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// CreateContactContactsPostParams defines parameters for CreateContactContactsPost.
-type CreateContactContactsPostParams struct {
+// CreateContactV1ContactsPostParams defines parameters for CreateContactV1ContactsPost.
+type CreateContactV1ContactsPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// DeleteContactContactsContactIdDeleteParams defines parameters for DeleteContactContactsContactIdDelete.
-type DeleteContactContactsContactIdDeleteParams struct {
+// DeleteContactV1ContactsContactIdDeleteParams defines parameters for DeleteContactV1ContactsContactIdDelete.
+type DeleteContactV1ContactsContactIdDeleteParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// PatchContactContactsContactIdPatchParams defines parameters for PatchContactContactsContactIdPatch.
-type PatchContactContactsContactIdPatchParams struct {
+// PatchContactV1ContactsContactIdPatchParams defines parameters for PatchContactV1ContactsContactIdPatch.
+type PatchContactV1ContactsContactIdPatchParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
@@ -1824,100 +2398,100 @@ type UploadEmailAttachmentParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// ListEmailDomainsEmailDomainsGetParams defines parameters for ListEmailDomainsEmailDomainsGet.
-type ListEmailDomainsEmailDomainsGetParams struct {
+// ListEmailDomainsV1EmailDomainsGetParams defines parameters for ListEmailDomainsV1EmailDomainsGet.
+type ListEmailDomainsV1EmailDomainsGetParams struct {
 	Cursor        *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 	Limit         *int    `form:"limit,omitempty" json:"limit,omitempty"`
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// CreateEmailDomainEmailDomainsPostParams defines parameters for CreateEmailDomainEmailDomainsPost.
-type CreateEmailDomainEmailDomainsPostParams struct {
+// CreateEmailDomainV1EmailDomainsPostParams defines parameters for CreateEmailDomainV1EmailDomainsPost.
+type CreateEmailDomainV1EmailDomainsPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// CheckDomainEmailDomainsCheckDomainGetParams defines parameters for CheckDomainEmailDomainsCheckDomainGet.
-type CheckDomainEmailDomainsCheckDomainGetParams struct {
+// CheckDomainV1EmailDomainsCheckDomainGetParams defines parameters for CheckDomainV1EmailDomainsCheckDomainGet.
+type CheckDomainV1EmailDomainsCheckDomainGetParams struct {
 	Domain        string  `form:"domain" json:"domain"`
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// DeleteEmailDomainEmailDomainsDomainIdDeleteParams defines parameters for DeleteEmailDomainEmailDomainsDomainIdDelete.
-type DeleteEmailDomainEmailDomainsDomainIdDeleteParams struct {
+// DeleteEmailDomainV1EmailDomainsDomainIdDeleteParams defines parameters for DeleteEmailDomainV1EmailDomainsDomainIdDelete.
+type DeleteEmailDomainV1EmailDomainsDomainIdDeleteParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// GetEmailDomainEmailDomainsDomainIdGetParams defines parameters for GetEmailDomainEmailDomainsDomainIdGet.
-type GetEmailDomainEmailDomainsDomainIdGetParams struct {
+// GetEmailDomainV1EmailDomainsDomainIdGetParams defines parameters for GetEmailDomainV1EmailDomainsDomainIdGet.
+type GetEmailDomainV1EmailDomainsDomainIdGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// PatchEmailDomainEmailDomainsDomainIdPatchParams defines parameters for PatchEmailDomainEmailDomainsDomainIdPatch.
-type PatchEmailDomainEmailDomainsDomainIdPatchParams struct {
+// PatchEmailDomainV1EmailDomainsDomainIdPatchParams defines parameters for PatchEmailDomainV1EmailDomainsDomainIdPatch.
+type PatchEmailDomainV1EmailDomainsDomainIdPatchParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// VerifyEmailDomainEmailDomainsDomainIdVerifyPostParams defines parameters for VerifyEmailDomainEmailDomainsDomainIdVerifyPost.
-type VerifyEmailDomainEmailDomainsDomainIdVerifyPostParams struct {
+// VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostParams defines parameters for VerifyEmailDomainV1EmailDomainsDomainIdVerifyPost.
+type VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// ListEmailsEmailsGetParams defines parameters for ListEmailsEmailsGet.
-type ListEmailsEmailsGetParams struct {
-	Cursor        *string                             `form:"cursor,omitempty" json:"cursor,omitempty"`
-	Limit         *int                                `form:"limit,omitempty" json:"limit,omitempty"`
-	Status        *ListEmailsEmailsGetParamsStatus    `form:"status,omitempty" json:"status,omitempty"`
-	Direction     *ListEmailsEmailsGetParamsDirection `form:"direction,omitempty" json:"direction,omitempty"`
-	Authorization *string                             `json:"authorization,omitempty"`
+// ListEmailsV1EmailsGetParams defines parameters for ListEmailsV1EmailsGet.
+type ListEmailsV1EmailsGetParams struct {
+	Cursor        *string                               `form:"cursor,omitempty" json:"cursor,omitempty"`
+	Limit         *int                                  `form:"limit,omitempty" json:"limit,omitempty"`
+	Status        *ListEmailsV1EmailsGetParamsStatus    `form:"status,omitempty" json:"status,omitempty"`
+	Direction     *ListEmailsV1EmailsGetParamsDirection `form:"direction,omitempty" json:"direction,omitempty"`
+	Authorization *string                               `json:"authorization,omitempty"`
 }
 
-// ListEmailsEmailsGetParamsStatus defines parameters for ListEmailsEmailsGet.
-type ListEmailsEmailsGetParamsStatus string
+// ListEmailsV1EmailsGetParamsStatus defines parameters for ListEmailsV1EmailsGet.
+type ListEmailsV1EmailsGetParamsStatus string
 
-// ListEmailsEmailsGetParamsDirection defines parameters for ListEmailsEmailsGet.
-type ListEmailsEmailsGetParamsDirection string
+// ListEmailsV1EmailsGetParamsDirection defines parameters for ListEmailsV1EmailsGet.
+type ListEmailsV1EmailsGetParamsDirection string
 
-// CreateEmailEmailsPostParams defines parameters for CreateEmailEmailsPost.
-type CreateEmailEmailsPostParams struct {
+// CreateEmailV1EmailsPostParams defines parameters for CreateEmailV1EmailsPost.
+type CreateEmailV1EmailsPostParams struct {
 	Authorization  *string `json:"authorization,omitempty"`
 	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
 }
 
-// GetEmailStatsEmailsStatsGetParams defines parameters for GetEmailStatsEmailsStatsGet.
-type GetEmailStatsEmailsStatsGetParams struct {
-	From          *time.Time                               `form:"from,omitempty" json:"from,omitempty"`
-	To            *time.Time                               `form:"to,omitempty" json:"to,omitempty"`
-	Bucket        *GetEmailStatsEmailsStatsGetParamsBucket `form:"bucket,omitempty" json:"bucket,omitempty"`
-	Authorization *string                                  `json:"authorization,omitempty"`
+// GetEmailStatsV1EmailsStatsGetParams defines parameters for GetEmailStatsV1EmailsStatsGet.
+type GetEmailStatsV1EmailsStatsGetParams struct {
+	From          *time.Time                                 `form:"from,omitempty" json:"from,omitempty"`
+	To            *time.Time                                 `form:"to,omitempty" json:"to,omitempty"`
+	Bucket        *GetEmailStatsV1EmailsStatsGetParamsBucket `form:"bucket,omitempty" json:"bucket,omitempty"`
+	Authorization *string                                    `json:"authorization,omitempty"`
 }
 
-// GetEmailStatsEmailsStatsGetParamsBucket defines parameters for GetEmailStatsEmailsStatsGet.
-type GetEmailStatsEmailsStatsGetParamsBucket string
+// GetEmailStatsV1EmailsStatsGetParamsBucket defines parameters for GetEmailStatsV1EmailsStatsGet.
+type GetEmailStatsV1EmailsStatsGetParamsBucket string
 
-// GetEmailEmailsEmailIdGetParams defines parameters for GetEmailEmailsEmailIdGet.
-type GetEmailEmailsEmailIdGetParams struct {
+// GetEmailV1EmailsEmailIdGetParams defines parameters for GetEmailV1EmailsEmailIdGet.
+type GetEmailV1EmailsEmailIdGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetParams defines parameters for GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGet.
-type GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetParams struct {
+// GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetParams defines parameters for GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGet.
+type GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// ListEmailEventsEmailsEmailIdEventsGetParams defines parameters for ListEmailEventsEmailsEmailIdEventsGet.
-type ListEmailEventsEmailsEmailIdEventsGetParams struct {
+// ListEmailEventsV1EmailsEmailIdEventsGetParams defines parameters for ListEmailEventsV1EmailsEmailIdEventsGet.
+type ListEmailEventsV1EmailsEmailIdEventsGetParams struct {
 	Cursor        *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 	Limit         *int    `form:"limit,omitempty" json:"limit,omitempty"`
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// GetEmailRawEmailsEmailIdRawGetParams defines parameters for GetEmailRawEmailsEmailIdRawGet.
-type GetEmailRawEmailsEmailIdRawGetParams struct {
+// GetEmailRawV1EmailsEmailIdRawGetParams defines parameters for GetEmailRawV1EmailsEmailIdRawGet.
+type GetEmailRawV1EmailsEmailIdRawGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// ListEventsEventsGetParams defines parameters for ListEventsEventsGet.
-type ListEventsEventsGetParams struct {
+// ListEventsV1EventsGetParams defines parameters for ListEventsV1EventsGet.
+type ListEventsV1EventsGetParams struct {
 	Cursor        *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 	Limit         *int    `form:"limit,omitempty" json:"limit,omitempty"`
 	Id            *string `form:"id,omitempty" json:"id,omitempty"`
@@ -1925,41 +2499,41 @@ type ListEventsEventsGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// DeleteMemberPhoneMembersUserIdPhoneDeleteParams defines parameters for DeleteMemberPhoneMembersUserIdPhoneDelete.
-type DeleteMemberPhoneMembersUserIdPhoneDeleteParams struct {
+// DeleteMemberPhoneV1MembersUserIdPhoneDeleteParams defines parameters for DeleteMemberPhoneV1MembersUserIdPhoneDelete.
+type DeleteMemberPhoneV1MembersUserIdPhoneDeleteParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// PutMemberPhoneMembersUserIdPhonePutParams defines parameters for PutMemberPhoneMembersUserIdPhonePut.
-type PutMemberPhoneMembersUserIdPhonePutParams struct {
+// PutMemberPhoneV1MembersUserIdPhonePutParams defines parameters for PutMemberPhoneV1MembersUserIdPhonePut.
+type PutMemberPhoneV1MembersUserIdPhonePutParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// ListNumbersNumbersGetParams defines parameters for ListNumbersNumbersGet.
-type ListNumbersNumbersGetParams struct {
+// ListNumbersV1NumbersGetParams defines parameters for ListNumbersV1NumbersGet.
+type ListNumbersV1NumbersGetParams struct {
 	Cursor        *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 	Limit         *int    `form:"limit,omitempty" json:"limit,omitempty"`
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// AcquireNumberNumbersPostParams defines parameters for AcquireNumberNumbersPost.
-type AcquireNumberNumbersPostParams struct {
+// AcquireNumberV1NumbersPostParams defines parameters for AcquireNumberV1NumbersPost.
+type AcquireNumberV1NumbersPostParams struct {
 	Authorization  *string `json:"authorization,omitempty"`
 	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
 }
 
-// ReleaseNumberNumbersNumberIdDeleteParams defines parameters for ReleaseNumberNumbersNumberIdDelete.
-type ReleaseNumberNumbersNumberIdDeleteParams struct {
+// ReleaseNumberV1NumbersNumberIdDeleteParams defines parameters for ReleaseNumberV1NumbersNumberIdDelete.
+type ReleaseNumberV1NumbersNumberIdDeleteParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// GetNumberNumbersNumberIdGetParams defines parameters for GetNumberNumbersNumberIdGet.
-type GetNumberNumbersNumberIdGetParams struct {
+// GetNumberV1NumbersNumberIdGetParams defines parameters for GetNumberV1NumbersNumberIdGet.
+type GetNumberV1NumbersNumberIdGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// EnableSmsNumbersNumberIdEnableSmsPostParams defines parameters for EnableSmsNumbersNumberIdEnableSmsPost.
-type EnableSmsNumbersNumberIdEnableSmsPostParams struct {
+// EnableSmsV1NumbersNumberIdEnableSmsPostParams defines parameters for EnableSmsV1NumbersNumberIdEnableSmsPost.
+type EnableSmsV1NumbersNumberIdEnableSmsPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
@@ -1988,131 +2562,131 @@ type DeleteProviderParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// ListSmsSmsGetParams defines parameters for ListSmsSmsGet.
-type ListSmsSmsGetParams struct {
-	Cursor        *string                    `form:"cursor,omitempty" json:"cursor,omitempty"`
-	Limit         *int                       `form:"limit,omitempty" json:"limit,omitempty"`
-	Status        *ListSmsSmsGetParamsStatus `form:"status,omitempty" json:"status,omitempty"`
-	To            *string                    `form:"to,omitempty" json:"to,omitempty"`
-	Authorization *string                    `json:"authorization,omitempty"`
+// ListSmsV1SmsGetParams defines parameters for ListSmsV1SmsGet.
+type ListSmsV1SmsGetParams struct {
+	Cursor        *string                      `form:"cursor,omitempty" json:"cursor,omitempty"`
+	Limit         *int                         `form:"limit,omitempty" json:"limit,omitempty"`
+	Status        *ListSmsV1SmsGetParamsStatus `form:"status,omitempty" json:"status,omitempty"`
+	To            *string                      `form:"to,omitempty" json:"to,omitempty"`
+	Authorization *string                      `json:"authorization,omitempty"`
 }
 
-// ListSmsSmsGetParamsStatus defines parameters for ListSmsSmsGet.
-type ListSmsSmsGetParamsStatus string
+// ListSmsV1SmsGetParamsStatus defines parameters for ListSmsV1SmsGet.
+type ListSmsV1SmsGetParamsStatus string
 
-// CreateSmsSmsPostParams defines parameters for CreateSmsSmsPost.
-type CreateSmsSmsPostParams struct {
+// CreateSmsV1SmsPostParams defines parameters for CreateSmsV1SmsPost.
+type CreateSmsV1SmsPostParams struct {
 	Authorization  *string `json:"authorization,omitempty"`
 	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
 }
 
-// GetSenderIdSmsSenderIdGetParams defines parameters for GetSenderIdSmsSenderIdGet.
-type GetSenderIdSmsSenderIdGetParams struct {
+// GetSenderIdV1SmsSenderIdGetParams defines parameters for GetSenderIdV1SmsSenderIdGet.
+type GetSenderIdV1SmsSenderIdGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// PatchSenderIdSmsSenderIdPatchParams defines parameters for PatchSenderIdSmsSenderIdPatch.
-type PatchSenderIdSmsSenderIdPatchParams struct {
+// PatchSenderIdV1SmsSenderIdPatchParams defines parameters for PatchSenderIdV1SmsSenderIdPatch.
+type PatchSenderIdV1SmsSenderIdPatchParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// ListSmsSuppressionsSmsSuppressionsGetParams defines parameters for ListSmsSuppressionsSmsSuppressionsGet.
-type ListSmsSuppressionsSmsSuppressionsGetParams struct {
+// ListSmsSuppressionsV1SmsSuppressionsGetParams defines parameters for ListSmsSuppressionsV1SmsSuppressionsGet.
+type ListSmsSuppressionsV1SmsSuppressionsGetParams struct {
 	Cursor        *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 	Limit         *int    `form:"limit,omitempty" json:"limit,omitempty"`
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// DeleteSmsSuppressionSmsSuppressionsNumberDeleteParams defines parameters for DeleteSmsSuppressionSmsSuppressionsNumberDelete.
-type DeleteSmsSuppressionSmsSuppressionsNumberDeleteParams struct {
+// DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteParams defines parameters for DeleteSmsSuppressionV1SmsSuppressionsNumberDelete.
+type DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// GetSmsSmsSmsIdGetParams defines parameters for GetSmsSmsSmsIdGet.
-type GetSmsSmsSmsIdGetParams struct {
+// GetSmsV1SmsSmsIdGetParams defines parameters for GetSmsV1SmsSmsIdGet.
+type GetSmsV1SmsSmsIdGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// UnsubscribeUnsubscribeGetParams defines parameters for UnsubscribeUnsubscribeGet.
-type UnsubscribeUnsubscribeGetParams struct {
+// UnsubscribeV1UnsubscribeGetParams defines parameters for UnsubscribeV1UnsubscribeGet.
+type UnsubscribeV1UnsubscribeGetParams struct {
 	Token string `form:"token" json:"token"`
 }
 
-// ListSubscriptionsWebhooksGetParams defines parameters for ListSubscriptionsWebhooksGet.
-type ListSubscriptionsWebhooksGetParams struct {
+// ListSubscriptionsV1WebhooksGetParams defines parameters for ListSubscriptionsV1WebhooksGet.
+type ListSubscriptionsV1WebhooksGetParams struct {
 	Cursor        *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 	Limit         *int    `form:"limit,omitempty" json:"limit,omitempty"`
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// CreateSubscriptionWebhooksPostParams defines parameters for CreateSubscriptionWebhooksPost.
-type CreateSubscriptionWebhooksPostParams struct {
+// CreateSubscriptionV1WebhooksPostParams defines parameters for CreateSubscriptionV1WebhooksPost.
+type CreateSubscriptionV1WebhooksPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// DeleteSubscriptionWebhooksSubIdDeleteParams defines parameters for DeleteSubscriptionWebhooksSubIdDelete.
-type DeleteSubscriptionWebhooksSubIdDeleteParams struct {
+// DeleteSubscriptionV1WebhooksSubIdDeleteParams defines parameters for DeleteSubscriptionV1WebhooksSubIdDelete.
+type DeleteSubscriptionV1WebhooksSubIdDeleteParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// GetSubscriptionWebhooksSubIdGetParams defines parameters for GetSubscriptionWebhooksSubIdGet.
-type GetSubscriptionWebhooksSubIdGetParams struct {
+// GetSubscriptionV1WebhooksSubIdGetParams defines parameters for GetSubscriptionV1WebhooksSubIdGet.
+type GetSubscriptionV1WebhooksSubIdGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// PatchSubscriptionWebhooksSubIdPatchParams defines parameters for PatchSubscriptionWebhooksSubIdPatch.
-type PatchSubscriptionWebhooksSubIdPatchParams struct {
+// PatchSubscriptionV1WebhooksSubIdPatchParams defines parameters for PatchSubscriptionV1WebhooksSubIdPatch.
+type PatchSubscriptionV1WebhooksSubIdPatchParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// ListDeliveriesWebhooksSubIdDeliveriesGetParams defines parameters for ListDeliveriesWebhooksSubIdDeliveriesGet.
-type ListDeliveriesWebhooksSubIdDeliveriesGetParams struct {
+// ListDeliveriesV1WebhooksSubIdDeliveriesGetParams defines parameters for ListDeliveriesV1WebhooksSubIdDeliveriesGet.
+type ListDeliveriesV1WebhooksSubIdDeliveriesGetParams struct {
 	Cursor        *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 	Limit         *int    `form:"limit,omitempty" json:"limit,omitempty"`
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostParams defines parameters for RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPost.
-type RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostParams struct {
+// RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostParams defines parameters for RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPost.
+type RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// RotateSecretWebhooksSubIdRotateSecretPostParams defines parameters for RotateSecretWebhooksSubIdRotateSecretPost.
-type RotateSecretWebhooksSubIdRotateSecretPostParams struct {
+// RotateSecretV1WebhooksSubIdRotateSecretPostParams defines parameters for RotateSecretV1WebhooksSubIdRotateSecretPost.
+type RotateSecretV1WebhooksSubIdRotateSecretPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// GetWhoamiWhoamiGetParams defines parameters for GetWhoamiWhoamiGet.
-type GetWhoamiWhoamiGetParams struct {
+// GetWhoamiV1WhoamiGetParams defines parameters for GetWhoamiV1WhoamiGet.
+type GetWhoamiV1WhoamiGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
-// CreateCallCallsPostJSONRequestBody defines body for CreateCallCallsPost for application/json ContentType.
-type CreateCallCallsPostJSONRequestBody = CallCreate
+// CreateCallV1CallsPostJSONRequestBody defines body for CreateCallV1CallsPost for application/json ContentType.
+type CreateCallV1CallsPostJSONRequestBody = CallCreate
 
-// CreateContactContactsPostJSONRequestBody defines body for CreateContactContactsPost for application/json ContentType.
-type CreateContactContactsPostJSONRequestBody = ContactCreate
+// CreateContactV1ContactsPostJSONRequestBody defines body for CreateContactV1ContactsPost for application/json ContentType.
+type CreateContactV1ContactsPostJSONRequestBody = ContactCreate
 
-// PatchContactContactsContactIdPatchJSONRequestBody defines body for PatchContactContactsContactIdPatch for application/json ContentType.
-type PatchContactContactsContactIdPatchJSONRequestBody = ContactPatch
+// PatchContactV1ContactsContactIdPatchJSONRequestBody defines body for PatchContactV1ContactsContactIdPatch for application/json ContentType.
+type PatchContactV1ContactsContactIdPatchJSONRequestBody = ContactPatch
 
 // UploadEmailAttachmentMultipartRequestBody defines body for UploadEmailAttachment for multipart/form-data ContentType.
 type UploadEmailAttachmentMultipartRequestBody = BodyUploadEmailAttachment
 
-// CreateEmailDomainEmailDomainsPostJSONRequestBody defines body for CreateEmailDomainEmailDomainsPost for application/json ContentType.
-type CreateEmailDomainEmailDomainsPostJSONRequestBody = EmailDomainCreate
+// CreateEmailDomainV1EmailDomainsPostJSONRequestBody defines body for CreateEmailDomainV1EmailDomainsPost for application/json ContentType.
+type CreateEmailDomainV1EmailDomainsPostJSONRequestBody = EmailDomainCreate
 
-// PatchEmailDomainEmailDomainsDomainIdPatchJSONRequestBody defines body for PatchEmailDomainEmailDomainsDomainIdPatch for application/json ContentType.
-type PatchEmailDomainEmailDomainsDomainIdPatchJSONRequestBody = EmailDomainPatch
+// PatchEmailDomainV1EmailDomainsDomainIdPatchJSONRequestBody defines body for PatchEmailDomainV1EmailDomainsDomainIdPatch for application/json ContentType.
+type PatchEmailDomainV1EmailDomainsDomainIdPatchJSONRequestBody = EmailDomainPatch
 
-// CreateEmailEmailsPostJSONRequestBody defines body for CreateEmailEmailsPost for application/json ContentType.
-type CreateEmailEmailsPostJSONRequestBody = EmailCreate
+// CreateEmailV1EmailsPostJSONRequestBody defines body for CreateEmailV1EmailsPost for application/json ContentType.
+type CreateEmailV1EmailsPostJSONRequestBody = EmailCreate
 
-// PutMemberPhoneMembersUserIdPhonePutJSONRequestBody defines body for PutMemberPhoneMembersUserIdPhonePut for application/json ContentType.
-type PutMemberPhoneMembersUserIdPhonePutJSONRequestBody = MemberPhonePut
+// PutMemberPhoneV1MembersUserIdPhonePutJSONRequestBody defines body for PutMemberPhoneV1MembersUserIdPhonePut for application/json ContentType.
+type PutMemberPhoneV1MembersUserIdPhonePutJSONRequestBody = MemberPhonePut
 
-// AcquireNumberNumbersPostJSONRequestBody defines body for AcquireNumberNumbersPost for application/json ContentType.
-type AcquireNumberNumbersPostJSONRequestBody = NumberAcquireRequest
+// AcquireNumberV1NumbersPostJSONRequestBody defines body for AcquireNumberV1NumbersPost for application/json ContentType.
+type AcquireNumberV1NumbersPostJSONRequestBody = NumberAcquireRequest
 
 // UpsertProviderJSONRequestBody defines body for UpsertProvider for application/json ContentType.
 type UpsertProviderJSONRequestBody = ProviderConfigUpsert
@@ -2123,17 +2697,17 @@ type ActivateProviderJSONRequestBody = ProviderActivateRequest
 // ValidateProviderJSONRequestBody defines body for ValidateProvider for application/json ContentType.
 type ValidateProviderJSONRequestBody = ProviderValidateRequest
 
-// CreateSmsSmsPostJSONRequestBody defines body for CreateSmsSmsPost for application/json ContentType.
-type CreateSmsSmsPostJSONRequestBody = SmsCreate
+// CreateSmsV1SmsPostJSONRequestBody defines body for CreateSmsV1SmsPost for application/json ContentType.
+type CreateSmsV1SmsPostJSONRequestBody = SmsCreate
 
-// PatchSenderIdSmsSenderIdPatchJSONRequestBody defines body for PatchSenderIdSmsSenderIdPatch for application/json ContentType.
-type PatchSenderIdSmsSenderIdPatchJSONRequestBody = SenderIdPatch
+// PatchSenderIdV1SmsSenderIdPatchJSONRequestBody defines body for PatchSenderIdV1SmsSenderIdPatch for application/json ContentType.
+type PatchSenderIdV1SmsSenderIdPatchJSONRequestBody = SenderIdPatch
 
-// CreateSubscriptionWebhooksPostJSONRequestBody defines body for CreateSubscriptionWebhooksPost for application/json ContentType.
-type CreateSubscriptionWebhooksPostJSONRequestBody = WebhookSubscriptionCreate
+// CreateSubscriptionV1WebhooksPostJSONRequestBody defines body for CreateSubscriptionV1WebhooksPost for application/json ContentType.
+type CreateSubscriptionV1WebhooksPostJSONRequestBody = WebhookSubscriptionCreate
 
-// PatchSubscriptionWebhooksSubIdPatchJSONRequestBody defines body for PatchSubscriptionWebhooksSubIdPatch for application/json ContentType.
-type PatchSubscriptionWebhooksSubIdPatchJSONRequestBody = WebhookSubscriptionPatch
+// PatchSubscriptionV1WebhooksSubIdPatchJSONRequestBody defines body for PatchSubscriptionV1WebhooksSubIdPatch for application/json ContentType.
+type PatchSubscriptionV1WebhooksSubIdPatchJSONRequestBody = WebhookSubscriptionPatch
 
 // Getter for additional properties for DnsRecordSchema. Returns the specified
 // element and whether it was found
@@ -2379,114 +2953,114 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 
 // The interface specification for the client above.
 type ClientInterface interface {
-	// ListCallsCallsGet request
-	ListCallsCallsGet(ctx context.Context, params *ListCallsCallsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// HealthzHealthzGet request
+	HealthzHealthzGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// CreateCallCallsPostWithBody request with any body
-	CreateCallCallsPostWithBody(ctx context.Context, params *CreateCallCallsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ListCallsV1CallsGet request
+	ListCallsV1CallsGet(ctx context.Context, params *ListCallsV1CallsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	CreateCallCallsPost(ctx context.Context, params *CreateCallCallsPostParams, body CreateCallCallsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// CreateCallV1CallsPostWithBody request with any body
+	CreateCallV1CallsPostWithBody(ctx context.Context, params *CreateCallV1CallsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetCallCallsCallIdGet request
-	GetCallCallsCallIdGet(ctx context.Context, callId openapi_types.UUID, params *GetCallCallsCallIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateCallV1CallsPost(ctx context.Context, params *CreateCallV1CallsPostParams, body CreateCallV1CallsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ListContactsContactsGet request
-	ListContactsContactsGet(ctx context.Context, params *ListContactsContactsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetCallV1CallsCallIdGet request
+	GetCallV1CallsCallIdGet(ctx context.Context, callId openapi_types.UUID, params *GetCallV1CallsCallIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// CreateContactContactsPostWithBody request with any body
-	CreateContactContactsPostWithBody(ctx context.Context, params *CreateContactContactsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ListContactsV1ContactsGet request
+	ListContactsV1ContactsGet(ctx context.Context, params *ListContactsV1ContactsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	CreateContactContactsPost(ctx context.Context, params *CreateContactContactsPostParams, body CreateContactContactsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// CreateContactV1ContactsPostWithBody request with any body
+	CreateContactV1ContactsPostWithBody(ctx context.Context, params *CreateContactV1ContactsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// DeleteContactContactsContactIdDelete request
-	DeleteContactContactsContactIdDelete(ctx context.Context, contactId string, params *DeleteContactContactsContactIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateContactV1ContactsPost(ctx context.Context, params *CreateContactV1ContactsPostParams, body CreateContactV1ContactsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PatchContactContactsContactIdPatchWithBody request with any body
-	PatchContactContactsContactIdPatchWithBody(ctx context.Context, contactId string, params *PatchContactContactsContactIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// DeleteContactV1ContactsContactIdDelete request
+	DeleteContactV1ContactsContactIdDelete(ctx context.Context, contactId string, params *DeleteContactV1ContactsContactIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PatchContactContactsContactIdPatch(ctx context.Context, contactId string, params *PatchContactContactsContactIdPatchParams, body PatchContactContactsContactIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// PatchContactV1ContactsContactIdPatchWithBody request with any body
+	PatchContactV1ContactsContactIdPatchWithBody(ctx context.Context, contactId string, params *PatchContactV1ContactsContactIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PatchContactV1ContactsContactIdPatch(ctx context.Context, contactId string, params *PatchContactV1ContactsContactIdPatchParams, body PatchContactV1ContactsContactIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UploadEmailAttachmentWithBody request with any body
 	UploadEmailAttachmentWithBody(ctx context.Context, params *UploadEmailAttachmentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ListEmailDomainsEmailDomainsGet request
-	ListEmailDomainsEmailDomainsGet(ctx context.Context, params *ListEmailDomainsEmailDomainsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ListEmailDomainsV1EmailDomainsGet request
+	ListEmailDomainsV1EmailDomainsGet(ctx context.Context, params *ListEmailDomainsV1EmailDomainsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// CreateEmailDomainEmailDomainsPostWithBody request with any body
-	CreateEmailDomainEmailDomainsPostWithBody(ctx context.Context, params *CreateEmailDomainEmailDomainsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// CreateEmailDomainV1EmailDomainsPostWithBody request with any body
+	CreateEmailDomainV1EmailDomainsPostWithBody(ctx context.Context, params *CreateEmailDomainV1EmailDomainsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	CreateEmailDomainEmailDomainsPost(ctx context.Context, params *CreateEmailDomainEmailDomainsPostParams, body CreateEmailDomainEmailDomainsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateEmailDomainV1EmailDomainsPost(ctx context.Context, params *CreateEmailDomainV1EmailDomainsPostParams, body CreateEmailDomainV1EmailDomainsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// CheckDomainEmailDomainsCheckDomainGet request
-	CheckDomainEmailDomainsCheckDomainGet(ctx context.Context, params *CheckDomainEmailDomainsCheckDomainGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// CheckDomainV1EmailDomainsCheckDomainGet request
+	CheckDomainV1EmailDomainsCheckDomainGet(ctx context.Context, params *CheckDomainV1EmailDomainsCheckDomainGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// DeleteEmailDomainEmailDomainsDomainIdDelete request
-	DeleteEmailDomainEmailDomainsDomainIdDelete(ctx context.Context, domainId openapi_types.UUID, params *DeleteEmailDomainEmailDomainsDomainIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// DeleteEmailDomainV1EmailDomainsDomainIdDelete request
+	DeleteEmailDomainV1EmailDomainsDomainIdDelete(ctx context.Context, domainId openapi_types.UUID, params *DeleteEmailDomainV1EmailDomainsDomainIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetEmailDomainEmailDomainsDomainIdGet request
-	GetEmailDomainEmailDomainsDomainIdGet(ctx context.Context, domainId openapi_types.UUID, params *GetEmailDomainEmailDomainsDomainIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetEmailDomainV1EmailDomainsDomainIdGet request
+	GetEmailDomainV1EmailDomainsDomainIdGet(ctx context.Context, domainId openapi_types.UUID, params *GetEmailDomainV1EmailDomainsDomainIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PatchEmailDomainEmailDomainsDomainIdPatchWithBody request with any body
-	PatchEmailDomainEmailDomainsDomainIdPatchWithBody(ctx context.Context, domainId openapi_types.UUID, params *PatchEmailDomainEmailDomainsDomainIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// PatchEmailDomainV1EmailDomainsDomainIdPatchWithBody request with any body
+	PatchEmailDomainV1EmailDomainsDomainIdPatchWithBody(ctx context.Context, domainId openapi_types.UUID, params *PatchEmailDomainV1EmailDomainsDomainIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PatchEmailDomainEmailDomainsDomainIdPatch(ctx context.Context, domainId openapi_types.UUID, params *PatchEmailDomainEmailDomainsDomainIdPatchParams, body PatchEmailDomainEmailDomainsDomainIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PatchEmailDomainV1EmailDomainsDomainIdPatch(ctx context.Context, domainId openapi_types.UUID, params *PatchEmailDomainV1EmailDomainsDomainIdPatchParams, body PatchEmailDomainV1EmailDomainsDomainIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// VerifyEmailDomainEmailDomainsDomainIdVerifyPost request
-	VerifyEmailDomainEmailDomainsDomainIdVerifyPost(ctx context.Context, domainId openapi_types.UUID, params *VerifyEmailDomainEmailDomainsDomainIdVerifyPostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// VerifyEmailDomainV1EmailDomainsDomainIdVerifyPost request
+	VerifyEmailDomainV1EmailDomainsDomainIdVerifyPost(ctx context.Context, domainId openapi_types.UUID, params *VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ListEmailsEmailsGet request
-	ListEmailsEmailsGet(ctx context.Context, params *ListEmailsEmailsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ListEmailsV1EmailsGet request
+	ListEmailsV1EmailsGet(ctx context.Context, params *ListEmailsV1EmailsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// CreateEmailEmailsPostWithBody request with any body
-	CreateEmailEmailsPostWithBody(ctx context.Context, params *CreateEmailEmailsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// CreateEmailV1EmailsPostWithBody request with any body
+	CreateEmailV1EmailsPostWithBody(ctx context.Context, params *CreateEmailV1EmailsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	CreateEmailEmailsPost(ctx context.Context, params *CreateEmailEmailsPostParams, body CreateEmailEmailsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateEmailV1EmailsPost(ctx context.Context, params *CreateEmailV1EmailsPostParams, body CreateEmailV1EmailsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetEmailStatsEmailsStatsGet request
-	GetEmailStatsEmailsStatsGet(ctx context.Context, params *GetEmailStatsEmailsStatsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetEmailStatsV1EmailsStatsGet request
+	GetEmailStatsV1EmailsStatsGet(ctx context.Context, params *GetEmailStatsV1EmailsStatsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetEmailEmailsEmailIdGet request
-	GetEmailEmailsEmailIdGet(ctx context.Context, emailId openapi_types.UUID, params *GetEmailEmailsEmailIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetEmailV1EmailsEmailIdGet request
+	GetEmailV1EmailsEmailIdGet(ctx context.Context, emailId openapi_types.UUID, params *GetEmailV1EmailsEmailIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGet request
-	GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGet(ctx context.Context, emailId openapi_types.UUID, attachmentId openapi_types.UUID, params *GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGet request
+	GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGet(ctx context.Context, emailId openapi_types.UUID, attachmentId openapi_types.UUID, params *GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ListEmailEventsEmailsEmailIdEventsGet request
-	ListEmailEventsEmailsEmailIdEventsGet(ctx context.Context, emailId openapi_types.UUID, params *ListEmailEventsEmailsEmailIdEventsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ListEmailEventsV1EmailsEmailIdEventsGet request
+	ListEmailEventsV1EmailsEmailIdEventsGet(ctx context.Context, emailId openapi_types.UUID, params *ListEmailEventsV1EmailsEmailIdEventsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetEmailRawEmailsEmailIdRawGet request
-	GetEmailRawEmailsEmailIdRawGet(ctx context.Context, emailId openapi_types.UUID, params *GetEmailRawEmailsEmailIdRawGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetEmailRawV1EmailsEmailIdRawGet request
+	GetEmailRawV1EmailsEmailIdRawGet(ctx context.Context, emailId openapi_types.UUID, params *GetEmailRawV1EmailsEmailIdRawGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ListEventsEventsGet request
-	ListEventsEventsGet(ctx context.Context, params *ListEventsEventsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ListEventsV1EventsGet request
+	ListEventsV1EventsGet(ctx context.Context, params *ListEventsV1EventsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// HealthzHealthzGet request
-	HealthzHealthzGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// DeleteMemberPhoneV1MembersUserIdPhoneDelete request
+	DeleteMemberPhoneV1MembersUserIdPhoneDelete(ctx context.Context, userId string, params *DeleteMemberPhoneV1MembersUserIdPhoneDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// DeleteMemberPhoneMembersUserIdPhoneDelete request
-	DeleteMemberPhoneMembersUserIdPhoneDelete(ctx context.Context, userId string, params *DeleteMemberPhoneMembersUserIdPhoneDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// PutMemberPhoneV1MembersUserIdPhonePutWithBody request with any body
+	PutMemberPhoneV1MembersUserIdPhonePutWithBody(ctx context.Context, userId string, params *PutMemberPhoneV1MembersUserIdPhonePutParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PutMemberPhoneMembersUserIdPhonePutWithBody request with any body
-	PutMemberPhoneMembersUserIdPhonePutWithBody(ctx context.Context, userId string, params *PutMemberPhoneMembersUserIdPhonePutParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PutMemberPhoneV1MembersUserIdPhonePut(ctx context.Context, userId string, params *PutMemberPhoneV1MembersUserIdPhonePutParams, body PutMemberPhoneV1MembersUserIdPhonePutJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PutMemberPhoneMembersUserIdPhonePut(ctx context.Context, userId string, params *PutMemberPhoneMembersUserIdPhonePutParams, body PutMemberPhoneMembersUserIdPhonePutJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ListNumbersV1NumbersGet request
+	ListNumbersV1NumbersGet(ctx context.Context, params *ListNumbersV1NumbersGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ListNumbersNumbersGet request
-	ListNumbersNumbersGet(ctx context.Context, params *ListNumbersNumbersGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// AcquireNumberV1NumbersPostWithBody request with any body
+	AcquireNumberV1NumbersPostWithBody(ctx context.Context, params *AcquireNumberV1NumbersPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// AcquireNumberNumbersPostWithBody request with any body
-	AcquireNumberNumbersPostWithBody(ctx context.Context, params *AcquireNumberNumbersPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	AcquireNumberV1NumbersPost(ctx context.Context, params *AcquireNumberV1NumbersPostParams, body AcquireNumberV1NumbersPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	AcquireNumberNumbersPost(ctx context.Context, params *AcquireNumberNumbersPostParams, body AcquireNumberNumbersPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ReleaseNumberV1NumbersNumberIdDelete request
+	ReleaseNumberV1NumbersNumberIdDelete(ctx context.Context, numberId openapi_types.UUID, params *ReleaseNumberV1NumbersNumberIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ReleaseNumberNumbersNumberIdDelete request
-	ReleaseNumberNumbersNumberIdDelete(ctx context.Context, numberId openapi_types.UUID, params *ReleaseNumberNumbersNumberIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetNumberV1NumbersNumberIdGet request
+	GetNumberV1NumbersNumberIdGet(ctx context.Context, numberId openapi_types.UUID, params *GetNumberV1NumbersNumberIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetNumberNumbersNumberIdGet request
-	GetNumberNumbersNumberIdGet(ctx context.Context, numberId openapi_types.UUID, params *GetNumberNumbersNumberIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// EnableSmsNumbersNumberIdEnableSmsPost request
-	EnableSmsNumbersNumberIdEnableSmsPost(ctx context.Context, numberId openapi_types.UUID, params *EnableSmsNumbersNumberIdEnableSmsPostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// EnableSmsV1NumbersNumberIdEnableSmsPost request
+	EnableSmsV1NumbersNumberIdEnableSmsPost(ctx context.Context, numberId openapi_types.UUID, params *EnableSmsV1NumbersNumberIdEnableSmsPostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListProviders request
 	ListProviders(ctx context.Context, params *ListProvidersParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2509,68 +3083,68 @@ type ClientInterface interface {
 	// DeleteProvider request
 	DeleteProvider(ctx context.Context, layer string, provider string, params *DeleteProviderParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ListSmsSmsGet request
-	ListSmsSmsGet(ctx context.Context, params *ListSmsSmsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ListSmsV1SmsGet request
+	ListSmsV1SmsGet(ctx context.Context, params *ListSmsV1SmsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// CreateSmsSmsPostWithBody request with any body
-	CreateSmsSmsPostWithBody(ctx context.Context, params *CreateSmsSmsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// CreateSmsV1SmsPostWithBody request with any body
+	CreateSmsV1SmsPostWithBody(ctx context.Context, params *CreateSmsV1SmsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	CreateSmsSmsPost(ctx context.Context, params *CreateSmsSmsPostParams, body CreateSmsSmsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateSmsV1SmsPost(ctx context.Context, params *CreateSmsV1SmsPostParams, body CreateSmsV1SmsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetSenderIdSmsSenderIdGet request
-	GetSenderIdSmsSenderIdGet(ctx context.Context, params *GetSenderIdSmsSenderIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetSenderIdV1SmsSenderIdGet request
+	GetSenderIdV1SmsSenderIdGet(ctx context.Context, params *GetSenderIdV1SmsSenderIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PatchSenderIdSmsSenderIdPatchWithBody request with any body
-	PatchSenderIdSmsSenderIdPatchWithBody(ctx context.Context, params *PatchSenderIdSmsSenderIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// PatchSenderIdV1SmsSenderIdPatchWithBody request with any body
+	PatchSenderIdV1SmsSenderIdPatchWithBody(ctx context.Context, params *PatchSenderIdV1SmsSenderIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PatchSenderIdSmsSenderIdPatch(ctx context.Context, params *PatchSenderIdSmsSenderIdPatchParams, body PatchSenderIdSmsSenderIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PatchSenderIdV1SmsSenderIdPatch(ctx context.Context, params *PatchSenderIdV1SmsSenderIdPatchParams, body PatchSenderIdV1SmsSenderIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ListSmsSuppressionsSmsSuppressionsGet request
-	ListSmsSuppressionsSmsSuppressionsGet(ctx context.Context, params *ListSmsSuppressionsSmsSuppressionsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ListSmsSuppressionsV1SmsSuppressionsGet request
+	ListSmsSuppressionsV1SmsSuppressionsGet(ctx context.Context, params *ListSmsSuppressionsV1SmsSuppressionsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// DeleteSmsSuppressionSmsSuppressionsNumberDelete request
-	DeleteSmsSuppressionSmsSuppressionsNumberDelete(ctx context.Context, number string, params *DeleteSmsSuppressionSmsSuppressionsNumberDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// DeleteSmsSuppressionV1SmsSuppressionsNumberDelete request
+	DeleteSmsSuppressionV1SmsSuppressionsNumberDelete(ctx context.Context, number string, params *DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetSmsSmsSmsIdGet request
-	GetSmsSmsSmsIdGet(ctx context.Context, smsId openapi_types.UUID, params *GetSmsSmsSmsIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetSmsV1SmsSmsIdGet request
+	GetSmsV1SmsSmsIdGet(ctx context.Context, smsId openapi_types.UUID, params *GetSmsV1SmsSmsIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// UnsubscribeUnsubscribeGet request
-	UnsubscribeUnsubscribeGet(ctx context.Context, params *UnsubscribeUnsubscribeGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// UnsubscribeV1UnsubscribeGet request
+	UnsubscribeV1UnsubscribeGet(ctx context.Context, params *UnsubscribeV1UnsubscribeGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ListSubscriptionsWebhooksGet request
-	ListSubscriptionsWebhooksGet(ctx context.Context, params *ListSubscriptionsWebhooksGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ListSubscriptionsV1WebhooksGet request
+	ListSubscriptionsV1WebhooksGet(ctx context.Context, params *ListSubscriptionsV1WebhooksGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// CreateSubscriptionWebhooksPostWithBody request with any body
-	CreateSubscriptionWebhooksPostWithBody(ctx context.Context, params *CreateSubscriptionWebhooksPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// CreateSubscriptionV1WebhooksPostWithBody request with any body
+	CreateSubscriptionV1WebhooksPostWithBody(ctx context.Context, params *CreateSubscriptionV1WebhooksPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	CreateSubscriptionWebhooksPost(ctx context.Context, params *CreateSubscriptionWebhooksPostParams, body CreateSubscriptionWebhooksPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateSubscriptionV1WebhooksPost(ctx context.Context, params *CreateSubscriptionV1WebhooksPostParams, body CreateSubscriptionV1WebhooksPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// DeleteSubscriptionWebhooksSubIdDelete request
-	DeleteSubscriptionWebhooksSubIdDelete(ctx context.Context, subId openapi_types.UUID, params *DeleteSubscriptionWebhooksSubIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// DeleteSubscriptionV1WebhooksSubIdDelete request
+	DeleteSubscriptionV1WebhooksSubIdDelete(ctx context.Context, subId openapi_types.UUID, params *DeleteSubscriptionV1WebhooksSubIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetSubscriptionWebhooksSubIdGet request
-	GetSubscriptionWebhooksSubIdGet(ctx context.Context, subId openapi_types.UUID, params *GetSubscriptionWebhooksSubIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetSubscriptionV1WebhooksSubIdGet request
+	GetSubscriptionV1WebhooksSubIdGet(ctx context.Context, subId openapi_types.UUID, params *GetSubscriptionV1WebhooksSubIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PatchSubscriptionWebhooksSubIdPatchWithBody request with any body
-	PatchSubscriptionWebhooksSubIdPatchWithBody(ctx context.Context, subId openapi_types.UUID, params *PatchSubscriptionWebhooksSubIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// PatchSubscriptionV1WebhooksSubIdPatchWithBody request with any body
+	PatchSubscriptionV1WebhooksSubIdPatchWithBody(ctx context.Context, subId openapi_types.UUID, params *PatchSubscriptionV1WebhooksSubIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PatchSubscriptionWebhooksSubIdPatch(ctx context.Context, subId openapi_types.UUID, params *PatchSubscriptionWebhooksSubIdPatchParams, body PatchSubscriptionWebhooksSubIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PatchSubscriptionV1WebhooksSubIdPatch(ctx context.Context, subId openapi_types.UUID, params *PatchSubscriptionV1WebhooksSubIdPatchParams, body PatchSubscriptionV1WebhooksSubIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ListDeliveriesWebhooksSubIdDeliveriesGet request
-	ListDeliveriesWebhooksSubIdDeliveriesGet(ctx context.Context, subId openapi_types.UUID, params *ListDeliveriesWebhooksSubIdDeliveriesGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ListDeliveriesV1WebhooksSubIdDeliveriesGet request
+	ListDeliveriesV1WebhooksSubIdDeliveriesGet(ctx context.Context, subId openapi_types.UUID, params *ListDeliveriesV1WebhooksSubIdDeliveriesGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPost request
-	RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPost(ctx context.Context, subId openapi_types.UUID, deliveryId openapi_types.UUID, params *RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPost request
+	RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPost(ctx context.Context, subId openapi_types.UUID, deliveryId openapi_types.UUID, params *RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// RotateSecretWebhooksSubIdRotateSecretPost request
-	RotateSecretWebhooksSubIdRotateSecretPost(ctx context.Context, subId openapi_types.UUID, params *RotateSecretWebhooksSubIdRotateSecretPostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// RotateSecretV1WebhooksSubIdRotateSecretPost request
+	RotateSecretV1WebhooksSubIdRotateSecretPost(ctx context.Context, subId openapi_types.UUID, params *RotateSecretV1WebhooksSubIdRotateSecretPostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetWhoamiWhoamiGet request
-	GetWhoamiWhoamiGet(ctx context.Context, params *GetWhoamiWhoamiGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetWhoamiV1WhoamiGet request
+	GetWhoamiV1WhoamiGet(ctx context.Context, params *GetWhoamiV1WhoamiGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
-func (c *Client) ListCallsCallsGet(ctx context.Context, params *ListCallsCallsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListCallsCallsGetRequest(c.Server, params)
+func (c *Client) HealthzHealthzGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewHealthzHealthzGetRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -2581,8 +3155,8 @@ func (c *Client) ListCallsCallsGet(ctx context.Context, params *ListCallsCallsGe
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateCallCallsPostWithBody(ctx context.Context, params *CreateCallCallsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateCallCallsPostRequestWithBody(c.Server, params, contentType, body)
+func (c *Client) ListCallsV1CallsGet(ctx context.Context, params *ListCallsV1CallsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListCallsV1CallsGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2593,8 +3167,8 @@ func (c *Client) CreateCallCallsPostWithBody(ctx context.Context, params *Create
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateCallCallsPost(ctx context.Context, params *CreateCallCallsPostParams, body CreateCallCallsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateCallCallsPostRequest(c.Server, params, body)
+func (c *Client) CreateCallV1CallsPostWithBody(ctx context.Context, params *CreateCallV1CallsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateCallV1CallsPostRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2605,8 +3179,8 @@ func (c *Client) CreateCallCallsPost(ctx context.Context, params *CreateCallCall
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetCallCallsCallIdGet(ctx context.Context, callId openapi_types.UUID, params *GetCallCallsCallIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetCallCallsCallIdGetRequest(c.Server, callId, params)
+func (c *Client) CreateCallV1CallsPost(ctx context.Context, params *CreateCallV1CallsPostParams, body CreateCallV1CallsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateCallV1CallsPostRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2617,8 +3191,8 @@ func (c *Client) GetCallCallsCallIdGet(ctx context.Context, callId openapi_types
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListContactsContactsGet(ctx context.Context, params *ListContactsContactsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListContactsContactsGetRequest(c.Server, params)
+func (c *Client) GetCallV1CallsCallIdGet(ctx context.Context, callId openapi_types.UUID, params *GetCallV1CallsCallIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetCallV1CallsCallIdGetRequest(c.Server, callId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2629,8 +3203,8 @@ func (c *Client) ListContactsContactsGet(ctx context.Context, params *ListContac
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateContactContactsPostWithBody(ctx context.Context, params *CreateContactContactsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateContactContactsPostRequestWithBody(c.Server, params, contentType, body)
+func (c *Client) ListContactsV1ContactsGet(ctx context.Context, params *ListContactsV1ContactsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListContactsV1ContactsGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2641,8 +3215,8 @@ func (c *Client) CreateContactContactsPostWithBody(ctx context.Context, params *
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateContactContactsPost(ctx context.Context, params *CreateContactContactsPostParams, body CreateContactContactsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateContactContactsPostRequest(c.Server, params, body)
+func (c *Client) CreateContactV1ContactsPostWithBody(ctx context.Context, params *CreateContactV1ContactsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateContactV1ContactsPostRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2653,8 +3227,8 @@ func (c *Client) CreateContactContactsPost(ctx context.Context, params *CreateCo
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteContactContactsContactIdDelete(ctx context.Context, contactId string, params *DeleteContactContactsContactIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteContactContactsContactIdDeleteRequest(c.Server, contactId, params)
+func (c *Client) CreateContactV1ContactsPost(ctx context.Context, params *CreateContactV1ContactsPostParams, body CreateContactV1ContactsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateContactV1ContactsPostRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2665,8 +3239,8 @@ func (c *Client) DeleteContactContactsContactIdDelete(ctx context.Context, conta
 	return c.Client.Do(req)
 }
 
-func (c *Client) PatchContactContactsContactIdPatchWithBody(ctx context.Context, contactId string, params *PatchContactContactsContactIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPatchContactContactsContactIdPatchRequestWithBody(c.Server, contactId, params, contentType, body)
+func (c *Client) DeleteContactV1ContactsContactIdDelete(ctx context.Context, contactId string, params *DeleteContactV1ContactsContactIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteContactV1ContactsContactIdDeleteRequest(c.Server, contactId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2677,8 +3251,20 @@ func (c *Client) PatchContactContactsContactIdPatchWithBody(ctx context.Context,
 	return c.Client.Do(req)
 }
 
-func (c *Client) PatchContactContactsContactIdPatch(ctx context.Context, contactId string, params *PatchContactContactsContactIdPatchParams, body PatchContactContactsContactIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPatchContactContactsContactIdPatchRequest(c.Server, contactId, params, body)
+func (c *Client) PatchContactV1ContactsContactIdPatchWithBody(ctx context.Context, contactId string, params *PatchContactV1ContactsContactIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchContactV1ContactsContactIdPatchRequestWithBody(c.Server, contactId, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PatchContactV1ContactsContactIdPatch(ctx context.Context, contactId string, params *PatchContactV1ContactsContactIdPatchParams, body PatchContactV1ContactsContactIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchContactV1ContactsContactIdPatchRequest(c.Server, contactId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2701,8 +3287,8 @@ func (c *Client) UploadEmailAttachmentWithBody(ctx context.Context, params *Uplo
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListEmailDomainsEmailDomainsGet(ctx context.Context, params *ListEmailDomainsEmailDomainsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListEmailDomainsEmailDomainsGetRequest(c.Server, params)
+func (c *Client) ListEmailDomainsV1EmailDomainsGet(ctx context.Context, params *ListEmailDomainsV1EmailDomainsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListEmailDomainsV1EmailDomainsGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2713,8 +3299,8 @@ func (c *Client) ListEmailDomainsEmailDomainsGet(ctx context.Context, params *Li
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateEmailDomainEmailDomainsPostWithBody(ctx context.Context, params *CreateEmailDomainEmailDomainsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateEmailDomainEmailDomainsPostRequestWithBody(c.Server, params, contentType, body)
+func (c *Client) CreateEmailDomainV1EmailDomainsPostWithBody(ctx context.Context, params *CreateEmailDomainV1EmailDomainsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateEmailDomainV1EmailDomainsPostRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2725,8 +3311,8 @@ func (c *Client) CreateEmailDomainEmailDomainsPostWithBody(ctx context.Context, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateEmailDomainEmailDomainsPost(ctx context.Context, params *CreateEmailDomainEmailDomainsPostParams, body CreateEmailDomainEmailDomainsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateEmailDomainEmailDomainsPostRequest(c.Server, params, body)
+func (c *Client) CreateEmailDomainV1EmailDomainsPost(ctx context.Context, params *CreateEmailDomainV1EmailDomainsPostParams, body CreateEmailDomainV1EmailDomainsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateEmailDomainV1EmailDomainsPostRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2737,8 +3323,8 @@ func (c *Client) CreateEmailDomainEmailDomainsPost(ctx context.Context, params *
 	return c.Client.Do(req)
 }
 
-func (c *Client) CheckDomainEmailDomainsCheckDomainGet(ctx context.Context, params *CheckDomainEmailDomainsCheckDomainGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCheckDomainEmailDomainsCheckDomainGetRequest(c.Server, params)
+func (c *Client) CheckDomainV1EmailDomainsCheckDomainGet(ctx context.Context, params *CheckDomainV1EmailDomainsCheckDomainGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCheckDomainV1EmailDomainsCheckDomainGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2749,8 +3335,8 @@ func (c *Client) CheckDomainEmailDomainsCheckDomainGet(ctx context.Context, para
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteEmailDomainEmailDomainsDomainIdDelete(ctx context.Context, domainId openapi_types.UUID, params *DeleteEmailDomainEmailDomainsDomainIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteEmailDomainEmailDomainsDomainIdDeleteRequest(c.Server, domainId, params)
+func (c *Client) DeleteEmailDomainV1EmailDomainsDomainIdDelete(ctx context.Context, domainId openapi_types.UUID, params *DeleteEmailDomainV1EmailDomainsDomainIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteEmailDomainV1EmailDomainsDomainIdDeleteRequest(c.Server, domainId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2761,8 +3347,8 @@ func (c *Client) DeleteEmailDomainEmailDomainsDomainIdDelete(ctx context.Context
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetEmailDomainEmailDomainsDomainIdGet(ctx context.Context, domainId openapi_types.UUID, params *GetEmailDomainEmailDomainsDomainIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetEmailDomainEmailDomainsDomainIdGetRequest(c.Server, domainId, params)
+func (c *Client) GetEmailDomainV1EmailDomainsDomainIdGet(ctx context.Context, domainId openapi_types.UUID, params *GetEmailDomainV1EmailDomainsDomainIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetEmailDomainV1EmailDomainsDomainIdGetRequest(c.Server, domainId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2773,8 +3359,8 @@ func (c *Client) GetEmailDomainEmailDomainsDomainIdGet(ctx context.Context, doma
 	return c.Client.Do(req)
 }
 
-func (c *Client) PatchEmailDomainEmailDomainsDomainIdPatchWithBody(ctx context.Context, domainId openapi_types.UUID, params *PatchEmailDomainEmailDomainsDomainIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPatchEmailDomainEmailDomainsDomainIdPatchRequestWithBody(c.Server, domainId, params, contentType, body)
+func (c *Client) PatchEmailDomainV1EmailDomainsDomainIdPatchWithBody(ctx context.Context, domainId openapi_types.UUID, params *PatchEmailDomainV1EmailDomainsDomainIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchEmailDomainV1EmailDomainsDomainIdPatchRequestWithBody(c.Server, domainId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2785,8 +3371,8 @@ func (c *Client) PatchEmailDomainEmailDomainsDomainIdPatchWithBody(ctx context.C
 	return c.Client.Do(req)
 }
 
-func (c *Client) PatchEmailDomainEmailDomainsDomainIdPatch(ctx context.Context, domainId openapi_types.UUID, params *PatchEmailDomainEmailDomainsDomainIdPatchParams, body PatchEmailDomainEmailDomainsDomainIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPatchEmailDomainEmailDomainsDomainIdPatchRequest(c.Server, domainId, params, body)
+func (c *Client) PatchEmailDomainV1EmailDomainsDomainIdPatch(ctx context.Context, domainId openapi_types.UUID, params *PatchEmailDomainV1EmailDomainsDomainIdPatchParams, body PatchEmailDomainV1EmailDomainsDomainIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchEmailDomainV1EmailDomainsDomainIdPatchRequest(c.Server, domainId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2797,8 +3383,8 @@ func (c *Client) PatchEmailDomainEmailDomainsDomainIdPatch(ctx context.Context, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) VerifyEmailDomainEmailDomainsDomainIdVerifyPost(ctx context.Context, domainId openapi_types.UUID, params *VerifyEmailDomainEmailDomainsDomainIdVerifyPostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewVerifyEmailDomainEmailDomainsDomainIdVerifyPostRequest(c.Server, domainId, params)
+func (c *Client) VerifyEmailDomainV1EmailDomainsDomainIdVerifyPost(ctx context.Context, domainId openapi_types.UUID, params *VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewVerifyEmailDomainV1EmailDomainsDomainIdVerifyPostRequest(c.Server, domainId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2809,8 +3395,8 @@ func (c *Client) VerifyEmailDomainEmailDomainsDomainIdVerifyPost(ctx context.Con
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListEmailsEmailsGet(ctx context.Context, params *ListEmailsEmailsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListEmailsEmailsGetRequest(c.Server, params)
+func (c *Client) ListEmailsV1EmailsGet(ctx context.Context, params *ListEmailsV1EmailsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListEmailsV1EmailsGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2821,8 +3407,8 @@ func (c *Client) ListEmailsEmailsGet(ctx context.Context, params *ListEmailsEmai
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateEmailEmailsPostWithBody(ctx context.Context, params *CreateEmailEmailsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateEmailEmailsPostRequestWithBody(c.Server, params, contentType, body)
+func (c *Client) CreateEmailV1EmailsPostWithBody(ctx context.Context, params *CreateEmailV1EmailsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateEmailV1EmailsPostRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2833,8 +3419,8 @@ func (c *Client) CreateEmailEmailsPostWithBody(ctx context.Context, params *Crea
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateEmailEmailsPost(ctx context.Context, params *CreateEmailEmailsPostParams, body CreateEmailEmailsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateEmailEmailsPostRequest(c.Server, params, body)
+func (c *Client) CreateEmailV1EmailsPost(ctx context.Context, params *CreateEmailV1EmailsPostParams, body CreateEmailV1EmailsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateEmailV1EmailsPostRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2845,8 +3431,8 @@ func (c *Client) CreateEmailEmailsPost(ctx context.Context, params *CreateEmailE
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetEmailStatsEmailsStatsGet(ctx context.Context, params *GetEmailStatsEmailsStatsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetEmailStatsEmailsStatsGetRequest(c.Server, params)
+func (c *Client) GetEmailStatsV1EmailsStatsGet(ctx context.Context, params *GetEmailStatsV1EmailsStatsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetEmailStatsV1EmailsStatsGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2857,8 +3443,8 @@ func (c *Client) GetEmailStatsEmailsStatsGet(ctx context.Context, params *GetEma
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetEmailEmailsEmailIdGet(ctx context.Context, emailId openapi_types.UUID, params *GetEmailEmailsEmailIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetEmailEmailsEmailIdGetRequest(c.Server, emailId, params)
+func (c *Client) GetEmailV1EmailsEmailIdGet(ctx context.Context, emailId openapi_types.UUID, params *GetEmailV1EmailsEmailIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetEmailV1EmailsEmailIdGetRequest(c.Server, emailId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2869,8 +3455,8 @@ func (c *Client) GetEmailEmailsEmailIdGet(ctx context.Context, emailId openapi_t
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGet(ctx context.Context, emailId openapi_types.UUID, attachmentId openapi_types.UUID, params *GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetRequest(c.Server, emailId, attachmentId, params)
+func (c *Client) GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGet(ctx context.Context, emailId openapi_types.UUID, attachmentId openapi_types.UUID, params *GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetRequest(c.Server, emailId, attachmentId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2881,8 +3467,8 @@ func (c *Client) GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGet(ctx c
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListEmailEventsEmailsEmailIdEventsGet(ctx context.Context, emailId openapi_types.UUID, params *ListEmailEventsEmailsEmailIdEventsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListEmailEventsEmailsEmailIdEventsGetRequest(c.Server, emailId, params)
+func (c *Client) ListEmailEventsV1EmailsEmailIdEventsGet(ctx context.Context, emailId openapi_types.UUID, params *ListEmailEventsV1EmailsEmailIdEventsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListEmailEventsV1EmailsEmailIdEventsGetRequest(c.Server, emailId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2893,8 +3479,8 @@ func (c *Client) ListEmailEventsEmailsEmailIdEventsGet(ctx context.Context, emai
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetEmailRawEmailsEmailIdRawGet(ctx context.Context, emailId openapi_types.UUID, params *GetEmailRawEmailsEmailIdRawGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetEmailRawEmailsEmailIdRawGetRequest(c.Server, emailId, params)
+func (c *Client) GetEmailRawV1EmailsEmailIdRawGet(ctx context.Context, emailId openapi_types.UUID, params *GetEmailRawV1EmailsEmailIdRawGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetEmailRawV1EmailsEmailIdRawGetRequest(c.Server, emailId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2905,8 +3491,8 @@ func (c *Client) GetEmailRawEmailsEmailIdRawGet(ctx context.Context, emailId ope
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListEventsEventsGet(ctx context.Context, params *ListEventsEventsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListEventsEventsGetRequest(c.Server, params)
+func (c *Client) ListEventsV1EventsGet(ctx context.Context, params *ListEventsV1EventsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListEventsV1EventsGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2917,8 +3503,8 @@ func (c *Client) ListEventsEventsGet(ctx context.Context, params *ListEventsEven
 	return c.Client.Do(req)
 }
 
-func (c *Client) HealthzHealthzGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewHealthzHealthzGetRequest(c.Server)
+func (c *Client) DeleteMemberPhoneV1MembersUserIdPhoneDelete(ctx context.Context, userId string, params *DeleteMemberPhoneV1MembersUserIdPhoneDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteMemberPhoneV1MembersUserIdPhoneDeleteRequest(c.Server, userId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2929,8 +3515,8 @@ func (c *Client) HealthzHealthzGet(ctx context.Context, reqEditors ...RequestEdi
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteMemberPhoneMembersUserIdPhoneDelete(ctx context.Context, userId string, params *DeleteMemberPhoneMembersUserIdPhoneDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteMemberPhoneMembersUserIdPhoneDeleteRequest(c.Server, userId, params)
+func (c *Client) PutMemberPhoneV1MembersUserIdPhonePutWithBody(ctx context.Context, userId string, params *PutMemberPhoneV1MembersUserIdPhonePutParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutMemberPhoneV1MembersUserIdPhonePutRequestWithBody(c.Server, userId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2941,8 +3527,8 @@ func (c *Client) DeleteMemberPhoneMembersUserIdPhoneDelete(ctx context.Context, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) PutMemberPhoneMembersUserIdPhonePutWithBody(ctx context.Context, userId string, params *PutMemberPhoneMembersUserIdPhonePutParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPutMemberPhoneMembersUserIdPhonePutRequestWithBody(c.Server, userId, params, contentType, body)
+func (c *Client) PutMemberPhoneV1MembersUserIdPhonePut(ctx context.Context, userId string, params *PutMemberPhoneV1MembersUserIdPhonePutParams, body PutMemberPhoneV1MembersUserIdPhonePutJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutMemberPhoneV1MembersUserIdPhonePutRequest(c.Server, userId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2953,8 +3539,8 @@ func (c *Client) PutMemberPhoneMembersUserIdPhonePutWithBody(ctx context.Context
 	return c.Client.Do(req)
 }
 
-func (c *Client) PutMemberPhoneMembersUserIdPhonePut(ctx context.Context, userId string, params *PutMemberPhoneMembersUserIdPhonePutParams, body PutMemberPhoneMembersUserIdPhonePutJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPutMemberPhoneMembersUserIdPhonePutRequest(c.Server, userId, params, body)
+func (c *Client) ListNumbersV1NumbersGet(ctx context.Context, params *ListNumbersV1NumbersGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListNumbersV1NumbersGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2965,8 +3551,8 @@ func (c *Client) PutMemberPhoneMembersUserIdPhonePut(ctx context.Context, userId
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListNumbersNumbersGet(ctx context.Context, params *ListNumbersNumbersGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListNumbersNumbersGetRequest(c.Server, params)
+func (c *Client) AcquireNumberV1NumbersPostWithBody(ctx context.Context, params *AcquireNumberV1NumbersPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAcquireNumberV1NumbersPostRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2977,8 +3563,8 @@ func (c *Client) ListNumbersNumbersGet(ctx context.Context, params *ListNumbersN
 	return c.Client.Do(req)
 }
 
-func (c *Client) AcquireNumberNumbersPostWithBody(ctx context.Context, params *AcquireNumberNumbersPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewAcquireNumberNumbersPostRequestWithBody(c.Server, params, contentType, body)
+func (c *Client) AcquireNumberV1NumbersPost(ctx context.Context, params *AcquireNumberV1NumbersPostParams, body AcquireNumberV1NumbersPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAcquireNumberV1NumbersPostRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2989,8 +3575,8 @@ func (c *Client) AcquireNumberNumbersPostWithBody(ctx context.Context, params *A
 	return c.Client.Do(req)
 }
 
-func (c *Client) AcquireNumberNumbersPost(ctx context.Context, params *AcquireNumberNumbersPostParams, body AcquireNumberNumbersPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewAcquireNumberNumbersPostRequest(c.Server, params, body)
+func (c *Client) ReleaseNumberV1NumbersNumberIdDelete(ctx context.Context, numberId openapi_types.UUID, params *ReleaseNumberV1NumbersNumberIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewReleaseNumberV1NumbersNumberIdDeleteRequest(c.Server, numberId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3001,8 +3587,8 @@ func (c *Client) AcquireNumberNumbersPost(ctx context.Context, params *AcquireNu
 	return c.Client.Do(req)
 }
 
-func (c *Client) ReleaseNumberNumbersNumberIdDelete(ctx context.Context, numberId openapi_types.UUID, params *ReleaseNumberNumbersNumberIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewReleaseNumberNumbersNumberIdDeleteRequest(c.Server, numberId, params)
+func (c *Client) GetNumberV1NumbersNumberIdGet(ctx context.Context, numberId openapi_types.UUID, params *GetNumberV1NumbersNumberIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetNumberV1NumbersNumberIdGetRequest(c.Server, numberId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3013,20 +3599,8 @@ func (c *Client) ReleaseNumberNumbersNumberIdDelete(ctx context.Context, numberI
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetNumberNumbersNumberIdGet(ctx context.Context, numberId openapi_types.UUID, params *GetNumberNumbersNumberIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetNumberNumbersNumberIdGetRequest(c.Server, numberId, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) EnableSmsNumbersNumberIdEnableSmsPost(ctx context.Context, numberId openapi_types.UUID, params *EnableSmsNumbersNumberIdEnableSmsPostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewEnableSmsNumbersNumberIdEnableSmsPostRequest(c.Server, numberId, params)
+func (c *Client) EnableSmsV1NumbersNumberIdEnableSmsPost(ctx context.Context, numberId openapi_types.UUID, params *EnableSmsV1NumbersNumberIdEnableSmsPostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEnableSmsV1NumbersNumberIdEnableSmsPostRequest(c.Server, numberId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3133,8 +3707,8 @@ func (c *Client) DeleteProvider(ctx context.Context, layer string, provider stri
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListSmsSmsGet(ctx context.Context, params *ListSmsSmsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListSmsSmsGetRequest(c.Server, params)
+func (c *Client) ListSmsV1SmsGet(ctx context.Context, params *ListSmsV1SmsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListSmsV1SmsGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3145,8 +3719,8 @@ func (c *Client) ListSmsSmsGet(ctx context.Context, params *ListSmsSmsGetParams,
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateSmsSmsPostWithBody(ctx context.Context, params *CreateSmsSmsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateSmsSmsPostRequestWithBody(c.Server, params, contentType, body)
+func (c *Client) CreateSmsV1SmsPostWithBody(ctx context.Context, params *CreateSmsV1SmsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateSmsV1SmsPostRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3157,8 +3731,8 @@ func (c *Client) CreateSmsSmsPostWithBody(ctx context.Context, params *CreateSms
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateSmsSmsPost(ctx context.Context, params *CreateSmsSmsPostParams, body CreateSmsSmsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateSmsSmsPostRequest(c.Server, params, body)
+func (c *Client) CreateSmsV1SmsPost(ctx context.Context, params *CreateSmsV1SmsPostParams, body CreateSmsV1SmsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateSmsV1SmsPostRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3169,8 +3743,8 @@ func (c *Client) CreateSmsSmsPost(ctx context.Context, params *CreateSmsSmsPostP
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetSenderIdSmsSenderIdGet(ctx context.Context, params *GetSenderIdSmsSenderIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetSenderIdSmsSenderIdGetRequest(c.Server, params)
+func (c *Client) GetSenderIdV1SmsSenderIdGet(ctx context.Context, params *GetSenderIdV1SmsSenderIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetSenderIdV1SmsSenderIdGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3181,8 +3755,8 @@ func (c *Client) GetSenderIdSmsSenderIdGet(ctx context.Context, params *GetSende
 	return c.Client.Do(req)
 }
 
-func (c *Client) PatchSenderIdSmsSenderIdPatchWithBody(ctx context.Context, params *PatchSenderIdSmsSenderIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPatchSenderIdSmsSenderIdPatchRequestWithBody(c.Server, params, contentType, body)
+func (c *Client) PatchSenderIdV1SmsSenderIdPatchWithBody(ctx context.Context, params *PatchSenderIdV1SmsSenderIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchSenderIdV1SmsSenderIdPatchRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3193,8 +3767,8 @@ func (c *Client) PatchSenderIdSmsSenderIdPatchWithBody(ctx context.Context, para
 	return c.Client.Do(req)
 }
 
-func (c *Client) PatchSenderIdSmsSenderIdPatch(ctx context.Context, params *PatchSenderIdSmsSenderIdPatchParams, body PatchSenderIdSmsSenderIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPatchSenderIdSmsSenderIdPatchRequest(c.Server, params, body)
+func (c *Client) PatchSenderIdV1SmsSenderIdPatch(ctx context.Context, params *PatchSenderIdV1SmsSenderIdPatchParams, body PatchSenderIdV1SmsSenderIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchSenderIdV1SmsSenderIdPatchRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3205,8 +3779,8 @@ func (c *Client) PatchSenderIdSmsSenderIdPatch(ctx context.Context, params *Patc
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListSmsSuppressionsSmsSuppressionsGet(ctx context.Context, params *ListSmsSuppressionsSmsSuppressionsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListSmsSuppressionsSmsSuppressionsGetRequest(c.Server, params)
+func (c *Client) ListSmsSuppressionsV1SmsSuppressionsGet(ctx context.Context, params *ListSmsSuppressionsV1SmsSuppressionsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListSmsSuppressionsV1SmsSuppressionsGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3217,8 +3791,8 @@ func (c *Client) ListSmsSuppressionsSmsSuppressionsGet(ctx context.Context, para
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteSmsSuppressionSmsSuppressionsNumberDelete(ctx context.Context, number string, params *DeleteSmsSuppressionSmsSuppressionsNumberDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteSmsSuppressionSmsSuppressionsNumberDeleteRequest(c.Server, number, params)
+func (c *Client) DeleteSmsSuppressionV1SmsSuppressionsNumberDelete(ctx context.Context, number string, params *DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteSmsSuppressionV1SmsSuppressionsNumberDeleteRequest(c.Server, number, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3229,8 +3803,8 @@ func (c *Client) DeleteSmsSuppressionSmsSuppressionsNumberDelete(ctx context.Con
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetSmsSmsSmsIdGet(ctx context.Context, smsId openapi_types.UUID, params *GetSmsSmsSmsIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetSmsSmsSmsIdGetRequest(c.Server, smsId, params)
+func (c *Client) GetSmsV1SmsSmsIdGet(ctx context.Context, smsId openapi_types.UUID, params *GetSmsV1SmsSmsIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetSmsV1SmsSmsIdGetRequest(c.Server, smsId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3241,8 +3815,8 @@ func (c *Client) GetSmsSmsSmsIdGet(ctx context.Context, smsId openapi_types.UUID
 	return c.Client.Do(req)
 }
 
-func (c *Client) UnsubscribeUnsubscribeGet(ctx context.Context, params *UnsubscribeUnsubscribeGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUnsubscribeUnsubscribeGetRequest(c.Server, params)
+func (c *Client) UnsubscribeV1UnsubscribeGet(ctx context.Context, params *UnsubscribeV1UnsubscribeGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUnsubscribeV1UnsubscribeGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3253,8 +3827,8 @@ func (c *Client) UnsubscribeUnsubscribeGet(ctx context.Context, params *Unsubscr
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListSubscriptionsWebhooksGet(ctx context.Context, params *ListSubscriptionsWebhooksGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListSubscriptionsWebhooksGetRequest(c.Server, params)
+func (c *Client) ListSubscriptionsV1WebhooksGet(ctx context.Context, params *ListSubscriptionsV1WebhooksGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListSubscriptionsV1WebhooksGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3265,8 +3839,8 @@ func (c *Client) ListSubscriptionsWebhooksGet(ctx context.Context, params *ListS
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateSubscriptionWebhooksPostWithBody(ctx context.Context, params *CreateSubscriptionWebhooksPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateSubscriptionWebhooksPostRequestWithBody(c.Server, params, contentType, body)
+func (c *Client) CreateSubscriptionV1WebhooksPostWithBody(ctx context.Context, params *CreateSubscriptionV1WebhooksPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateSubscriptionV1WebhooksPostRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3277,8 +3851,8 @@ func (c *Client) CreateSubscriptionWebhooksPostWithBody(ctx context.Context, par
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateSubscriptionWebhooksPost(ctx context.Context, params *CreateSubscriptionWebhooksPostParams, body CreateSubscriptionWebhooksPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateSubscriptionWebhooksPostRequest(c.Server, params, body)
+func (c *Client) CreateSubscriptionV1WebhooksPost(ctx context.Context, params *CreateSubscriptionV1WebhooksPostParams, body CreateSubscriptionV1WebhooksPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateSubscriptionV1WebhooksPostRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3289,8 +3863,8 @@ func (c *Client) CreateSubscriptionWebhooksPost(ctx context.Context, params *Cre
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteSubscriptionWebhooksSubIdDelete(ctx context.Context, subId openapi_types.UUID, params *DeleteSubscriptionWebhooksSubIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteSubscriptionWebhooksSubIdDeleteRequest(c.Server, subId, params)
+func (c *Client) DeleteSubscriptionV1WebhooksSubIdDelete(ctx context.Context, subId openapi_types.UUID, params *DeleteSubscriptionV1WebhooksSubIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteSubscriptionV1WebhooksSubIdDeleteRequest(c.Server, subId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3301,8 +3875,8 @@ func (c *Client) DeleteSubscriptionWebhooksSubIdDelete(ctx context.Context, subI
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetSubscriptionWebhooksSubIdGet(ctx context.Context, subId openapi_types.UUID, params *GetSubscriptionWebhooksSubIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetSubscriptionWebhooksSubIdGetRequest(c.Server, subId, params)
+func (c *Client) GetSubscriptionV1WebhooksSubIdGet(ctx context.Context, subId openapi_types.UUID, params *GetSubscriptionV1WebhooksSubIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetSubscriptionV1WebhooksSubIdGetRequest(c.Server, subId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3313,8 +3887,8 @@ func (c *Client) GetSubscriptionWebhooksSubIdGet(ctx context.Context, subId open
 	return c.Client.Do(req)
 }
 
-func (c *Client) PatchSubscriptionWebhooksSubIdPatchWithBody(ctx context.Context, subId openapi_types.UUID, params *PatchSubscriptionWebhooksSubIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPatchSubscriptionWebhooksSubIdPatchRequestWithBody(c.Server, subId, params, contentType, body)
+func (c *Client) PatchSubscriptionV1WebhooksSubIdPatchWithBody(ctx context.Context, subId openapi_types.UUID, params *PatchSubscriptionV1WebhooksSubIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchSubscriptionV1WebhooksSubIdPatchRequestWithBody(c.Server, subId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3325,8 +3899,8 @@ func (c *Client) PatchSubscriptionWebhooksSubIdPatchWithBody(ctx context.Context
 	return c.Client.Do(req)
 }
 
-func (c *Client) PatchSubscriptionWebhooksSubIdPatch(ctx context.Context, subId openapi_types.UUID, params *PatchSubscriptionWebhooksSubIdPatchParams, body PatchSubscriptionWebhooksSubIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPatchSubscriptionWebhooksSubIdPatchRequest(c.Server, subId, params, body)
+func (c *Client) PatchSubscriptionV1WebhooksSubIdPatch(ctx context.Context, subId openapi_types.UUID, params *PatchSubscriptionV1WebhooksSubIdPatchParams, body PatchSubscriptionV1WebhooksSubIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchSubscriptionV1WebhooksSubIdPatchRequest(c.Server, subId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3337,8 +3911,8 @@ func (c *Client) PatchSubscriptionWebhooksSubIdPatch(ctx context.Context, subId 
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListDeliveriesWebhooksSubIdDeliveriesGet(ctx context.Context, subId openapi_types.UUID, params *ListDeliveriesWebhooksSubIdDeliveriesGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListDeliveriesWebhooksSubIdDeliveriesGetRequest(c.Server, subId, params)
+func (c *Client) ListDeliveriesV1WebhooksSubIdDeliveriesGet(ctx context.Context, subId openapi_types.UUID, params *ListDeliveriesV1WebhooksSubIdDeliveriesGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListDeliveriesV1WebhooksSubIdDeliveriesGetRequest(c.Server, subId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3349,8 +3923,8 @@ func (c *Client) ListDeliveriesWebhooksSubIdDeliveriesGet(ctx context.Context, s
 	return c.Client.Do(req)
 }
 
-func (c *Client) RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPost(ctx context.Context, subId openapi_types.UUID, deliveryId openapi_types.UUID, params *RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewRedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostRequest(c.Server, subId, deliveryId, params)
+func (c *Client) RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPost(ctx context.Context, subId openapi_types.UUID, deliveryId openapi_types.UUID, params *RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostRequest(c.Server, subId, deliveryId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3361,8 +3935,8 @@ func (c *Client) RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPost(ctx con
 	return c.Client.Do(req)
 }
 
-func (c *Client) RotateSecretWebhooksSubIdRotateSecretPost(ctx context.Context, subId openapi_types.UUID, params *RotateSecretWebhooksSubIdRotateSecretPostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewRotateSecretWebhooksSubIdRotateSecretPostRequest(c.Server, subId, params)
+func (c *Client) RotateSecretV1WebhooksSubIdRotateSecretPost(ctx context.Context, subId openapi_types.UUID, params *RotateSecretV1WebhooksSubIdRotateSecretPostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRotateSecretV1WebhooksSubIdRotateSecretPostRequest(c.Server, subId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3373,8 +3947,8 @@ func (c *Client) RotateSecretWebhooksSubIdRotateSecretPost(ctx context.Context, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetWhoamiWhoamiGet(ctx context.Context, params *GetWhoamiWhoamiGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetWhoamiWhoamiGetRequest(c.Server, params)
+func (c *Client) GetWhoamiV1WhoamiGet(ctx context.Context, params *GetWhoamiV1WhoamiGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetWhoamiV1WhoamiGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3385,8 +3959,8 @@ func (c *Client) GetWhoamiWhoamiGet(ctx context.Context, params *GetWhoamiWhoami
 	return c.Client.Do(req)
 }
 
-// NewListCallsCallsGetRequest generates requests for ListCallsCallsGet
-func NewListCallsCallsGetRequest(server string, params *ListCallsCallsGetParams) (*http.Request, error) {
+// NewHealthzHealthzGetRequest generates requests for HealthzHealthzGet
+func NewHealthzHealthzGetRequest(server string) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -3394,7 +3968,34 @@ func NewListCallsCallsGetRequest(server string, params *ListCallsCallsGetParams)
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/calls")
+	operationPath := fmt.Sprintf("/healthz")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListCallsV1CallsGetRequest generates requests for ListCallsV1CallsGet
+func NewListCallsV1CallsGetRequest(server string, params *ListCallsV1CallsGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/calls")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -3497,19 +4098,19 @@ func NewListCallsCallsGetRequest(server string, params *ListCallsCallsGetParams)
 	return req, nil
 }
 
-// NewCreateCallCallsPostRequest calls the generic CreateCallCallsPost builder with application/json body
-func NewCreateCallCallsPostRequest(server string, params *CreateCallCallsPostParams, body CreateCallCallsPostJSONRequestBody) (*http.Request, error) {
+// NewCreateCallV1CallsPostRequest calls the generic CreateCallV1CallsPost builder with application/json body
+func NewCreateCallV1CallsPostRequest(server string, params *CreateCallV1CallsPostParams, body CreateCallV1CallsPostJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewCreateCallCallsPostRequestWithBody(server, params, "application/json", bodyReader)
+	return NewCreateCallV1CallsPostRequestWithBody(server, params, "application/json", bodyReader)
 }
 
-// NewCreateCallCallsPostRequestWithBody generates requests for CreateCallCallsPost with any type of body
-func NewCreateCallCallsPostRequestWithBody(server string, params *CreateCallCallsPostParams, contentType string, body io.Reader) (*http.Request, error) {
+// NewCreateCallV1CallsPostRequestWithBody generates requests for CreateCallV1CallsPost with any type of body
+func NewCreateCallV1CallsPostRequestWithBody(server string, params *CreateCallV1CallsPostParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -3517,7 +4118,7 @@ func NewCreateCallCallsPostRequestWithBody(server string, params *CreateCallCall
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/calls")
+	operationPath := fmt.Sprintf("/v1/calls")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -3563,8 +4164,8 @@ func NewCreateCallCallsPostRequestWithBody(server string, params *CreateCallCall
 	return req, nil
 }
 
-// NewGetCallCallsCallIdGetRequest generates requests for GetCallCallsCallIdGet
-func NewGetCallCallsCallIdGetRequest(server string, callId openapi_types.UUID, params *GetCallCallsCallIdGetParams) (*http.Request, error) {
+// NewGetCallV1CallsCallIdGetRequest generates requests for GetCallV1CallsCallIdGet
+func NewGetCallV1CallsCallIdGetRequest(server string, callId openapi_types.UUID, params *GetCallV1CallsCallIdGetParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -3579,7 +4180,7 @@ func NewGetCallCallsCallIdGetRequest(server string, callId openapi_types.UUID, p
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/calls/%s", pathParam0)
+	operationPath := fmt.Sprintf("/v1/calls/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -3612,8 +4213,8 @@ func NewGetCallCallsCallIdGetRequest(server string, callId openapi_types.UUID, p
 	return req, nil
 }
 
-// NewListContactsContactsGetRequest generates requests for ListContactsContactsGet
-func NewListContactsContactsGetRequest(server string, params *ListContactsContactsGetParams) (*http.Request, error) {
+// NewListContactsV1ContactsGetRequest generates requests for ListContactsV1ContactsGet
+func NewListContactsV1ContactsGetRequest(server string, params *ListContactsV1ContactsGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -3621,7 +4222,7 @@ func NewListContactsContactsGetRequest(server string, params *ListContactsContac
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/contacts")
+	operationPath := fmt.Sprintf("/v1/contacts")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -3708,19 +4309,19 @@ func NewListContactsContactsGetRequest(server string, params *ListContactsContac
 	return req, nil
 }
 
-// NewCreateContactContactsPostRequest calls the generic CreateContactContactsPost builder with application/json body
-func NewCreateContactContactsPostRequest(server string, params *CreateContactContactsPostParams, body CreateContactContactsPostJSONRequestBody) (*http.Request, error) {
+// NewCreateContactV1ContactsPostRequest calls the generic CreateContactV1ContactsPost builder with application/json body
+func NewCreateContactV1ContactsPostRequest(server string, params *CreateContactV1ContactsPostParams, body CreateContactV1ContactsPostJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewCreateContactContactsPostRequestWithBody(server, params, "application/json", bodyReader)
+	return NewCreateContactV1ContactsPostRequestWithBody(server, params, "application/json", bodyReader)
 }
 
-// NewCreateContactContactsPostRequestWithBody generates requests for CreateContactContactsPost with any type of body
-func NewCreateContactContactsPostRequestWithBody(server string, params *CreateContactContactsPostParams, contentType string, body io.Reader) (*http.Request, error) {
+// NewCreateContactV1ContactsPostRequestWithBody generates requests for CreateContactV1ContactsPost with any type of body
+func NewCreateContactV1ContactsPostRequestWithBody(server string, params *CreateContactV1ContactsPostParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -3728,7 +4329,7 @@ func NewCreateContactContactsPostRequestWithBody(server string, params *CreateCo
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/contacts")
+	operationPath := fmt.Sprintf("/v1/contacts")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -3763,8 +4364,8 @@ func NewCreateContactContactsPostRequestWithBody(server string, params *CreateCo
 	return req, nil
 }
 
-// NewDeleteContactContactsContactIdDeleteRequest generates requests for DeleteContactContactsContactIdDelete
-func NewDeleteContactContactsContactIdDeleteRequest(server string, contactId string, params *DeleteContactContactsContactIdDeleteParams) (*http.Request, error) {
+// NewDeleteContactV1ContactsContactIdDeleteRequest generates requests for DeleteContactV1ContactsContactIdDelete
+func NewDeleteContactV1ContactsContactIdDeleteRequest(server string, contactId string, params *DeleteContactV1ContactsContactIdDeleteParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -3779,7 +4380,7 @@ func NewDeleteContactContactsContactIdDeleteRequest(server string, contactId str
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/contacts/%s", pathParam0)
+	operationPath := fmt.Sprintf("/v1/contacts/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -3812,19 +4413,19 @@ func NewDeleteContactContactsContactIdDeleteRequest(server string, contactId str
 	return req, nil
 }
 
-// NewPatchContactContactsContactIdPatchRequest calls the generic PatchContactContactsContactIdPatch builder with application/json body
-func NewPatchContactContactsContactIdPatchRequest(server string, contactId string, params *PatchContactContactsContactIdPatchParams, body PatchContactContactsContactIdPatchJSONRequestBody) (*http.Request, error) {
+// NewPatchContactV1ContactsContactIdPatchRequest calls the generic PatchContactV1ContactsContactIdPatch builder with application/json body
+func NewPatchContactV1ContactsContactIdPatchRequest(server string, contactId string, params *PatchContactV1ContactsContactIdPatchParams, body PatchContactV1ContactsContactIdPatchJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPatchContactContactsContactIdPatchRequestWithBody(server, contactId, params, "application/json", bodyReader)
+	return NewPatchContactV1ContactsContactIdPatchRequestWithBody(server, contactId, params, "application/json", bodyReader)
 }
 
-// NewPatchContactContactsContactIdPatchRequestWithBody generates requests for PatchContactContactsContactIdPatch with any type of body
-func NewPatchContactContactsContactIdPatchRequestWithBody(server string, contactId string, params *PatchContactContactsContactIdPatchParams, contentType string, body io.Reader) (*http.Request, error) {
+// NewPatchContactV1ContactsContactIdPatchRequestWithBody generates requests for PatchContactV1ContactsContactIdPatch with any type of body
+func NewPatchContactV1ContactsContactIdPatchRequestWithBody(server string, contactId string, params *PatchContactV1ContactsContactIdPatchParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -3839,7 +4440,7 @@ func NewPatchContactContactsContactIdPatchRequestWithBody(server string, contact
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/contacts/%s", pathParam0)
+	operationPath := fmt.Sprintf("/v1/contacts/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -3883,7 +4484,7 @@ func NewUploadEmailAttachmentRequestWithBody(server string, params *UploadEmailA
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/email-attachments")
+	operationPath := fmt.Sprintf("/v1/email-attachments")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -3918,8 +4519,8 @@ func NewUploadEmailAttachmentRequestWithBody(server string, params *UploadEmailA
 	return req, nil
 }
 
-// NewListEmailDomainsEmailDomainsGetRequest generates requests for ListEmailDomainsEmailDomainsGet
-func NewListEmailDomainsEmailDomainsGetRequest(server string, params *ListEmailDomainsEmailDomainsGetParams) (*http.Request, error) {
+// NewListEmailDomainsV1EmailDomainsGetRequest generates requests for ListEmailDomainsV1EmailDomainsGet
+func NewListEmailDomainsV1EmailDomainsGetRequest(server string, params *ListEmailDomainsV1EmailDomainsGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -3927,7 +4528,7 @@ func NewListEmailDomainsEmailDomainsGetRequest(server string, params *ListEmailD
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/email-domains")
+	operationPath := fmt.Sprintf("/v1/email-domains")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -3998,19 +4599,19 @@ func NewListEmailDomainsEmailDomainsGetRequest(server string, params *ListEmailD
 	return req, nil
 }
 
-// NewCreateEmailDomainEmailDomainsPostRequest calls the generic CreateEmailDomainEmailDomainsPost builder with application/json body
-func NewCreateEmailDomainEmailDomainsPostRequest(server string, params *CreateEmailDomainEmailDomainsPostParams, body CreateEmailDomainEmailDomainsPostJSONRequestBody) (*http.Request, error) {
+// NewCreateEmailDomainV1EmailDomainsPostRequest calls the generic CreateEmailDomainV1EmailDomainsPost builder with application/json body
+func NewCreateEmailDomainV1EmailDomainsPostRequest(server string, params *CreateEmailDomainV1EmailDomainsPostParams, body CreateEmailDomainV1EmailDomainsPostJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewCreateEmailDomainEmailDomainsPostRequestWithBody(server, params, "application/json", bodyReader)
+	return NewCreateEmailDomainV1EmailDomainsPostRequestWithBody(server, params, "application/json", bodyReader)
 }
 
-// NewCreateEmailDomainEmailDomainsPostRequestWithBody generates requests for CreateEmailDomainEmailDomainsPost with any type of body
-func NewCreateEmailDomainEmailDomainsPostRequestWithBody(server string, params *CreateEmailDomainEmailDomainsPostParams, contentType string, body io.Reader) (*http.Request, error) {
+// NewCreateEmailDomainV1EmailDomainsPostRequestWithBody generates requests for CreateEmailDomainV1EmailDomainsPost with any type of body
+func NewCreateEmailDomainV1EmailDomainsPostRequestWithBody(server string, params *CreateEmailDomainV1EmailDomainsPostParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -4018,7 +4619,7 @@ func NewCreateEmailDomainEmailDomainsPostRequestWithBody(server string, params *
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/email-domains")
+	operationPath := fmt.Sprintf("/v1/email-domains")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -4053,8 +4654,8 @@ func NewCreateEmailDomainEmailDomainsPostRequestWithBody(server string, params *
 	return req, nil
 }
 
-// NewCheckDomainEmailDomainsCheckDomainGetRequest generates requests for CheckDomainEmailDomainsCheckDomainGet
-func NewCheckDomainEmailDomainsCheckDomainGetRequest(server string, params *CheckDomainEmailDomainsCheckDomainGetParams) (*http.Request, error) {
+// NewCheckDomainV1EmailDomainsCheckDomainGetRequest generates requests for CheckDomainV1EmailDomainsCheckDomainGet
+func NewCheckDomainV1EmailDomainsCheckDomainGetRequest(server string, params *CheckDomainV1EmailDomainsCheckDomainGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -4062,7 +4663,7 @@ func NewCheckDomainEmailDomainsCheckDomainGetRequest(server string, params *Chec
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/email-domains/check-domain")
+	operationPath := fmt.Sprintf("/v1/email-domains/check-domain")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -4113,8 +4714,8 @@ func NewCheckDomainEmailDomainsCheckDomainGetRequest(server string, params *Chec
 	return req, nil
 }
 
-// NewDeleteEmailDomainEmailDomainsDomainIdDeleteRequest generates requests for DeleteEmailDomainEmailDomainsDomainIdDelete
-func NewDeleteEmailDomainEmailDomainsDomainIdDeleteRequest(server string, domainId openapi_types.UUID, params *DeleteEmailDomainEmailDomainsDomainIdDeleteParams) (*http.Request, error) {
+// NewDeleteEmailDomainV1EmailDomainsDomainIdDeleteRequest generates requests for DeleteEmailDomainV1EmailDomainsDomainIdDelete
+func NewDeleteEmailDomainV1EmailDomainsDomainIdDeleteRequest(server string, domainId openapi_types.UUID, params *DeleteEmailDomainV1EmailDomainsDomainIdDeleteParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4129,7 +4730,7 @@ func NewDeleteEmailDomainEmailDomainsDomainIdDeleteRequest(server string, domain
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/email-domains/%s", pathParam0)
+	operationPath := fmt.Sprintf("/v1/email-domains/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -4162,8 +4763,8 @@ func NewDeleteEmailDomainEmailDomainsDomainIdDeleteRequest(server string, domain
 	return req, nil
 }
 
-// NewGetEmailDomainEmailDomainsDomainIdGetRequest generates requests for GetEmailDomainEmailDomainsDomainIdGet
-func NewGetEmailDomainEmailDomainsDomainIdGetRequest(server string, domainId openapi_types.UUID, params *GetEmailDomainEmailDomainsDomainIdGetParams) (*http.Request, error) {
+// NewGetEmailDomainV1EmailDomainsDomainIdGetRequest generates requests for GetEmailDomainV1EmailDomainsDomainIdGet
+func NewGetEmailDomainV1EmailDomainsDomainIdGetRequest(server string, domainId openapi_types.UUID, params *GetEmailDomainV1EmailDomainsDomainIdGetParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4178,7 +4779,7 @@ func NewGetEmailDomainEmailDomainsDomainIdGetRequest(server string, domainId ope
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/email-domains/%s", pathParam0)
+	operationPath := fmt.Sprintf("/v1/email-domains/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -4211,19 +4812,19 @@ func NewGetEmailDomainEmailDomainsDomainIdGetRequest(server string, domainId ope
 	return req, nil
 }
 
-// NewPatchEmailDomainEmailDomainsDomainIdPatchRequest calls the generic PatchEmailDomainEmailDomainsDomainIdPatch builder with application/json body
-func NewPatchEmailDomainEmailDomainsDomainIdPatchRequest(server string, domainId openapi_types.UUID, params *PatchEmailDomainEmailDomainsDomainIdPatchParams, body PatchEmailDomainEmailDomainsDomainIdPatchJSONRequestBody) (*http.Request, error) {
+// NewPatchEmailDomainV1EmailDomainsDomainIdPatchRequest calls the generic PatchEmailDomainV1EmailDomainsDomainIdPatch builder with application/json body
+func NewPatchEmailDomainV1EmailDomainsDomainIdPatchRequest(server string, domainId openapi_types.UUID, params *PatchEmailDomainV1EmailDomainsDomainIdPatchParams, body PatchEmailDomainV1EmailDomainsDomainIdPatchJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPatchEmailDomainEmailDomainsDomainIdPatchRequestWithBody(server, domainId, params, "application/json", bodyReader)
+	return NewPatchEmailDomainV1EmailDomainsDomainIdPatchRequestWithBody(server, domainId, params, "application/json", bodyReader)
 }
 
-// NewPatchEmailDomainEmailDomainsDomainIdPatchRequestWithBody generates requests for PatchEmailDomainEmailDomainsDomainIdPatch with any type of body
-func NewPatchEmailDomainEmailDomainsDomainIdPatchRequestWithBody(server string, domainId openapi_types.UUID, params *PatchEmailDomainEmailDomainsDomainIdPatchParams, contentType string, body io.Reader) (*http.Request, error) {
+// NewPatchEmailDomainV1EmailDomainsDomainIdPatchRequestWithBody generates requests for PatchEmailDomainV1EmailDomainsDomainIdPatch with any type of body
+func NewPatchEmailDomainV1EmailDomainsDomainIdPatchRequestWithBody(server string, domainId openapi_types.UUID, params *PatchEmailDomainV1EmailDomainsDomainIdPatchParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4238,7 +4839,7 @@ func NewPatchEmailDomainEmailDomainsDomainIdPatchRequestWithBody(server string, 
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/email-domains/%s", pathParam0)
+	operationPath := fmt.Sprintf("/v1/email-domains/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -4273,8 +4874,8 @@ func NewPatchEmailDomainEmailDomainsDomainIdPatchRequestWithBody(server string, 
 	return req, nil
 }
 
-// NewVerifyEmailDomainEmailDomainsDomainIdVerifyPostRequest generates requests for VerifyEmailDomainEmailDomainsDomainIdVerifyPost
-func NewVerifyEmailDomainEmailDomainsDomainIdVerifyPostRequest(server string, domainId openapi_types.UUID, params *VerifyEmailDomainEmailDomainsDomainIdVerifyPostParams) (*http.Request, error) {
+// NewVerifyEmailDomainV1EmailDomainsDomainIdVerifyPostRequest generates requests for VerifyEmailDomainV1EmailDomainsDomainIdVerifyPost
+func NewVerifyEmailDomainV1EmailDomainsDomainIdVerifyPostRequest(server string, domainId openapi_types.UUID, params *VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4289,7 +4890,7 @@ func NewVerifyEmailDomainEmailDomainsDomainIdVerifyPostRequest(server string, do
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/email-domains/%s/verify", pathParam0)
+	operationPath := fmt.Sprintf("/v1/email-domains/%s/verify", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -4322,8 +4923,8 @@ func NewVerifyEmailDomainEmailDomainsDomainIdVerifyPostRequest(server string, do
 	return req, nil
 }
 
-// NewListEmailsEmailsGetRequest generates requests for ListEmailsEmailsGet
-func NewListEmailsEmailsGetRequest(server string, params *ListEmailsEmailsGetParams) (*http.Request, error) {
+// NewListEmailsV1EmailsGetRequest generates requests for ListEmailsV1EmailsGet
+func NewListEmailsV1EmailsGetRequest(server string, params *ListEmailsV1EmailsGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -4331,7 +4932,7 @@ func NewListEmailsEmailsGetRequest(server string, params *ListEmailsEmailsGetPar
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/emails")
+	operationPath := fmt.Sprintf("/v1/emails")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -4434,19 +5035,19 @@ func NewListEmailsEmailsGetRequest(server string, params *ListEmailsEmailsGetPar
 	return req, nil
 }
 
-// NewCreateEmailEmailsPostRequest calls the generic CreateEmailEmailsPost builder with application/json body
-func NewCreateEmailEmailsPostRequest(server string, params *CreateEmailEmailsPostParams, body CreateEmailEmailsPostJSONRequestBody) (*http.Request, error) {
+// NewCreateEmailV1EmailsPostRequest calls the generic CreateEmailV1EmailsPost builder with application/json body
+func NewCreateEmailV1EmailsPostRequest(server string, params *CreateEmailV1EmailsPostParams, body CreateEmailV1EmailsPostJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewCreateEmailEmailsPostRequestWithBody(server, params, "application/json", bodyReader)
+	return NewCreateEmailV1EmailsPostRequestWithBody(server, params, "application/json", bodyReader)
 }
 
-// NewCreateEmailEmailsPostRequestWithBody generates requests for CreateEmailEmailsPost with any type of body
-func NewCreateEmailEmailsPostRequestWithBody(server string, params *CreateEmailEmailsPostParams, contentType string, body io.Reader) (*http.Request, error) {
+// NewCreateEmailV1EmailsPostRequestWithBody generates requests for CreateEmailV1EmailsPost with any type of body
+func NewCreateEmailV1EmailsPostRequestWithBody(server string, params *CreateEmailV1EmailsPostParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -4454,7 +5055,7 @@ func NewCreateEmailEmailsPostRequestWithBody(server string, params *CreateEmailE
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/emails")
+	operationPath := fmt.Sprintf("/v1/emails")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -4500,8 +5101,8 @@ func NewCreateEmailEmailsPostRequestWithBody(server string, params *CreateEmailE
 	return req, nil
 }
 
-// NewGetEmailStatsEmailsStatsGetRequest generates requests for GetEmailStatsEmailsStatsGet
-func NewGetEmailStatsEmailsStatsGetRequest(server string, params *GetEmailStatsEmailsStatsGetParams) (*http.Request, error) {
+// NewGetEmailStatsV1EmailsStatsGetRequest generates requests for GetEmailStatsV1EmailsStatsGet
+func NewGetEmailStatsV1EmailsStatsGetRequest(server string, params *GetEmailStatsV1EmailsStatsGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -4509,7 +5110,7 @@ func NewGetEmailStatsEmailsStatsGetRequest(server string, params *GetEmailStatsE
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/emails/stats")
+	operationPath := fmt.Sprintf("/v1/emails/stats")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -4596,8 +5197,8 @@ func NewGetEmailStatsEmailsStatsGetRequest(server string, params *GetEmailStatsE
 	return req, nil
 }
 
-// NewGetEmailEmailsEmailIdGetRequest generates requests for GetEmailEmailsEmailIdGet
-func NewGetEmailEmailsEmailIdGetRequest(server string, emailId openapi_types.UUID, params *GetEmailEmailsEmailIdGetParams) (*http.Request, error) {
+// NewGetEmailV1EmailsEmailIdGetRequest generates requests for GetEmailV1EmailsEmailIdGet
+func NewGetEmailV1EmailsEmailIdGetRequest(server string, emailId openapi_types.UUID, params *GetEmailV1EmailsEmailIdGetParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4612,7 +5213,7 @@ func NewGetEmailEmailsEmailIdGetRequest(server string, emailId openapi_types.UUI
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/emails/%s", pathParam0)
+	operationPath := fmt.Sprintf("/v1/emails/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -4645,8 +5246,8 @@ func NewGetEmailEmailsEmailIdGetRequest(server string, emailId openapi_types.UUI
 	return req, nil
 }
 
-// NewGetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetRequest generates requests for GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGet
-func NewGetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetRequest(server string, emailId openapi_types.UUID, attachmentId openapi_types.UUID, params *GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetParams) (*http.Request, error) {
+// NewGetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetRequest generates requests for GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGet
+func NewGetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetRequest(server string, emailId openapi_types.UUID, attachmentId openapi_types.UUID, params *GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4668,7 +5269,7 @@ func NewGetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetRequest(server 
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/emails/%s/attachments/%s", pathParam0, pathParam1)
+	operationPath := fmt.Sprintf("/v1/emails/%s/attachments/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -4701,8 +5302,8 @@ func NewGetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetRequest(server 
 	return req, nil
 }
 
-// NewListEmailEventsEmailsEmailIdEventsGetRequest generates requests for ListEmailEventsEmailsEmailIdEventsGet
-func NewListEmailEventsEmailsEmailIdEventsGetRequest(server string, emailId openapi_types.UUID, params *ListEmailEventsEmailsEmailIdEventsGetParams) (*http.Request, error) {
+// NewListEmailEventsV1EmailsEmailIdEventsGetRequest generates requests for ListEmailEventsV1EmailsEmailIdEventsGet
+func NewListEmailEventsV1EmailsEmailIdEventsGetRequest(server string, emailId openapi_types.UUID, params *ListEmailEventsV1EmailsEmailIdEventsGetParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4717,7 +5318,7 @@ func NewListEmailEventsEmailsEmailIdEventsGetRequest(server string, emailId open
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/emails/%s/events", pathParam0)
+	operationPath := fmt.Sprintf("/v1/emails/%s/events", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -4788,8 +5389,8 @@ func NewListEmailEventsEmailsEmailIdEventsGetRequest(server string, emailId open
 	return req, nil
 }
 
-// NewGetEmailRawEmailsEmailIdRawGetRequest generates requests for GetEmailRawEmailsEmailIdRawGet
-func NewGetEmailRawEmailsEmailIdRawGetRequest(server string, emailId openapi_types.UUID, params *GetEmailRawEmailsEmailIdRawGetParams) (*http.Request, error) {
+// NewGetEmailRawV1EmailsEmailIdRawGetRequest generates requests for GetEmailRawV1EmailsEmailIdRawGet
+func NewGetEmailRawV1EmailsEmailIdRawGetRequest(server string, emailId openapi_types.UUID, params *GetEmailRawV1EmailsEmailIdRawGetParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4804,7 +5405,7 @@ func NewGetEmailRawEmailsEmailIdRawGetRequest(server string, emailId openapi_typ
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/emails/%s/raw", pathParam0)
+	operationPath := fmt.Sprintf("/v1/emails/%s/raw", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -4837,8 +5438,8 @@ func NewGetEmailRawEmailsEmailIdRawGetRequest(server string, emailId openapi_typ
 	return req, nil
 }
 
-// NewListEventsEventsGetRequest generates requests for ListEventsEventsGet
-func NewListEventsEventsGetRequest(server string, params *ListEventsEventsGetParams) (*http.Request, error) {
+// NewListEventsV1EventsGetRequest generates requests for ListEventsV1EventsGet
+func NewListEventsV1EventsGetRequest(server string, params *ListEventsV1EventsGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -4846,7 +5447,7 @@ func NewListEventsEventsGetRequest(server string, params *ListEventsEventsGetPar
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/events")
+	operationPath := fmt.Sprintf("/v1/events")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -4949,35 +5550,8 @@ func NewListEventsEventsGetRequest(server string, params *ListEventsEventsGetPar
 	return req, nil
 }
 
-// NewHealthzHealthzGetRequest generates requests for HealthzHealthzGet
-func NewHealthzHealthzGetRequest(server string) (*http.Request, error) {
-	var err error
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/healthz")
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewDeleteMemberPhoneMembersUserIdPhoneDeleteRequest generates requests for DeleteMemberPhoneMembersUserIdPhoneDelete
-func NewDeleteMemberPhoneMembersUserIdPhoneDeleteRequest(server string, userId string, params *DeleteMemberPhoneMembersUserIdPhoneDeleteParams) (*http.Request, error) {
+// NewDeleteMemberPhoneV1MembersUserIdPhoneDeleteRequest generates requests for DeleteMemberPhoneV1MembersUserIdPhoneDelete
+func NewDeleteMemberPhoneV1MembersUserIdPhoneDeleteRequest(server string, userId string, params *DeleteMemberPhoneV1MembersUserIdPhoneDeleteParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4992,7 +5566,7 @@ func NewDeleteMemberPhoneMembersUserIdPhoneDeleteRequest(server string, userId s
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/members/%s/phone", pathParam0)
+	operationPath := fmt.Sprintf("/v1/members/%s/phone", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5025,19 +5599,19 @@ func NewDeleteMemberPhoneMembersUserIdPhoneDeleteRequest(server string, userId s
 	return req, nil
 }
 
-// NewPutMemberPhoneMembersUserIdPhonePutRequest calls the generic PutMemberPhoneMembersUserIdPhonePut builder with application/json body
-func NewPutMemberPhoneMembersUserIdPhonePutRequest(server string, userId string, params *PutMemberPhoneMembersUserIdPhonePutParams, body PutMemberPhoneMembersUserIdPhonePutJSONRequestBody) (*http.Request, error) {
+// NewPutMemberPhoneV1MembersUserIdPhonePutRequest calls the generic PutMemberPhoneV1MembersUserIdPhonePut builder with application/json body
+func NewPutMemberPhoneV1MembersUserIdPhonePutRequest(server string, userId string, params *PutMemberPhoneV1MembersUserIdPhonePutParams, body PutMemberPhoneV1MembersUserIdPhonePutJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPutMemberPhoneMembersUserIdPhonePutRequestWithBody(server, userId, params, "application/json", bodyReader)
+	return NewPutMemberPhoneV1MembersUserIdPhonePutRequestWithBody(server, userId, params, "application/json", bodyReader)
 }
 
-// NewPutMemberPhoneMembersUserIdPhonePutRequestWithBody generates requests for PutMemberPhoneMembersUserIdPhonePut with any type of body
-func NewPutMemberPhoneMembersUserIdPhonePutRequestWithBody(server string, userId string, params *PutMemberPhoneMembersUserIdPhonePutParams, contentType string, body io.Reader) (*http.Request, error) {
+// NewPutMemberPhoneV1MembersUserIdPhonePutRequestWithBody generates requests for PutMemberPhoneV1MembersUserIdPhonePut with any type of body
+func NewPutMemberPhoneV1MembersUserIdPhonePutRequestWithBody(server string, userId string, params *PutMemberPhoneV1MembersUserIdPhonePutParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5052,7 +5626,7 @@ func NewPutMemberPhoneMembersUserIdPhonePutRequestWithBody(server string, userId
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/members/%s/phone", pathParam0)
+	operationPath := fmt.Sprintf("/v1/members/%s/phone", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5087,8 +5661,8 @@ func NewPutMemberPhoneMembersUserIdPhonePutRequestWithBody(server string, userId
 	return req, nil
 }
 
-// NewListNumbersNumbersGetRequest generates requests for ListNumbersNumbersGet
-func NewListNumbersNumbersGetRequest(server string, params *ListNumbersNumbersGetParams) (*http.Request, error) {
+// NewListNumbersV1NumbersGetRequest generates requests for ListNumbersV1NumbersGet
+func NewListNumbersV1NumbersGetRequest(server string, params *ListNumbersV1NumbersGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -5096,7 +5670,7 @@ func NewListNumbersNumbersGetRequest(server string, params *ListNumbersNumbersGe
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/numbers")
+	operationPath := fmt.Sprintf("/v1/numbers")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5167,19 +5741,19 @@ func NewListNumbersNumbersGetRequest(server string, params *ListNumbersNumbersGe
 	return req, nil
 }
 
-// NewAcquireNumberNumbersPostRequest calls the generic AcquireNumberNumbersPost builder with application/json body
-func NewAcquireNumberNumbersPostRequest(server string, params *AcquireNumberNumbersPostParams, body AcquireNumberNumbersPostJSONRequestBody) (*http.Request, error) {
+// NewAcquireNumberV1NumbersPostRequest calls the generic AcquireNumberV1NumbersPost builder with application/json body
+func NewAcquireNumberV1NumbersPostRequest(server string, params *AcquireNumberV1NumbersPostParams, body AcquireNumberV1NumbersPostJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewAcquireNumberNumbersPostRequestWithBody(server, params, "application/json", bodyReader)
+	return NewAcquireNumberV1NumbersPostRequestWithBody(server, params, "application/json", bodyReader)
 }
 
-// NewAcquireNumberNumbersPostRequestWithBody generates requests for AcquireNumberNumbersPost with any type of body
-func NewAcquireNumberNumbersPostRequestWithBody(server string, params *AcquireNumberNumbersPostParams, contentType string, body io.Reader) (*http.Request, error) {
+// NewAcquireNumberV1NumbersPostRequestWithBody generates requests for AcquireNumberV1NumbersPost with any type of body
+func NewAcquireNumberV1NumbersPostRequestWithBody(server string, params *AcquireNumberV1NumbersPostParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -5187,7 +5761,7 @@ func NewAcquireNumberNumbersPostRequestWithBody(server string, params *AcquireNu
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/numbers")
+	operationPath := fmt.Sprintf("/v1/numbers")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5233,8 +5807,8 @@ func NewAcquireNumberNumbersPostRequestWithBody(server string, params *AcquireNu
 	return req, nil
 }
 
-// NewReleaseNumberNumbersNumberIdDeleteRequest generates requests for ReleaseNumberNumbersNumberIdDelete
-func NewReleaseNumberNumbersNumberIdDeleteRequest(server string, numberId openapi_types.UUID, params *ReleaseNumberNumbersNumberIdDeleteParams) (*http.Request, error) {
+// NewReleaseNumberV1NumbersNumberIdDeleteRequest generates requests for ReleaseNumberV1NumbersNumberIdDelete
+func NewReleaseNumberV1NumbersNumberIdDeleteRequest(server string, numberId openapi_types.UUID, params *ReleaseNumberV1NumbersNumberIdDeleteParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5249,7 +5823,7 @@ func NewReleaseNumberNumbersNumberIdDeleteRequest(server string, numberId openap
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/numbers/%s", pathParam0)
+	operationPath := fmt.Sprintf("/v1/numbers/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5282,8 +5856,8 @@ func NewReleaseNumberNumbersNumberIdDeleteRequest(server string, numberId openap
 	return req, nil
 }
 
-// NewGetNumberNumbersNumberIdGetRequest generates requests for GetNumberNumbersNumberIdGet
-func NewGetNumberNumbersNumberIdGetRequest(server string, numberId openapi_types.UUID, params *GetNumberNumbersNumberIdGetParams) (*http.Request, error) {
+// NewGetNumberV1NumbersNumberIdGetRequest generates requests for GetNumberV1NumbersNumberIdGet
+func NewGetNumberV1NumbersNumberIdGetRequest(server string, numberId openapi_types.UUID, params *GetNumberV1NumbersNumberIdGetParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5298,7 +5872,7 @@ func NewGetNumberNumbersNumberIdGetRequest(server string, numberId openapi_types
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/numbers/%s", pathParam0)
+	operationPath := fmt.Sprintf("/v1/numbers/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5331,8 +5905,8 @@ func NewGetNumberNumbersNumberIdGetRequest(server string, numberId openapi_types
 	return req, nil
 }
 
-// NewEnableSmsNumbersNumberIdEnableSmsPostRequest generates requests for EnableSmsNumbersNumberIdEnableSmsPost
-func NewEnableSmsNumbersNumberIdEnableSmsPostRequest(server string, numberId openapi_types.UUID, params *EnableSmsNumbersNumberIdEnableSmsPostParams) (*http.Request, error) {
+// NewEnableSmsV1NumbersNumberIdEnableSmsPostRequest generates requests for EnableSmsV1NumbersNumberIdEnableSmsPost
+func NewEnableSmsV1NumbersNumberIdEnableSmsPostRequest(server string, numberId openapi_types.UUID, params *EnableSmsV1NumbersNumberIdEnableSmsPostParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5347,7 +5921,7 @@ func NewEnableSmsNumbersNumberIdEnableSmsPostRequest(server string, numberId ope
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/numbers/%s/enable-sms", pathParam0)
+	operationPath := fmt.Sprintf("/v1/numbers/%s/enable-sms", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5389,7 +5963,7 @@ func NewListProvidersRequest(server string, params *ListProvidersParams) (*http.
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/providers")
+	operationPath := fmt.Sprintf("/v1/providers")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5449,7 +6023,7 @@ func NewUpsertProviderRequestWithBody(server string, layer string, params *Upser
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/providers/%s", pathParam0)
+	operationPath := fmt.Sprintf("/v1/providers/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5511,7 +6085,7 @@ func NewActivateProviderRequestWithBody(server string, layer string, params *Act
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/providers/%s/activate", pathParam0)
+	operationPath := fmt.Sprintf("/v1/providers/%s/activate", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5573,7 +6147,7 @@ func NewValidateProviderRequestWithBody(server string, layer string, params *Val
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/providers/%s/validate", pathParam0)
+	operationPath := fmt.Sprintf("/v1/providers/%s/validate", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5631,7 +6205,7 @@ func NewDeleteProviderRequest(server string, layer string, provider string, para
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/providers/%s/%s", pathParam0, pathParam1)
+	operationPath := fmt.Sprintf("/v1/providers/%s/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5664,8 +6238,8 @@ func NewDeleteProviderRequest(server string, layer string, provider string, para
 	return req, nil
 }
 
-// NewListSmsSmsGetRequest generates requests for ListSmsSmsGet
-func NewListSmsSmsGetRequest(server string, params *ListSmsSmsGetParams) (*http.Request, error) {
+// NewListSmsV1SmsGetRequest generates requests for ListSmsV1SmsGet
+func NewListSmsV1SmsGetRequest(server string, params *ListSmsV1SmsGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -5673,7 +6247,7 @@ func NewListSmsSmsGetRequest(server string, params *ListSmsSmsGetParams) (*http.
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/sms")
+	operationPath := fmt.Sprintf("/v1/sms")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5776,19 +6350,19 @@ func NewListSmsSmsGetRequest(server string, params *ListSmsSmsGetParams) (*http.
 	return req, nil
 }
 
-// NewCreateSmsSmsPostRequest calls the generic CreateSmsSmsPost builder with application/json body
-func NewCreateSmsSmsPostRequest(server string, params *CreateSmsSmsPostParams, body CreateSmsSmsPostJSONRequestBody) (*http.Request, error) {
+// NewCreateSmsV1SmsPostRequest calls the generic CreateSmsV1SmsPost builder with application/json body
+func NewCreateSmsV1SmsPostRequest(server string, params *CreateSmsV1SmsPostParams, body CreateSmsV1SmsPostJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewCreateSmsSmsPostRequestWithBody(server, params, "application/json", bodyReader)
+	return NewCreateSmsV1SmsPostRequestWithBody(server, params, "application/json", bodyReader)
 }
 
-// NewCreateSmsSmsPostRequestWithBody generates requests for CreateSmsSmsPost with any type of body
-func NewCreateSmsSmsPostRequestWithBody(server string, params *CreateSmsSmsPostParams, contentType string, body io.Reader) (*http.Request, error) {
+// NewCreateSmsV1SmsPostRequestWithBody generates requests for CreateSmsV1SmsPost with any type of body
+func NewCreateSmsV1SmsPostRequestWithBody(server string, params *CreateSmsV1SmsPostParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -5796,7 +6370,7 @@ func NewCreateSmsSmsPostRequestWithBody(server string, params *CreateSmsSmsPostP
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/sms")
+	operationPath := fmt.Sprintf("/v1/sms")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5842,8 +6416,8 @@ func NewCreateSmsSmsPostRequestWithBody(server string, params *CreateSmsSmsPostP
 	return req, nil
 }
 
-// NewGetSenderIdSmsSenderIdGetRequest generates requests for GetSenderIdSmsSenderIdGet
-func NewGetSenderIdSmsSenderIdGetRequest(server string, params *GetSenderIdSmsSenderIdGetParams) (*http.Request, error) {
+// NewGetSenderIdV1SmsSenderIdGetRequest generates requests for GetSenderIdV1SmsSenderIdGet
+func NewGetSenderIdV1SmsSenderIdGetRequest(server string, params *GetSenderIdV1SmsSenderIdGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -5851,7 +6425,7 @@ func NewGetSenderIdSmsSenderIdGetRequest(server string, params *GetSenderIdSmsSe
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/sms/sender-id")
+	operationPath := fmt.Sprintf("/v1/sms/sender-id")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5884,19 +6458,19 @@ func NewGetSenderIdSmsSenderIdGetRequest(server string, params *GetSenderIdSmsSe
 	return req, nil
 }
 
-// NewPatchSenderIdSmsSenderIdPatchRequest calls the generic PatchSenderIdSmsSenderIdPatch builder with application/json body
-func NewPatchSenderIdSmsSenderIdPatchRequest(server string, params *PatchSenderIdSmsSenderIdPatchParams, body PatchSenderIdSmsSenderIdPatchJSONRequestBody) (*http.Request, error) {
+// NewPatchSenderIdV1SmsSenderIdPatchRequest calls the generic PatchSenderIdV1SmsSenderIdPatch builder with application/json body
+func NewPatchSenderIdV1SmsSenderIdPatchRequest(server string, params *PatchSenderIdV1SmsSenderIdPatchParams, body PatchSenderIdV1SmsSenderIdPatchJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPatchSenderIdSmsSenderIdPatchRequestWithBody(server, params, "application/json", bodyReader)
+	return NewPatchSenderIdV1SmsSenderIdPatchRequestWithBody(server, params, "application/json", bodyReader)
 }
 
-// NewPatchSenderIdSmsSenderIdPatchRequestWithBody generates requests for PatchSenderIdSmsSenderIdPatch with any type of body
-func NewPatchSenderIdSmsSenderIdPatchRequestWithBody(server string, params *PatchSenderIdSmsSenderIdPatchParams, contentType string, body io.Reader) (*http.Request, error) {
+// NewPatchSenderIdV1SmsSenderIdPatchRequestWithBody generates requests for PatchSenderIdV1SmsSenderIdPatch with any type of body
+func NewPatchSenderIdV1SmsSenderIdPatchRequestWithBody(server string, params *PatchSenderIdV1SmsSenderIdPatchParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -5904,7 +6478,7 @@ func NewPatchSenderIdSmsSenderIdPatchRequestWithBody(server string, params *Patc
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/sms/sender-id")
+	operationPath := fmt.Sprintf("/v1/sms/sender-id")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5939,8 +6513,8 @@ func NewPatchSenderIdSmsSenderIdPatchRequestWithBody(server string, params *Patc
 	return req, nil
 }
 
-// NewListSmsSuppressionsSmsSuppressionsGetRequest generates requests for ListSmsSuppressionsSmsSuppressionsGet
-func NewListSmsSuppressionsSmsSuppressionsGetRequest(server string, params *ListSmsSuppressionsSmsSuppressionsGetParams) (*http.Request, error) {
+// NewListSmsSuppressionsV1SmsSuppressionsGetRequest generates requests for ListSmsSuppressionsV1SmsSuppressionsGet
+func NewListSmsSuppressionsV1SmsSuppressionsGetRequest(server string, params *ListSmsSuppressionsV1SmsSuppressionsGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -5948,7 +6522,7 @@ func NewListSmsSuppressionsSmsSuppressionsGetRequest(server string, params *List
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/sms/suppressions")
+	operationPath := fmt.Sprintf("/v1/sms/suppressions")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6019,8 +6593,8 @@ func NewListSmsSuppressionsSmsSuppressionsGetRequest(server string, params *List
 	return req, nil
 }
 
-// NewDeleteSmsSuppressionSmsSuppressionsNumberDeleteRequest generates requests for DeleteSmsSuppressionSmsSuppressionsNumberDelete
-func NewDeleteSmsSuppressionSmsSuppressionsNumberDeleteRequest(server string, number string, params *DeleteSmsSuppressionSmsSuppressionsNumberDeleteParams) (*http.Request, error) {
+// NewDeleteSmsSuppressionV1SmsSuppressionsNumberDeleteRequest generates requests for DeleteSmsSuppressionV1SmsSuppressionsNumberDelete
+func NewDeleteSmsSuppressionV1SmsSuppressionsNumberDeleteRequest(server string, number string, params *DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -6035,7 +6609,7 @@ func NewDeleteSmsSuppressionSmsSuppressionsNumberDeleteRequest(server string, nu
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/sms/suppressions/%s", pathParam0)
+	operationPath := fmt.Sprintf("/v1/sms/suppressions/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6068,8 +6642,8 @@ func NewDeleteSmsSuppressionSmsSuppressionsNumberDeleteRequest(server string, nu
 	return req, nil
 }
 
-// NewGetSmsSmsSmsIdGetRequest generates requests for GetSmsSmsSmsIdGet
-func NewGetSmsSmsSmsIdGetRequest(server string, smsId openapi_types.UUID, params *GetSmsSmsSmsIdGetParams) (*http.Request, error) {
+// NewGetSmsV1SmsSmsIdGetRequest generates requests for GetSmsV1SmsSmsIdGet
+func NewGetSmsV1SmsSmsIdGetRequest(server string, smsId openapi_types.UUID, params *GetSmsV1SmsSmsIdGetParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -6084,7 +6658,7 @@ func NewGetSmsSmsSmsIdGetRequest(server string, smsId openapi_types.UUID, params
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/sms/%s", pathParam0)
+	operationPath := fmt.Sprintf("/v1/sms/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6117,8 +6691,8 @@ func NewGetSmsSmsSmsIdGetRequest(server string, smsId openapi_types.UUID, params
 	return req, nil
 }
 
-// NewUnsubscribeUnsubscribeGetRequest generates requests for UnsubscribeUnsubscribeGet
-func NewUnsubscribeUnsubscribeGetRequest(server string, params *UnsubscribeUnsubscribeGetParams) (*http.Request, error) {
+// NewUnsubscribeV1UnsubscribeGetRequest generates requests for UnsubscribeV1UnsubscribeGet
+func NewUnsubscribeV1UnsubscribeGetRequest(server string, params *UnsubscribeV1UnsubscribeGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -6126,7 +6700,7 @@ func NewUnsubscribeUnsubscribeGetRequest(server string, params *UnsubscribeUnsub
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/unsubscribe")
+	operationPath := fmt.Sprintf("/v1/unsubscribe")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6162,8 +6736,8 @@ func NewUnsubscribeUnsubscribeGetRequest(server string, params *UnsubscribeUnsub
 	return req, nil
 }
 
-// NewListSubscriptionsWebhooksGetRequest generates requests for ListSubscriptionsWebhooksGet
-func NewListSubscriptionsWebhooksGetRequest(server string, params *ListSubscriptionsWebhooksGetParams) (*http.Request, error) {
+// NewListSubscriptionsV1WebhooksGetRequest generates requests for ListSubscriptionsV1WebhooksGet
+func NewListSubscriptionsV1WebhooksGetRequest(server string, params *ListSubscriptionsV1WebhooksGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -6171,7 +6745,7 @@ func NewListSubscriptionsWebhooksGetRequest(server string, params *ListSubscript
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/webhooks")
+	operationPath := fmt.Sprintf("/v1/webhooks")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6242,19 +6816,19 @@ func NewListSubscriptionsWebhooksGetRequest(server string, params *ListSubscript
 	return req, nil
 }
 
-// NewCreateSubscriptionWebhooksPostRequest calls the generic CreateSubscriptionWebhooksPost builder with application/json body
-func NewCreateSubscriptionWebhooksPostRequest(server string, params *CreateSubscriptionWebhooksPostParams, body CreateSubscriptionWebhooksPostJSONRequestBody) (*http.Request, error) {
+// NewCreateSubscriptionV1WebhooksPostRequest calls the generic CreateSubscriptionV1WebhooksPost builder with application/json body
+func NewCreateSubscriptionV1WebhooksPostRequest(server string, params *CreateSubscriptionV1WebhooksPostParams, body CreateSubscriptionV1WebhooksPostJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewCreateSubscriptionWebhooksPostRequestWithBody(server, params, "application/json", bodyReader)
+	return NewCreateSubscriptionV1WebhooksPostRequestWithBody(server, params, "application/json", bodyReader)
 }
 
-// NewCreateSubscriptionWebhooksPostRequestWithBody generates requests for CreateSubscriptionWebhooksPost with any type of body
-func NewCreateSubscriptionWebhooksPostRequestWithBody(server string, params *CreateSubscriptionWebhooksPostParams, contentType string, body io.Reader) (*http.Request, error) {
+// NewCreateSubscriptionV1WebhooksPostRequestWithBody generates requests for CreateSubscriptionV1WebhooksPost with any type of body
+func NewCreateSubscriptionV1WebhooksPostRequestWithBody(server string, params *CreateSubscriptionV1WebhooksPostParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -6262,7 +6836,7 @@ func NewCreateSubscriptionWebhooksPostRequestWithBody(server string, params *Cre
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/webhooks")
+	operationPath := fmt.Sprintf("/v1/webhooks")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6297,8 +6871,8 @@ func NewCreateSubscriptionWebhooksPostRequestWithBody(server string, params *Cre
 	return req, nil
 }
 
-// NewDeleteSubscriptionWebhooksSubIdDeleteRequest generates requests for DeleteSubscriptionWebhooksSubIdDelete
-func NewDeleteSubscriptionWebhooksSubIdDeleteRequest(server string, subId openapi_types.UUID, params *DeleteSubscriptionWebhooksSubIdDeleteParams) (*http.Request, error) {
+// NewDeleteSubscriptionV1WebhooksSubIdDeleteRequest generates requests for DeleteSubscriptionV1WebhooksSubIdDelete
+func NewDeleteSubscriptionV1WebhooksSubIdDeleteRequest(server string, subId openapi_types.UUID, params *DeleteSubscriptionV1WebhooksSubIdDeleteParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -6313,7 +6887,7 @@ func NewDeleteSubscriptionWebhooksSubIdDeleteRequest(server string, subId openap
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/webhooks/%s", pathParam0)
+	operationPath := fmt.Sprintf("/v1/webhooks/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6346,8 +6920,8 @@ func NewDeleteSubscriptionWebhooksSubIdDeleteRequest(server string, subId openap
 	return req, nil
 }
 
-// NewGetSubscriptionWebhooksSubIdGetRequest generates requests for GetSubscriptionWebhooksSubIdGet
-func NewGetSubscriptionWebhooksSubIdGetRequest(server string, subId openapi_types.UUID, params *GetSubscriptionWebhooksSubIdGetParams) (*http.Request, error) {
+// NewGetSubscriptionV1WebhooksSubIdGetRequest generates requests for GetSubscriptionV1WebhooksSubIdGet
+func NewGetSubscriptionV1WebhooksSubIdGetRequest(server string, subId openapi_types.UUID, params *GetSubscriptionV1WebhooksSubIdGetParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -6362,7 +6936,7 @@ func NewGetSubscriptionWebhooksSubIdGetRequest(server string, subId openapi_type
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/webhooks/%s", pathParam0)
+	operationPath := fmt.Sprintf("/v1/webhooks/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6395,19 +6969,19 @@ func NewGetSubscriptionWebhooksSubIdGetRequest(server string, subId openapi_type
 	return req, nil
 }
 
-// NewPatchSubscriptionWebhooksSubIdPatchRequest calls the generic PatchSubscriptionWebhooksSubIdPatch builder with application/json body
-func NewPatchSubscriptionWebhooksSubIdPatchRequest(server string, subId openapi_types.UUID, params *PatchSubscriptionWebhooksSubIdPatchParams, body PatchSubscriptionWebhooksSubIdPatchJSONRequestBody) (*http.Request, error) {
+// NewPatchSubscriptionV1WebhooksSubIdPatchRequest calls the generic PatchSubscriptionV1WebhooksSubIdPatch builder with application/json body
+func NewPatchSubscriptionV1WebhooksSubIdPatchRequest(server string, subId openapi_types.UUID, params *PatchSubscriptionV1WebhooksSubIdPatchParams, body PatchSubscriptionV1WebhooksSubIdPatchJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPatchSubscriptionWebhooksSubIdPatchRequestWithBody(server, subId, params, "application/json", bodyReader)
+	return NewPatchSubscriptionV1WebhooksSubIdPatchRequestWithBody(server, subId, params, "application/json", bodyReader)
 }
 
-// NewPatchSubscriptionWebhooksSubIdPatchRequestWithBody generates requests for PatchSubscriptionWebhooksSubIdPatch with any type of body
-func NewPatchSubscriptionWebhooksSubIdPatchRequestWithBody(server string, subId openapi_types.UUID, params *PatchSubscriptionWebhooksSubIdPatchParams, contentType string, body io.Reader) (*http.Request, error) {
+// NewPatchSubscriptionV1WebhooksSubIdPatchRequestWithBody generates requests for PatchSubscriptionV1WebhooksSubIdPatch with any type of body
+func NewPatchSubscriptionV1WebhooksSubIdPatchRequestWithBody(server string, subId openapi_types.UUID, params *PatchSubscriptionV1WebhooksSubIdPatchParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -6422,7 +6996,7 @@ func NewPatchSubscriptionWebhooksSubIdPatchRequestWithBody(server string, subId 
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/webhooks/%s", pathParam0)
+	operationPath := fmt.Sprintf("/v1/webhooks/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6457,8 +7031,8 @@ func NewPatchSubscriptionWebhooksSubIdPatchRequestWithBody(server string, subId 
 	return req, nil
 }
 
-// NewListDeliveriesWebhooksSubIdDeliveriesGetRequest generates requests for ListDeliveriesWebhooksSubIdDeliveriesGet
-func NewListDeliveriesWebhooksSubIdDeliveriesGetRequest(server string, subId openapi_types.UUID, params *ListDeliveriesWebhooksSubIdDeliveriesGetParams) (*http.Request, error) {
+// NewListDeliveriesV1WebhooksSubIdDeliveriesGetRequest generates requests for ListDeliveriesV1WebhooksSubIdDeliveriesGet
+func NewListDeliveriesV1WebhooksSubIdDeliveriesGetRequest(server string, subId openapi_types.UUID, params *ListDeliveriesV1WebhooksSubIdDeliveriesGetParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -6473,7 +7047,7 @@ func NewListDeliveriesWebhooksSubIdDeliveriesGetRequest(server string, subId ope
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/webhooks/%s/deliveries", pathParam0)
+	operationPath := fmt.Sprintf("/v1/webhooks/%s/deliveries", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6544,8 +7118,8 @@ func NewListDeliveriesWebhooksSubIdDeliveriesGetRequest(server string, subId ope
 	return req, nil
 }
 
-// NewRedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostRequest generates requests for RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPost
-func NewRedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostRequest(server string, subId openapi_types.UUID, deliveryId openapi_types.UUID, params *RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostParams) (*http.Request, error) {
+// NewRedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostRequest generates requests for RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPost
+func NewRedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostRequest(server string, subId openapi_types.UUID, deliveryId openapi_types.UUID, params *RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -6567,7 +7141,7 @@ func NewRedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostRequest(server st
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/webhooks/%s/deliveries/%s/redeliver", pathParam0, pathParam1)
+	operationPath := fmt.Sprintf("/v1/webhooks/%s/deliveries/%s/redeliver", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6600,8 +7174,8 @@ func NewRedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostRequest(server st
 	return req, nil
 }
 
-// NewRotateSecretWebhooksSubIdRotateSecretPostRequest generates requests for RotateSecretWebhooksSubIdRotateSecretPost
-func NewRotateSecretWebhooksSubIdRotateSecretPostRequest(server string, subId openapi_types.UUID, params *RotateSecretWebhooksSubIdRotateSecretPostParams) (*http.Request, error) {
+// NewRotateSecretV1WebhooksSubIdRotateSecretPostRequest generates requests for RotateSecretV1WebhooksSubIdRotateSecretPost
+func NewRotateSecretV1WebhooksSubIdRotateSecretPostRequest(server string, subId openapi_types.UUID, params *RotateSecretV1WebhooksSubIdRotateSecretPostParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -6616,7 +7190,7 @@ func NewRotateSecretWebhooksSubIdRotateSecretPostRequest(server string, subId op
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/webhooks/%s/rotate-secret", pathParam0)
+	operationPath := fmt.Sprintf("/v1/webhooks/%s/rotate-secret", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6649,8 +7223,8 @@ func NewRotateSecretWebhooksSubIdRotateSecretPostRequest(server string, subId op
 	return req, nil
 }
 
-// NewGetWhoamiWhoamiGetRequest generates requests for GetWhoamiWhoamiGet
-func NewGetWhoamiWhoamiGetRequest(server string, params *GetWhoamiWhoamiGetParams) (*http.Request, error) {
+// NewGetWhoamiV1WhoamiGetRequest generates requests for GetWhoamiV1WhoamiGet
+func NewGetWhoamiV1WhoamiGetRequest(server string, params *GetWhoamiV1WhoamiGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -6658,7 +7232,7 @@ func NewGetWhoamiWhoamiGetRequest(server string, params *GetWhoamiWhoamiGetParam
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/whoami")
+	operationPath := fmt.Sprintf("/v1/whoami")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -6734,114 +7308,114 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
-	// ListCallsCallsGetWithResponse request
-	ListCallsCallsGetWithResponse(ctx context.Context, params *ListCallsCallsGetParams, reqEditors ...RequestEditorFn) (*ListCallsCallsGetResponse, error)
+	// HealthzHealthzGetWithResponse request
+	HealthzHealthzGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*HealthzHealthzGetResponse, error)
 
-	// CreateCallCallsPostWithBodyWithResponse request with any body
-	CreateCallCallsPostWithBodyWithResponse(ctx context.Context, params *CreateCallCallsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateCallCallsPostResponse, error)
+	// ListCallsV1CallsGetWithResponse request
+	ListCallsV1CallsGetWithResponse(ctx context.Context, params *ListCallsV1CallsGetParams, reqEditors ...RequestEditorFn) (*ListCallsV1CallsGetResponse, error)
 
-	CreateCallCallsPostWithResponse(ctx context.Context, params *CreateCallCallsPostParams, body CreateCallCallsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateCallCallsPostResponse, error)
+	// CreateCallV1CallsPostWithBodyWithResponse request with any body
+	CreateCallV1CallsPostWithBodyWithResponse(ctx context.Context, params *CreateCallV1CallsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateCallV1CallsPostResponse, error)
 
-	// GetCallCallsCallIdGetWithResponse request
-	GetCallCallsCallIdGetWithResponse(ctx context.Context, callId openapi_types.UUID, params *GetCallCallsCallIdGetParams, reqEditors ...RequestEditorFn) (*GetCallCallsCallIdGetResponse, error)
+	CreateCallV1CallsPostWithResponse(ctx context.Context, params *CreateCallV1CallsPostParams, body CreateCallV1CallsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateCallV1CallsPostResponse, error)
 
-	// ListContactsContactsGetWithResponse request
-	ListContactsContactsGetWithResponse(ctx context.Context, params *ListContactsContactsGetParams, reqEditors ...RequestEditorFn) (*ListContactsContactsGetResponse, error)
+	// GetCallV1CallsCallIdGetWithResponse request
+	GetCallV1CallsCallIdGetWithResponse(ctx context.Context, callId openapi_types.UUID, params *GetCallV1CallsCallIdGetParams, reqEditors ...RequestEditorFn) (*GetCallV1CallsCallIdGetResponse, error)
 
-	// CreateContactContactsPostWithBodyWithResponse request with any body
-	CreateContactContactsPostWithBodyWithResponse(ctx context.Context, params *CreateContactContactsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateContactContactsPostResponse, error)
+	// ListContactsV1ContactsGetWithResponse request
+	ListContactsV1ContactsGetWithResponse(ctx context.Context, params *ListContactsV1ContactsGetParams, reqEditors ...RequestEditorFn) (*ListContactsV1ContactsGetResponse, error)
 
-	CreateContactContactsPostWithResponse(ctx context.Context, params *CreateContactContactsPostParams, body CreateContactContactsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateContactContactsPostResponse, error)
+	// CreateContactV1ContactsPostWithBodyWithResponse request with any body
+	CreateContactV1ContactsPostWithBodyWithResponse(ctx context.Context, params *CreateContactV1ContactsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateContactV1ContactsPostResponse, error)
 
-	// DeleteContactContactsContactIdDeleteWithResponse request
-	DeleteContactContactsContactIdDeleteWithResponse(ctx context.Context, contactId string, params *DeleteContactContactsContactIdDeleteParams, reqEditors ...RequestEditorFn) (*DeleteContactContactsContactIdDeleteResponse, error)
+	CreateContactV1ContactsPostWithResponse(ctx context.Context, params *CreateContactV1ContactsPostParams, body CreateContactV1ContactsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateContactV1ContactsPostResponse, error)
 
-	// PatchContactContactsContactIdPatchWithBodyWithResponse request with any body
-	PatchContactContactsContactIdPatchWithBodyWithResponse(ctx context.Context, contactId string, params *PatchContactContactsContactIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchContactContactsContactIdPatchResponse, error)
+	// DeleteContactV1ContactsContactIdDeleteWithResponse request
+	DeleteContactV1ContactsContactIdDeleteWithResponse(ctx context.Context, contactId string, params *DeleteContactV1ContactsContactIdDeleteParams, reqEditors ...RequestEditorFn) (*DeleteContactV1ContactsContactIdDeleteResponse, error)
 
-	PatchContactContactsContactIdPatchWithResponse(ctx context.Context, contactId string, params *PatchContactContactsContactIdPatchParams, body PatchContactContactsContactIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchContactContactsContactIdPatchResponse, error)
+	// PatchContactV1ContactsContactIdPatchWithBodyWithResponse request with any body
+	PatchContactV1ContactsContactIdPatchWithBodyWithResponse(ctx context.Context, contactId string, params *PatchContactV1ContactsContactIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchContactV1ContactsContactIdPatchResponse, error)
+
+	PatchContactV1ContactsContactIdPatchWithResponse(ctx context.Context, contactId string, params *PatchContactV1ContactsContactIdPatchParams, body PatchContactV1ContactsContactIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchContactV1ContactsContactIdPatchResponse, error)
 
 	// UploadEmailAttachmentWithBodyWithResponse request with any body
 	UploadEmailAttachmentWithBodyWithResponse(ctx context.Context, params *UploadEmailAttachmentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UploadEmailAttachmentResponse, error)
 
-	// ListEmailDomainsEmailDomainsGetWithResponse request
-	ListEmailDomainsEmailDomainsGetWithResponse(ctx context.Context, params *ListEmailDomainsEmailDomainsGetParams, reqEditors ...RequestEditorFn) (*ListEmailDomainsEmailDomainsGetResponse, error)
+	// ListEmailDomainsV1EmailDomainsGetWithResponse request
+	ListEmailDomainsV1EmailDomainsGetWithResponse(ctx context.Context, params *ListEmailDomainsV1EmailDomainsGetParams, reqEditors ...RequestEditorFn) (*ListEmailDomainsV1EmailDomainsGetResponse, error)
 
-	// CreateEmailDomainEmailDomainsPostWithBodyWithResponse request with any body
-	CreateEmailDomainEmailDomainsPostWithBodyWithResponse(ctx context.Context, params *CreateEmailDomainEmailDomainsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateEmailDomainEmailDomainsPostResponse, error)
+	// CreateEmailDomainV1EmailDomainsPostWithBodyWithResponse request with any body
+	CreateEmailDomainV1EmailDomainsPostWithBodyWithResponse(ctx context.Context, params *CreateEmailDomainV1EmailDomainsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateEmailDomainV1EmailDomainsPostResponse, error)
 
-	CreateEmailDomainEmailDomainsPostWithResponse(ctx context.Context, params *CreateEmailDomainEmailDomainsPostParams, body CreateEmailDomainEmailDomainsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateEmailDomainEmailDomainsPostResponse, error)
+	CreateEmailDomainV1EmailDomainsPostWithResponse(ctx context.Context, params *CreateEmailDomainV1EmailDomainsPostParams, body CreateEmailDomainV1EmailDomainsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateEmailDomainV1EmailDomainsPostResponse, error)
 
-	// CheckDomainEmailDomainsCheckDomainGetWithResponse request
-	CheckDomainEmailDomainsCheckDomainGetWithResponse(ctx context.Context, params *CheckDomainEmailDomainsCheckDomainGetParams, reqEditors ...RequestEditorFn) (*CheckDomainEmailDomainsCheckDomainGetResponse, error)
+	// CheckDomainV1EmailDomainsCheckDomainGetWithResponse request
+	CheckDomainV1EmailDomainsCheckDomainGetWithResponse(ctx context.Context, params *CheckDomainV1EmailDomainsCheckDomainGetParams, reqEditors ...RequestEditorFn) (*CheckDomainV1EmailDomainsCheckDomainGetResponse, error)
 
-	// DeleteEmailDomainEmailDomainsDomainIdDeleteWithResponse request
-	DeleteEmailDomainEmailDomainsDomainIdDeleteWithResponse(ctx context.Context, domainId openapi_types.UUID, params *DeleteEmailDomainEmailDomainsDomainIdDeleteParams, reqEditors ...RequestEditorFn) (*DeleteEmailDomainEmailDomainsDomainIdDeleteResponse, error)
+	// DeleteEmailDomainV1EmailDomainsDomainIdDeleteWithResponse request
+	DeleteEmailDomainV1EmailDomainsDomainIdDeleteWithResponse(ctx context.Context, domainId openapi_types.UUID, params *DeleteEmailDomainV1EmailDomainsDomainIdDeleteParams, reqEditors ...RequestEditorFn) (*DeleteEmailDomainV1EmailDomainsDomainIdDeleteResponse, error)
 
-	// GetEmailDomainEmailDomainsDomainIdGetWithResponse request
-	GetEmailDomainEmailDomainsDomainIdGetWithResponse(ctx context.Context, domainId openapi_types.UUID, params *GetEmailDomainEmailDomainsDomainIdGetParams, reqEditors ...RequestEditorFn) (*GetEmailDomainEmailDomainsDomainIdGetResponse, error)
+	// GetEmailDomainV1EmailDomainsDomainIdGetWithResponse request
+	GetEmailDomainV1EmailDomainsDomainIdGetWithResponse(ctx context.Context, domainId openapi_types.UUID, params *GetEmailDomainV1EmailDomainsDomainIdGetParams, reqEditors ...RequestEditorFn) (*GetEmailDomainV1EmailDomainsDomainIdGetResponse, error)
 
-	// PatchEmailDomainEmailDomainsDomainIdPatchWithBodyWithResponse request with any body
-	PatchEmailDomainEmailDomainsDomainIdPatchWithBodyWithResponse(ctx context.Context, domainId openapi_types.UUID, params *PatchEmailDomainEmailDomainsDomainIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchEmailDomainEmailDomainsDomainIdPatchResponse, error)
+	// PatchEmailDomainV1EmailDomainsDomainIdPatchWithBodyWithResponse request with any body
+	PatchEmailDomainV1EmailDomainsDomainIdPatchWithBodyWithResponse(ctx context.Context, domainId openapi_types.UUID, params *PatchEmailDomainV1EmailDomainsDomainIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchEmailDomainV1EmailDomainsDomainIdPatchResponse, error)
 
-	PatchEmailDomainEmailDomainsDomainIdPatchWithResponse(ctx context.Context, domainId openapi_types.UUID, params *PatchEmailDomainEmailDomainsDomainIdPatchParams, body PatchEmailDomainEmailDomainsDomainIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchEmailDomainEmailDomainsDomainIdPatchResponse, error)
+	PatchEmailDomainV1EmailDomainsDomainIdPatchWithResponse(ctx context.Context, domainId openapi_types.UUID, params *PatchEmailDomainV1EmailDomainsDomainIdPatchParams, body PatchEmailDomainV1EmailDomainsDomainIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchEmailDomainV1EmailDomainsDomainIdPatchResponse, error)
 
-	// VerifyEmailDomainEmailDomainsDomainIdVerifyPostWithResponse request
-	VerifyEmailDomainEmailDomainsDomainIdVerifyPostWithResponse(ctx context.Context, domainId openapi_types.UUID, params *VerifyEmailDomainEmailDomainsDomainIdVerifyPostParams, reqEditors ...RequestEditorFn) (*VerifyEmailDomainEmailDomainsDomainIdVerifyPostResponse, error)
+	// VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostWithResponse request
+	VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostWithResponse(ctx context.Context, domainId openapi_types.UUID, params *VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostParams, reqEditors ...RequestEditorFn) (*VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostResponse, error)
 
-	// ListEmailsEmailsGetWithResponse request
-	ListEmailsEmailsGetWithResponse(ctx context.Context, params *ListEmailsEmailsGetParams, reqEditors ...RequestEditorFn) (*ListEmailsEmailsGetResponse, error)
+	// ListEmailsV1EmailsGetWithResponse request
+	ListEmailsV1EmailsGetWithResponse(ctx context.Context, params *ListEmailsV1EmailsGetParams, reqEditors ...RequestEditorFn) (*ListEmailsV1EmailsGetResponse, error)
 
-	// CreateEmailEmailsPostWithBodyWithResponse request with any body
-	CreateEmailEmailsPostWithBodyWithResponse(ctx context.Context, params *CreateEmailEmailsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateEmailEmailsPostResponse, error)
+	// CreateEmailV1EmailsPostWithBodyWithResponse request with any body
+	CreateEmailV1EmailsPostWithBodyWithResponse(ctx context.Context, params *CreateEmailV1EmailsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateEmailV1EmailsPostResponse, error)
 
-	CreateEmailEmailsPostWithResponse(ctx context.Context, params *CreateEmailEmailsPostParams, body CreateEmailEmailsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateEmailEmailsPostResponse, error)
+	CreateEmailV1EmailsPostWithResponse(ctx context.Context, params *CreateEmailV1EmailsPostParams, body CreateEmailV1EmailsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateEmailV1EmailsPostResponse, error)
 
-	// GetEmailStatsEmailsStatsGetWithResponse request
-	GetEmailStatsEmailsStatsGetWithResponse(ctx context.Context, params *GetEmailStatsEmailsStatsGetParams, reqEditors ...RequestEditorFn) (*GetEmailStatsEmailsStatsGetResponse, error)
+	// GetEmailStatsV1EmailsStatsGetWithResponse request
+	GetEmailStatsV1EmailsStatsGetWithResponse(ctx context.Context, params *GetEmailStatsV1EmailsStatsGetParams, reqEditors ...RequestEditorFn) (*GetEmailStatsV1EmailsStatsGetResponse, error)
 
-	// GetEmailEmailsEmailIdGetWithResponse request
-	GetEmailEmailsEmailIdGetWithResponse(ctx context.Context, emailId openapi_types.UUID, params *GetEmailEmailsEmailIdGetParams, reqEditors ...RequestEditorFn) (*GetEmailEmailsEmailIdGetResponse, error)
+	// GetEmailV1EmailsEmailIdGetWithResponse request
+	GetEmailV1EmailsEmailIdGetWithResponse(ctx context.Context, emailId openapi_types.UUID, params *GetEmailV1EmailsEmailIdGetParams, reqEditors ...RequestEditorFn) (*GetEmailV1EmailsEmailIdGetResponse, error)
 
-	// GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetWithResponse request
-	GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetWithResponse(ctx context.Context, emailId openapi_types.UUID, attachmentId openapi_types.UUID, params *GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetParams, reqEditors ...RequestEditorFn) (*GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetResponse, error)
+	// GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetWithResponse request
+	GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetWithResponse(ctx context.Context, emailId openapi_types.UUID, attachmentId openapi_types.UUID, params *GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetParams, reqEditors ...RequestEditorFn) (*GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetResponse, error)
 
-	// ListEmailEventsEmailsEmailIdEventsGetWithResponse request
-	ListEmailEventsEmailsEmailIdEventsGetWithResponse(ctx context.Context, emailId openapi_types.UUID, params *ListEmailEventsEmailsEmailIdEventsGetParams, reqEditors ...RequestEditorFn) (*ListEmailEventsEmailsEmailIdEventsGetResponse, error)
+	// ListEmailEventsV1EmailsEmailIdEventsGetWithResponse request
+	ListEmailEventsV1EmailsEmailIdEventsGetWithResponse(ctx context.Context, emailId openapi_types.UUID, params *ListEmailEventsV1EmailsEmailIdEventsGetParams, reqEditors ...RequestEditorFn) (*ListEmailEventsV1EmailsEmailIdEventsGetResponse, error)
 
-	// GetEmailRawEmailsEmailIdRawGetWithResponse request
-	GetEmailRawEmailsEmailIdRawGetWithResponse(ctx context.Context, emailId openapi_types.UUID, params *GetEmailRawEmailsEmailIdRawGetParams, reqEditors ...RequestEditorFn) (*GetEmailRawEmailsEmailIdRawGetResponse, error)
+	// GetEmailRawV1EmailsEmailIdRawGetWithResponse request
+	GetEmailRawV1EmailsEmailIdRawGetWithResponse(ctx context.Context, emailId openapi_types.UUID, params *GetEmailRawV1EmailsEmailIdRawGetParams, reqEditors ...RequestEditorFn) (*GetEmailRawV1EmailsEmailIdRawGetResponse, error)
 
-	// ListEventsEventsGetWithResponse request
-	ListEventsEventsGetWithResponse(ctx context.Context, params *ListEventsEventsGetParams, reqEditors ...RequestEditorFn) (*ListEventsEventsGetResponse, error)
+	// ListEventsV1EventsGetWithResponse request
+	ListEventsV1EventsGetWithResponse(ctx context.Context, params *ListEventsV1EventsGetParams, reqEditors ...RequestEditorFn) (*ListEventsV1EventsGetResponse, error)
 
-	// HealthzHealthzGetWithResponse request
-	HealthzHealthzGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*HealthzHealthzGetResponse, error)
+	// DeleteMemberPhoneV1MembersUserIdPhoneDeleteWithResponse request
+	DeleteMemberPhoneV1MembersUserIdPhoneDeleteWithResponse(ctx context.Context, userId string, params *DeleteMemberPhoneV1MembersUserIdPhoneDeleteParams, reqEditors ...RequestEditorFn) (*DeleteMemberPhoneV1MembersUserIdPhoneDeleteResponse, error)
 
-	// DeleteMemberPhoneMembersUserIdPhoneDeleteWithResponse request
-	DeleteMemberPhoneMembersUserIdPhoneDeleteWithResponse(ctx context.Context, userId string, params *DeleteMemberPhoneMembersUserIdPhoneDeleteParams, reqEditors ...RequestEditorFn) (*DeleteMemberPhoneMembersUserIdPhoneDeleteResponse, error)
+	// PutMemberPhoneV1MembersUserIdPhonePutWithBodyWithResponse request with any body
+	PutMemberPhoneV1MembersUserIdPhonePutWithBodyWithResponse(ctx context.Context, userId string, params *PutMemberPhoneV1MembersUserIdPhonePutParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutMemberPhoneV1MembersUserIdPhonePutResponse, error)
 
-	// PutMemberPhoneMembersUserIdPhonePutWithBodyWithResponse request with any body
-	PutMemberPhoneMembersUserIdPhonePutWithBodyWithResponse(ctx context.Context, userId string, params *PutMemberPhoneMembersUserIdPhonePutParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutMemberPhoneMembersUserIdPhonePutResponse, error)
+	PutMemberPhoneV1MembersUserIdPhonePutWithResponse(ctx context.Context, userId string, params *PutMemberPhoneV1MembersUserIdPhonePutParams, body PutMemberPhoneV1MembersUserIdPhonePutJSONRequestBody, reqEditors ...RequestEditorFn) (*PutMemberPhoneV1MembersUserIdPhonePutResponse, error)
 
-	PutMemberPhoneMembersUserIdPhonePutWithResponse(ctx context.Context, userId string, params *PutMemberPhoneMembersUserIdPhonePutParams, body PutMemberPhoneMembersUserIdPhonePutJSONRequestBody, reqEditors ...RequestEditorFn) (*PutMemberPhoneMembersUserIdPhonePutResponse, error)
+	// ListNumbersV1NumbersGetWithResponse request
+	ListNumbersV1NumbersGetWithResponse(ctx context.Context, params *ListNumbersV1NumbersGetParams, reqEditors ...RequestEditorFn) (*ListNumbersV1NumbersGetResponse, error)
 
-	// ListNumbersNumbersGetWithResponse request
-	ListNumbersNumbersGetWithResponse(ctx context.Context, params *ListNumbersNumbersGetParams, reqEditors ...RequestEditorFn) (*ListNumbersNumbersGetResponse, error)
+	// AcquireNumberV1NumbersPostWithBodyWithResponse request with any body
+	AcquireNumberV1NumbersPostWithBodyWithResponse(ctx context.Context, params *AcquireNumberV1NumbersPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AcquireNumberV1NumbersPostResponse, error)
 
-	// AcquireNumberNumbersPostWithBodyWithResponse request with any body
-	AcquireNumberNumbersPostWithBodyWithResponse(ctx context.Context, params *AcquireNumberNumbersPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AcquireNumberNumbersPostResponse, error)
+	AcquireNumberV1NumbersPostWithResponse(ctx context.Context, params *AcquireNumberV1NumbersPostParams, body AcquireNumberV1NumbersPostJSONRequestBody, reqEditors ...RequestEditorFn) (*AcquireNumberV1NumbersPostResponse, error)
 
-	AcquireNumberNumbersPostWithResponse(ctx context.Context, params *AcquireNumberNumbersPostParams, body AcquireNumberNumbersPostJSONRequestBody, reqEditors ...RequestEditorFn) (*AcquireNumberNumbersPostResponse, error)
+	// ReleaseNumberV1NumbersNumberIdDeleteWithResponse request
+	ReleaseNumberV1NumbersNumberIdDeleteWithResponse(ctx context.Context, numberId openapi_types.UUID, params *ReleaseNumberV1NumbersNumberIdDeleteParams, reqEditors ...RequestEditorFn) (*ReleaseNumberV1NumbersNumberIdDeleteResponse, error)
 
-	// ReleaseNumberNumbersNumberIdDeleteWithResponse request
-	ReleaseNumberNumbersNumberIdDeleteWithResponse(ctx context.Context, numberId openapi_types.UUID, params *ReleaseNumberNumbersNumberIdDeleteParams, reqEditors ...RequestEditorFn) (*ReleaseNumberNumbersNumberIdDeleteResponse, error)
+	// GetNumberV1NumbersNumberIdGetWithResponse request
+	GetNumberV1NumbersNumberIdGetWithResponse(ctx context.Context, numberId openapi_types.UUID, params *GetNumberV1NumbersNumberIdGetParams, reqEditors ...RequestEditorFn) (*GetNumberV1NumbersNumberIdGetResponse, error)
 
-	// GetNumberNumbersNumberIdGetWithResponse request
-	GetNumberNumbersNumberIdGetWithResponse(ctx context.Context, numberId openapi_types.UUID, params *GetNumberNumbersNumberIdGetParams, reqEditors ...RequestEditorFn) (*GetNumberNumbersNumberIdGetResponse, error)
-
-	// EnableSmsNumbersNumberIdEnableSmsPostWithResponse request
-	EnableSmsNumbersNumberIdEnableSmsPostWithResponse(ctx context.Context, numberId openapi_types.UUID, params *EnableSmsNumbersNumberIdEnableSmsPostParams, reqEditors ...RequestEditorFn) (*EnableSmsNumbersNumberIdEnableSmsPostResponse, error)
+	// EnableSmsV1NumbersNumberIdEnableSmsPostWithResponse request
+	EnableSmsV1NumbersNumberIdEnableSmsPostWithResponse(ctx context.Context, numberId openapi_types.UUID, params *EnableSmsV1NumbersNumberIdEnableSmsPostParams, reqEditors ...RequestEditorFn) (*EnableSmsV1NumbersNumberIdEnableSmsPostResponse, error)
 
 	// ListProvidersWithResponse request
 	ListProvidersWithResponse(ctx context.Context, params *ListProvidersParams, reqEditors ...RequestEditorFn) (*ListProvidersResponse, error)
@@ -6864,67 +7438,89 @@ type ClientWithResponsesInterface interface {
 	// DeleteProviderWithResponse request
 	DeleteProviderWithResponse(ctx context.Context, layer string, provider string, params *DeleteProviderParams, reqEditors ...RequestEditorFn) (*DeleteProviderResponse, error)
 
-	// ListSmsSmsGetWithResponse request
-	ListSmsSmsGetWithResponse(ctx context.Context, params *ListSmsSmsGetParams, reqEditors ...RequestEditorFn) (*ListSmsSmsGetResponse, error)
+	// ListSmsV1SmsGetWithResponse request
+	ListSmsV1SmsGetWithResponse(ctx context.Context, params *ListSmsV1SmsGetParams, reqEditors ...RequestEditorFn) (*ListSmsV1SmsGetResponse, error)
 
-	// CreateSmsSmsPostWithBodyWithResponse request with any body
-	CreateSmsSmsPostWithBodyWithResponse(ctx context.Context, params *CreateSmsSmsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSmsSmsPostResponse, error)
+	// CreateSmsV1SmsPostWithBodyWithResponse request with any body
+	CreateSmsV1SmsPostWithBodyWithResponse(ctx context.Context, params *CreateSmsV1SmsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSmsV1SmsPostResponse, error)
 
-	CreateSmsSmsPostWithResponse(ctx context.Context, params *CreateSmsSmsPostParams, body CreateSmsSmsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateSmsSmsPostResponse, error)
+	CreateSmsV1SmsPostWithResponse(ctx context.Context, params *CreateSmsV1SmsPostParams, body CreateSmsV1SmsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateSmsV1SmsPostResponse, error)
 
-	// GetSenderIdSmsSenderIdGetWithResponse request
-	GetSenderIdSmsSenderIdGetWithResponse(ctx context.Context, params *GetSenderIdSmsSenderIdGetParams, reqEditors ...RequestEditorFn) (*GetSenderIdSmsSenderIdGetResponse, error)
+	// GetSenderIdV1SmsSenderIdGetWithResponse request
+	GetSenderIdV1SmsSenderIdGetWithResponse(ctx context.Context, params *GetSenderIdV1SmsSenderIdGetParams, reqEditors ...RequestEditorFn) (*GetSenderIdV1SmsSenderIdGetResponse, error)
 
-	// PatchSenderIdSmsSenderIdPatchWithBodyWithResponse request with any body
-	PatchSenderIdSmsSenderIdPatchWithBodyWithResponse(ctx context.Context, params *PatchSenderIdSmsSenderIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchSenderIdSmsSenderIdPatchResponse, error)
+	// PatchSenderIdV1SmsSenderIdPatchWithBodyWithResponse request with any body
+	PatchSenderIdV1SmsSenderIdPatchWithBodyWithResponse(ctx context.Context, params *PatchSenderIdV1SmsSenderIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchSenderIdV1SmsSenderIdPatchResponse, error)
 
-	PatchSenderIdSmsSenderIdPatchWithResponse(ctx context.Context, params *PatchSenderIdSmsSenderIdPatchParams, body PatchSenderIdSmsSenderIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchSenderIdSmsSenderIdPatchResponse, error)
+	PatchSenderIdV1SmsSenderIdPatchWithResponse(ctx context.Context, params *PatchSenderIdV1SmsSenderIdPatchParams, body PatchSenderIdV1SmsSenderIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchSenderIdV1SmsSenderIdPatchResponse, error)
 
-	// ListSmsSuppressionsSmsSuppressionsGetWithResponse request
-	ListSmsSuppressionsSmsSuppressionsGetWithResponse(ctx context.Context, params *ListSmsSuppressionsSmsSuppressionsGetParams, reqEditors ...RequestEditorFn) (*ListSmsSuppressionsSmsSuppressionsGetResponse, error)
+	// ListSmsSuppressionsV1SmsSuppressionsGetWithResponse request
+	ListSmsSuppressionsV1SmsSuppressionsGetWithResponse(ctx context.Context, params *ListSmsSuppressionsV1SmsSuppressionsGetParams, reqEditors ...RequestEditorFn) (*ListSmsSuppressionsV1SmsSuppressionsGetResponse, error)
 
-	// DeleteSmsSuppressionSmsSuppressionsNumberDeleteWithResponse request
-	DeleteSmsSuppressionSmsSuppressionsNumberDeleteWithResponse(ctx context.Context, number string, params *DeleteSmsSuppressionSmsSuppressionsNumberDeleteParams, reqEditors ...RequestEditorFn) (*DeleteSmsSuppressionSmsSuppressionsNumberDeleteResponse, error)
+	// DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteWithResponse request
+	DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteWithResponse(ctx context.Context, number string, params *DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteParams, reqEditors ...RequestEditorFn) (*DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteResponse, error)
 
-	// GetSmsSmsSmsIdGetWithResponse request
-	GetSmsSmsSmsIdGetWithResponse(ctx context.Context, smsId openapi_types.UUID, params *GetSmsSmsSmsIdGetParams, reqEditors ...RequestEditorFn) (*GetSmsSmsSmsIdGetResponse, error)
+	// GetSmsV1SmsSmsIdGetWithResponse request
+	GetSmsV1SmsSmsIdGetWithResponse(ctx context.Context, smsId openapi_types.UUID, params *GetSmsV1SmsSmsIdGetParams, reqEditors ...RequestEditorFn) (*GetSmsV1SmsSmsIdGetResponse, error)
 
-	// UnsubscribeUnsubscribeGetWithResponse request
-	UnsubscribeUnsubscribeGetWithResponse(ctx context.Context, params *UnsubscribeUnsubscribeGetParams, reqEditors ...RequestEditorFn) (*UnsubscribeUnsubscribeGetResponse, error)
+	// UnsubscribeV1UnsubscribeGetWithResponse request
+	UnsubscribeV1UnsubscribeGetWithResponse(ctx context.Context, params *UnsubscribeV1UnsubscribeGetParams, reqEditors ...RequestEditorFn) (*UnsubscribeV1UnsubscribeGetResponse, error)
 
-	// ListSubscriptionsWebhooksGetWithResponse request
-	ListSubscriptionsWebhooksGetWithResponse(ctx context.Context, params *ListSubscriptionsWebhooksGetParams, reqEditors ...RequestEditorFn) (*ListSubscriptionsWebhooksGetResponse, error)
+	// ListSubscriptionsV1WebhooksGetWithResponse request
+	ListSubscriptionsV1WebhooksGetWithResponse(ctx context.Context, params *ListSubscriptionsV1WebhooksGetParams, reqEditors ...RequestEditorFn) (*ListSubscriptionsV1WebhooksGetResponse, error)
 
-	// CreateSubscriptionWebhooksPostWithBodyWithResponse request with any body
-	CreateSubscriptionWebhooksPostWithBodyWithResponse(ctx context.Context, params *CreateSubscriptionWebhooksPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSubscriptionWebhooksPostResponse, error)
+	// CreateSubscriptionV1WebhooksPostWithBodyWithResponse request with any body
+	CreateSubscriptionV1WebhooksPostWithBodyWithResponse(ctx context.Context, params *CreateSubscriptionV1WebhooksPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSubscriptionV1WebhooksPostResponse, error)
 
-	CreateSubscriptionWebhooksPostWithResponse(ctx context.Context, params *CreateSubscriptionWebhooksPostParams, body CreateSubscriptionWebhooksPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateSubscriptionWebhooksPostResponse, error)
+	CreateSubscriptionV1WebhooksPostWithResponse(ctx context.Context, params *CreateSubscriptionV1WebhooksPostParams, body CreateSubscriptionV1WebhooksPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateSubscriptionV1WebhooksPostResponse, error)
 
-	// DeleteSubscriptionWebhooksSubIdDeleteWithResponse request
-	DeleteSubscriptionWebhooksSubIdDeleteWithResponse(ctx context.Context, subId openapi_types.UUID, params *DeleteSubscriptionWebhooksSubIdDeleteParams, reqEditors ...RequestEditorFn) (*DeleteSubscriptionWebhooksSubIdDeleteResponse, error)
+	// DeleteSubscriptionV1WebhooksSubIdDeleteWithResponse request
+	DeleteSubscriptionV1WebhooksSubIdDeleteWithResponse(ctx context.Context, subId openapi_types.UUID, params *DeleteSubscriptionV1WebhooksSubIdDeleteParams, reqEditors ...RequestEditorFn) (*DeleteSubscriptionV1WebhooksSubIdDeleteResponse, error)
 
-	// GetSubscriptionWebhooksSubIdGetWithResponse request
-	GetSubscriptionWebhooksSubIdGetWithResponse(ctx context.Context, subId openapi_types.UUID, params *GetSubscriptionWebhooksSubIdGetParams, reqEditors ...RequestEditorFn) (*GetSubscriptionWebhooksSubIdGetResponse, error)
+	// GetSubscriptionV1WebhooksSubIdGetWithResponse request
+	GetSubscriptionV1WebhooksSubIdGetWithResponse(ctx context.Context, subId openapi_types.UUID, params *GetSubscriptionV1WebhooksSubIdGetParams, reqEditors ...RequestEditorFn) (*GetSubscriptionV1WebhooksSubIdGetResponse, error)
 
-	// PatchSubscriptionWebhooksSubIdPatchWithBodyWithResponse request with any body
-	PatchSubscriptionWebhooksSubIdPatchWithBodyWithResponse(ctx context.Context, subId openapi_types.UUID, params *PatchSubscriptionWebhooksSubIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchSubscriptionWebhooksSubIdPatchResponse, error)
+	// PatchSubscriptionV1WebhooksSubIdPatchWithBodyWithResponse request with any body
+	PatchSubscriptionV1WebhooksSubIdPatchWithBodyWithResponse(ctx context.Context, subId openapi_types.UUID, params *PatchSubscriptionV1WebhooksSubIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchSubscriptionV1WebhooksSubIdPatchResponse, error)
 
-	PatchSubscriptionWebhooksSubIdPatchWithResponse(ctx context.Context, subId openapi_types.UUID, params *PatchSubscriptionWebhooksSubIdPatchParams, body PatchSubscriptionWebhooksSubIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchSubscriptionWebhooksSubIdPatchResponse, error)
+	PatchSubscriptionV1WebhooksSubIdPatchWithResponse(ctx context.Context, subId openapi_types.UUID, params *PatchSubscriptionV1WebhooksSubIdPatchParams, body PatchSubscriptionV1WebhooksSubIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchSubscriptionV1WebhooksSubIdPatchResponse, error)
 
-	// ListDeliveriesWebhooksSubIdDeliveriesGetWithResponse request
-	ListDeliveriesWebhooksSubIdDeliveriesGetWithResponse(ctx context.Context, subId openapi_types.UUID, params *ListDeliveriesWebhooksSubIdDeliveriesGetParams, reqEditors ...RequestEditorFn) (*ListDeliveriesWebhooksSubIdDeliveriesGetResponse, error)
+	// ListDeliveriesV1WebhooksSubIdDeliveriesGetWithResponse request
+	ListDeliveriesV1WebhooksSubIdDeliveriesGetWithResponse(ctx context.Context, subId openapi_types.UUID, params *ListDeliveriesV1WebhooksSubIdDeliveriesGetParams, reqEditors ...RequestEditorFn) (*ListDeliveriesV1WebhooksSubIdDeliveriesGetResponse, error)
 
-	// RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostWithResponse request
-	RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostWithResponse(ctx context.Context, subId openapi_types.UUID, deliveryId openapi_types.UUID, params *RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostParams, reqEditors ...RequestEditorFn) (*RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse, error)
+	// RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostWithResponse request
+	RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostWithResponse(ctx context.Context, subId openapi_types.UUID, deliveryId openapi_types.UUID, params *RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostParams, reqEditors ...RequestEditorFn) (*RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse, error)
 
-	// RotateSecretWebhooksSubIdRotateSecretPostWithResponse request
-	RotateSecretWebhooksSubIdRotateSecretPostWithResponse(ctx context.Context, subId openapi_types.UUID, params *RotateSecretWebhooksSubIdRotateSecretPostParams, reqEditors ...RequestEditorFn) (*RotateSecretWebhooksSubIdRotateSecretPostResponse, error)
+	// RotateSecretV1WebhooksSubIdRotateSecretPostWithResponse request
+	RotateSecretV1WebhooksSubIdRotateSecretPostWithResponse(ctx context.Context, subId openapi_types.UUID, params *RotateSecretV1WebhooksSubIdRotateSecretPostParams, reqEditors ...RequestEditorFn) (*RotateSecretV1WebhooksSubIdRotateSecretPostResponse, error)
 
-	// GetWhoamiWhoamiGetWithResponse request
-	GetWhoamiWhoamiGetWithResponse(ctx context.Context, params *GetWhoamiWhoamiGetParams, reqEditors ...RequestEditorFn) (*GetWhoamiWhoamiGetResponse, error)
+	// GetWhoamiV1WhoamiGetWithResponse request
+	GetWhoamiV1WhoamiGetWithResponse(ctx context.Context, params *GetWhoamiV1WhoamiGetParams, reqEditors ...RequestEditorFn) (*GetWhoamiV1WhoamiGetResponse, error)
 }
 
-type ListCallsCallsGetResponse struct {
+type HealthzHealthzGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string]string
+}
+
+// Status returns HTTPResponse.Status
+func (r HealthzHealthzGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r HealthzHealthzGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListCallsV1CallsGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *CallListResponse
@@ -6932,7 +7528,7 @@ type ListCallsCallsGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ListCallsCallsGetResponse) Status() string {
+func (r ListCallsV1CallsGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -6940,14 +7536,14 @@ func (r ListCallsCallsGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ListCallsCallsGetResponse) StatusCode() int {
+func (r ListCallsV1CallsGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type CreateCallCallsPostResponse struct {
+type CreateCallV1CallsPostResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON201      *CallResponse
@@ -6955,7 +7551,7 @@ type CreateCallCallsPostResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r CreateCallCallsPostResponse) Status() string {
+func (r CreateCallV1CallsPostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -6963,14 +7559,14 @@ func (r CreateCallCallsPostResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r CreateCallCallsPostResponse) StatusCode() int {
+func (r CreateCallV1CallsPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetCallCallsCallIdGetResponse struct {
+type GetCallV1CallsCallIdGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *CallResponse
@@ -6978,7 +7574,7 @@ type GetCallCallsCallIdGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetCallCallsCallIdGetResponse) Status() string {
+func (r GetCallV1CallsCallIdGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -6986,14 +7582,14 @@ func (r GetCallCallsCallIdGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetCallCallsCallIdGetResponse) StatusCode() int {
+func (r GetCallV1CallsCallIdGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type ListContactsContactsGetResponse struct {
+type ListContactsV1ContactsGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *ContactListResponse
@@ -7001,7 +7597,7 @@ type ListContactsContactsGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ListContactsContactsGetResponse) Status() string {
+func (r ListContactsV1ContactsGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7009,14 +7605,14 @@ func (r ListContactsContactsGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ListContactsContactsGetResponse) StatusCode() int {
+func (r ListContactsV1ContactsGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type CreateContactContactsPostResponse struct {
+type CreateContactV1ContactsPostResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON201      *ContactEntry
@@ -7024,7 +7620,7 @@ type CreateContactContactsPostResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r CreateContactContactsPostResponse) Status() string {
+func (r CreateContactV1ContactsPostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7032,21 +7628,21 @@ func (r CreateContactContactsPostResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r CreateContactContactsPostResponse) StatusCode() int {
+func (r CreateContactV1ContactsPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type DeleteContactContactsContactIdDeleteResponse struct {
+type DeleteContactV1ContactsContactIdDeleteResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON422      *HTTPValidationError
 }
 
 // Status returns HTTPResponse.Status
-func (r DeleteContactContactsContactIdDeleteResponse) Status() string {
+func (r DeleteContactV1ContactsContactIdDeleteResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7054,14 +7650,14 @@ func (r DeleteContactContactsContactIdDeleteResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r DeleteContactContactsContactIdDeleteResponse) StatusCode() int {
+func (r DeleteContactV1ContactsContactIdDeleteResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type PatchContactContactsContactIdPatchResponse struct {
+type PatchContactV1ContactsContactIdPatchResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *ContactEntry
@@ -7069,7 +7665,7 @@ type PatchContactContactsContactIdPatchResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r PatchContactContactsContactIdPatchResponse) Status() string {
+func (r PatchContactV1ContactsContactIdPatchResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7077,7 +7673,7 @@ func (r PatchContactContactsContactIdPatchResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PatchContactContactsContactIdPatchResponse) StatusCode() int {
+func (r PatchContactV1ContactsContactIdPatchResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -7107,7 +7703,7 @@ func (r UploadEmailAttachmentResponse) StatusCode() int {
 	return 0
 }
 
-type ListEmailDomainsEmailDomainsGetResponse struct {
+type ListEmailDomainsV1EmailDomainsGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *EmailDomainListResponse
@@ -7115,7 +7711,7 @@ type ListEmailDomainsEmailDomainsGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ListEmailDomainsEmailDomainsGetResponse) Status() string {
+func (r ListEmailDomainsV1EmailDomainsGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7123,14 +7719,14 @@ func (r ListEmailDomainsEmailDomainsGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ListEmailDomainsEmailDomainsGetResponse) StatusCode() int {
+func (r ListEmailDomainsV1EmailDomainsGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type CreateEmailDomainEmailDomainsPostResponse struct {
+type CreateEmailDomainV1EmailDomainsPostResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON201      *EmailDomainResponse
@@ -7138,7 +7734,7 @@ type CreateEmailDomainEmailDomainsPostResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r CreateEmailDomainEmailDomainsPostResponse) Status() string {
+func (r CreateEmailDomainV1EmailDomainsPostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7146,14 +7742,14 @@ func (r CreateEmailDomainEmailDomainsPostResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r CreateEmailDomainEmailDomainsPostResponse) StatusCode() int {
+func (r CreateEmailDomainV1EmailDomainsPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type CheckDomainEmailDomainsCheckDomainGetResponse struct {
+type CheckDomainV1EmailDomainsCheckDomainGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *DomainCheckResponse
@@ -7161,7 +7757,7 @@ type CheckDomainEmailDomainsCheckDomainGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r CheckDomainEmailDomainsCheckDomainGetResponse) Status() string {
+func (r CheckDomainV1EmailDomainsCheckDomainGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7169,21 +7765,21 @@ func (r CheckDomainEmailDomainsCheckDomainGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r CheckDomainEmailDomainsCheckDomainGetResponse) StatusCode() int {
+func (r CheckDomainV1EmailDomainsCheckDomainGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type DeleteEmailDomainEmailDomainsDomainIdDeleteResponse struct {
+type DeleteEmailDomainV1EmailDomainsDomainIdDeleteResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON422      *HTTPValidationError
 }
 
 // Status returns HTTPResponse.Status
-func (r DeleteEmailDomainEmailDomainsDomainIdDeleteResponse) Status() string {
+func (r DeleteEmailDomainV1EmailDomainsDomainIdDeleteResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7191,37 +7787,14 @@ func (r DeleteEmailDomainEmailDomainsDomainIdDeleteResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r DeleteEmailDomainEmailDomainsDomainIdDeleteResponse) StatusCode() int {
+func (r DeleteEmailDomainV1EmailDomainsDomainIdDeleteResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetEmailDomainEmailDomainsDomainIdGetResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *EmailDomainResponse
-	JSON422      *HTTPValidationError
-}
-
-// Status returns HTTPResponse.Status
-func (r GetEmailDomainEmailDomainsDomainIdGetResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetEmailDomainEmailDomainsDomainIdGetResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type PatchEmailDomainEmailDomainsDomainIdPatchResponse struct {
+type GetEmailDomainV1EmailDomainsDomainIdGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *EmailDomainResponse
@@ -7229,7 +7802,7 @@ type PatchEmailDomainEmailDomainsDomainIdPatchResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r PatchEmailDomainEmailDomainsDomainIdPatchResponse) Status() string {
+func (r GetEmailDomainV1EmailDomainsDomainIdGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7237,14 +7810,14 @@ func (r PatchEmailDomainEmailDomainsDomainIdPatchResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PatchEmailDomainEmailDomainsDomainIdPatchResponse) StatusCode() int {
+func (r GetEmailDomainV1EmailDomainsDomainIdGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type VerifyEmailDomainEmailDomainsDomainIdVerifyPostResponse struct {
+type PatchEmailDomainV1EmailDomainsDomainIdPatchResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *EmailDomainResponse
@@ -7252,7 +7825,7 @@ type VerifyEmailDomainEmailDomainsDomainIdVerifyPostResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r VerifyEmailDomainEmailDomainsDomainIdVerifyPostResponse) Status() string {
+func (r PatchEmailDomainV1EmailDomainsDomainIdPatchResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7260,14 +7833,37 @@ func (r VerifyEmailDomainEmailDomainsDomainIdVerifyPostResponse) Status() string
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r VerifyEmailDomainEmailDomainsDomainIdVerifyPostResponse) StatusCode() int {
+func (r PatchEmailDomainV1EmailDomainsDomainIdPatchResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type ListEmailsEmailsGetResponse struct {
+type VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *EmailDomainResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListEmailsV1EmailsGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *EmailListResponse
@@ -7275,7 +7871,7 @@ type ListEmailsEmailsGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ListEmailsEmailsGetResponse) Status() string {
+func (r ListEmailsV1EmailsGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7283,14 +7879,14 @@ func (r ListEmailsEmailsGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ListEmailsEmailsGetResponse) StatusCode() int {
+func (r ListEmailsV1EmailsGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type CreateEmailEmailsPostResponse struct {
+type CreateEmailV1EmailsPostResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON201      *EmailResponse
@@ -7298,7 +7894,7 @@ type CreateEmailEmailsPostResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r CreateEmailEmailsPostResponse) Status() string {
+func (r CreateEmailV1EmailsPostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7306,14 +7902,14 @@ func (r CreateEmailEmailsPostResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r CreateEmailEmailsPostResponse) StatusCode() int {
+func (r CreateEmailV1EmailsPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetEmailStatsEmailsStatsGetResponse struct {
+type GetEmailStatsV1EmailsStatsGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *EmailStatsResponse
@@ -7321,7 +7917,7 @@ type GetEmailStatsEmailsStatsGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetEmailStatsEmailsStatsGetResponse) Status() string {
+func (r GetEmailStatsV1EmailsStatsGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7329,14 +7925,14 @@ func (r GetEmailStatsEmailsStatsGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetEmailStatsEmailsStatsGetResponse) StatusCode() int {
+func (r GetEmailStatsV1EmailsStatsGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetEmailEmailsEmailIdGetResponse struct {
+type GetEmailV1EmailsEmailIdGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *EmailResponse
@@ -7344,7 +7940,7 @@ type GetEmailEmailsEmailIdGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetEmailEmailsEmailIdGetResponse) Status() string {
+func (r GetEmailV1EmailsEmailIdGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7352,14 +7948,14 @@ func (r GetEmailEmailsEmailIdGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetEmailEmailsEmailIdGetResponse) StatusCode() int {
+func (r GetEmailV1EmailsEmailIdGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetResponse struct {
+type GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *interface{}
@@ -7367,7 +7963,7 @@ type GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetResponse) Status() string {
+func (r GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7375,14 +7971,14 @@ func (r GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetResponse) Statu
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetResponse) StatusCode() int {
+func (r GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type ListEmailEventsEmailsEmailIdEventsGetResponse struct {
+type ListEmailEventsV1EmailsEmailIdEventsGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *EmailEventListResponse
@@ -7390,7 +7986,7 @@ type ListEmailEventsEmailsEmailIdEventsGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ListEmailEventsEmailsEmailIdEventsGetResponse) Status() string {
+func (r ListEmailEventsV1EmailsEmailIdEventsGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7398,14 +7994,14 @@ func (r ListEmailEventsEmailsEmailIdEventsGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ListEmailEventsEmailsEmailIdEventsGetResponse) StatusCode() int {
+func (r ListEmailEventsV1EmailsEmailIdEventsGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetEmailRawEmailsEmailIdRawGetResponse struct {
+type GetEmailRawV1EmailsEmailIdRawGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *interface{}
@@ -7413,7 +8009,7 @@ type GetEmailRawEmailsEmailIdRawGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetEmailRawEmailsEmailIdRawGetResponse) Status() string {
+func (r GetEmailRawV1EmailsEmailIdRawGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7421,14 +8017,14 @@ func (r GetEmailRawEmailsEmailIdRawGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetEmailRawEmailsEmailIdRawGetResponse) StatusCode() int {
+func (r GetEmailRawV1EmailsEmailIdRawGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type ListEventsEventsGetResponse struct {
+type ListEventsV1EventsGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *EventStreamResponse
@@ -7436,7 +8032,7 @@ type ListEventsEventsGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ListEventsEventsGetResponse) Status() string {
+func (r ListEventsV1EventsGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7444,43 +8040,21 @@ func (r ListEventsEventsGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ListEventsEventsGetResponse) StatusCode() int {
+func (r ListEventsV1EventsGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type HealthzHealthzGetResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *map[string]string
-}
-
-// Status returns HTTPResponse.Status
-func (r HealthzHealthzGetResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r HealthzHealthzGetResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type DeleteMemberPhoneMembersUserIdPhoneDeleteResponse struct {
+type DeleteMemberPhoneV1MembersUserIdPhoneDeleteResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON422      *HTTPValidationError
 }
 
 // Status returns HTTPResponse.Status
-func (r DeleteMemberPhoneMembersUserIdPhoneDeleteResponse) Status() string {
+func (r DeleteMemberPhoneV1MembersUserIdPhoneDeleteResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7488,14 +8062,14 @@ func (r DeleteMemberPhoneMembersUserIdPhoneDeleteResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r DeleteMemberPhoneMembersUserIdPhoneDeleteResponse) StatusCode() int {
+func (r DeleteMemberPhoneV1MembersUserIdPhoneDeleteResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type PutMemberPhoneMembersUserIdPhonePutResponse struct {
+type PutMemberPhoneV1MembersUserIdPhonePutResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *map[string]string
@@ -7503,7 +8077,7 @@ type PutMemberPhoneMembersUserIdPhonePutResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r PutMemberPhoneMembersUserIdPhonePutResponse) Status() string {
+func (r PutMemberPhoneV1MembersUserIdPhonePutResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7511,14 +8085,14 @@ func (r PutMemberPhoneMembersUserIdPhonePutResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PutMemberPhoneMembersUserIdPhonePutResponse) StatusCode() int {
+func (r PutMemberPhoneV1MembersUserIdPhonePutResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type ListNumbersNumbersGetResponse struct {
+type ListNumbersV1NumbersGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *PhoneNumberListResponse
@@ -7526,7 +8100,7 @@ type ListNumbersNumbersGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ListNumbersNumbersGetResponse) Status() string {
+func (r ListNumbersV1NumbersGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7534,14 +8108,14 @@ func (r ListNumbersNumbersGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ListNumbersNumbersGetResponse) StatusCode() int {
+func (r ListNumbersV1NumbersGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type AcquireNumberNumbersPostResponse struct {
+type AcquireNumberV1NumbersPostResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON201      *PhoneNumberResponse
@@ -7549,7 +8123,7 @@ type AcquireNumberNumbersPostResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r AcquireNumberNumbersPostResponse) Status() string {
+func (r AcquireNumberV1NumbersPostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7557,21 +8131,21 @@ func (r AcquireNumberNumbersPostResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r AcquireNumberNumbersPostResponse) StatusCode() int {
+func (r AcquireNumberV1NumbersPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type ReleaseNumberNumbersNumberIdDeleteResponse struct {
+type ReleaseNumberV1NumbersNumberIdDeleteResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON422      *HTTPValidationError
 }
 
 // Status returns HTTPResponse.Status
-func (r ReleaseNumberNumbersNumberIdDeleteResponse) Status() string {
+func (r ReleaseNumberV1NumbersNumberIdDeleteResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7579,37 +8153,14 @@ func (r ReleaseNumberNumbersNumberIdDeleteResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ReleaseNumberNumbersNumberIdDeleteResponse) StatusCode() int {
+func (r ReleaseNumberV1NumbersNumberIdDeleteResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetNumberNumbersNumberIdGetResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *PhoneNumberResponse
-	JSON422      *HTTPValidationError
-}
-
-// Status returns HTTPResponse.Status
-func (r GetNumberNumbersNumberIdGetResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetNumberNumbersNumberIdGetResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type EnableSmsNumbersNumberIdEnableSmsPostResponse struct {
+type GetNumberV1NumbersNumberIdGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *PhoneNumberResponse
@@ -7617,7 +8168,7 @@ type EnableSmsNumbersNumberIdEnableSmsPostResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r EnableSmsNumbersNumberIdEnableSmsPostResponse) Status() string {
+func (r GetNumberV1NumbersNumberIdGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7625,7 +8176,30 @@ func (r EnableSmsNumbersNumberIdEnableSmsPostResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r EnableSmsNumbersNumberIdEnableSmsPostResponse) StatusCode() int {
+func (r GetNumberV1NumbersNumberIdGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type EnableSmsV1NumbersNumberIdEnableSmsPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *PhoneNumberResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r EnableSmsV1NumbersNumberIdEnableSmsPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EnableSmsV1NumbersNumberIdEnableSmsPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -7746,7 +8320,7 @@ func (r DeleteProviderResponse) StatusCode() int {
 	return 0
 }
 
-type ListSmsSmsGetResponse struct {
+type ListSmsV1SmsGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *SmsListResponse
@@ -7754,7 +8328,7 @@ type ListSmsSmsGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ListSmsSmsGetResponse) Status() string {
+func (r ListSmsV1SmsGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7762,14 +8336,14 @@ func (r ListSmsSmsGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ListSmsSmsGetResponse) StatusCode() int {
+func (r ListSmsV1SmsGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type CreateSmsSmsPostResponse struct {
+type CreateSmsV1SmsPostResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON201      *SmsResponse
@@ -7777,7 +8351,7 @@ type CreateSmsSmsPostResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r CreateSmsSmsPostResponse) Status() string {
+func (r CreateSmsV1SmsPostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7785,14 +8359,14 @@ func (r CreateSmsSmsPostResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r CreateSmsSmsPostResponse) StatusCode() int {
+func (r CreateSmsV1SmsPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetSenderIdSmsSenderIdGetResponse struct {
+type GetSenderIdV1SmsSenderIdGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *SenderIdResponse
@@ -7800,7 +8374,7 @@ type GetSenderIdSmsSenderIdGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetSenderIdSmsSenderIdGetResponse) Status() string {
+func (r GetSenderIdV1SmsSenderIdGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7808,14 +8382,14 @@ func (r GetSenderIdSmsSenderIdGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetSenderIdSmsSenderIdGetResponse) StatusCode() int {
+func (r GetSenderIdV1SmsSenderIdGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type PatchSenderIdSmsSenderIdPatchResponse struct {
+type PatchSenderIdV1SmsSenderIdPatchResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *SenderIdResponse
@@ -7823,7 +8397,7 @@ type PatchSenderIdSmsSenderIdPatchResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r PatchSenderIdSmsSenderIdPatchResponse) Status() string {
+func (r PatchSenderIdV1SmsSenderIdPatchResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7831,14 +8405,14 @@ func (r PatchSenderIdSmsSenderIdPatchResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PatchSenderIdSmsSenderIdPatchResponse) StatusCode() int {
+func (r PatchSenderIdV1SmsSenderIdPatchResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type ListSmsSuppressionsSmsSuppressionsGetResponse struct {
+type ListSmsSuppressionsV1SmsSuppressionsGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *SuppressionListResponse
@@ -7846,7 +8420,7 @@ type ListSmsSuppressionsSmsSuppressionsGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ListSmsSuppressionsSmsSuppressionsGetResponse) Status() string {
+func (r ListSmsSuppressionsV1SmsSuppressionsGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7854,21 +8428,21 @@ func (r ListSmsSuppressionsSmsSuppressionsGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ListSmsSuppressionsSmsSuppressionsGetResponse) StatusCode() int {
+func (r ListSmsSuppressionsV1SmsSuppressionsGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type DeleteSmsSuppressionSmsSuppressionsNumberDeleteResponse struct {
+type DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON422      *HTTPValidationError
 }
 
 // Status returns HTTPResponse.Status
-func (r DeleteSmsSuppressionSmsSuppressionsNumberDeleteResponse) Status() string {
+func (r DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7876,14 +8450,14 @@ func (r DeleteSmsSuppressionSmsSuppressionsNumberDeleteResponse) Status() string
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r DeleteSmsSuppressionSmsSuppressionsNumberDeleteResponse) StatusCode() int {
+func (r DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetSmsSmsSmsIdGetResponse struct {
+type GetSmsV1SmsSmsIdGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *SmsResponse
@@ -7891,7 +8465,7 @@ type GetSmsSmsSmsIdGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetSmsSmsSmsIdGetResponse) Status() string {
+func (r GetSmsV1SmsSmsIdGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7899,21 +8473,21 @@ func (r GetSmsSmsSmsIdGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetSmsSmsSmsIdGetResponse) StatusCode() int {
+func (r GetSmsV1SmsSmsIdGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type UnsubscribeUnsubscribeGetResponse struct {
+type UnsubscribeV1UnsubscribeGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON422      *HTTPValidationError
 }
 
 // Status returns HTTPResponse.Status
-func (r UnsubscribeUnsubscribeGetResponse) Status() string {
+func (r UnsubscribeV1UnsubscribeGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7921,14 +8495,14 @@ func (r UnsubscribeUnsubscribeGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r UnsubscribeUnsubscribeGetResponse) StatusCode() int {
+func (r UnsubscribeV1UnsubscribeGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type ListSubscriptionsWebhooksGetResponse struct {
+type ListSubscriptionsV1WebhooksGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *WebhookSubscriptionListResponse
@@ -7936,7 +8510,7 @@ type ListSubscriptionsWebhooksGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ListSubscriptionsWebhooksGetResponse) Status() string {
+func (r ListSubscriptionsV1WebhooksGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7944,14 +8518,14 @@ func (r ListSubscriptionsWebhooksGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ListSubscriptionsWebhooksGetResponse) StatusCode() int {
+func (r ListSubscriptionsV1WebhooksGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type CreateSubscriptionWebhooksPostResponse struct {
+type CreateSubscriptionV1WebhooksPostResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON201      *WebhookSubscriptionResponse
@@ -7959,7 +8533,7 @@ type CreateSubscriptionWebhooksPostResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r CreateSubscriptionWebhooksPostResponse) Status() string {
+func (r CreateSubscriptionV1WebhooksPostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7967,21 +8541,21 @@ func (r CreateSubscriptionWebhooksPostResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r CreateSubscriptionWebhooksPostResponse) StatusCode() int {
+func (r CreateSubscriptionV1WebhooksPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type DeleteSubscriptionWebhooksSubIdDeleteResponse struct {
+type DeleteSubscriptionV1WebhooksSubIdDeleteResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON422      *HTTPValidationError
 }
 
 // Status returns HTTPResponse.Status
-func (r DeleteSubscriptionWebhooksSubIdDeleteResponse) Status() string {
+func (r DeleteSubscriptionV1WebhooksSubIdDeleteResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -7989,37 +8563,14 @@ func (r DeleteSubscriptionWebhooksSubIdDeleteResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r DeleteSubscriptionWebhooksSubIdDeleteResponse) StatusCode() int {
+func (r DeleteSubscriptionV1WebhooksSubIdDeleteResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetSubscriptionWebhooksSubIdGetResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *WebhookSubscriptionResponse
-	JSON422      *HTTPValidationError
-}
-
-// Status returns HTTPResponse.Status
-func (r GetSubscriptionWebhooksSubIdGetResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetSubscriptionWebhooksSubIdGetResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type PatchSubscriptionWebhooksSubIdPatchResponse struct {
+type GetSubscriptionV1WebhooksSubIdGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *WebhookSubscriptionResponse
@@ -8027,7 +8578,7 @@ type PatchSubscriptionWebhooksSubIdPatchResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r PatchSubscriptionWebhooksSubIdPatchResponse) Status() string {
+func (r GetSubscriptionV1WebhooksSubIdGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -8035,14 +8586,37 @@ func (r PatchSubscriptionWebhooksSubIdPatchResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PatchSubscriptionWebhooksSubIdPatchResponse) StatusCode() int {
+func (r GetSubscriptionV1WebhooksSubIdGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type ListDeliveriesWebhooksSubIdDeliveriesGetResponse struct {
+type PatchSubscriptionV1WebhooksSubIdPatchResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *WebhookSubscriptionResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r PatchSubscriptionV1WebhooksSubIdPatchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PatchSubscriptionV1WebhooksSubIdPatchResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListDeliveriesV1WebhooksSubIdDeliveriesGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *WebhookDeliveryListResponse
@@ -8050,7 +8624,7 @@ type ListDeliveriesWebhooksSubIdDeliveriesGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ListDeliveriesWebhooksSubIdDeliveriesGetResponse) Status() string {
+func (r ListDeliveriesV1WebhooksSubIdDeliveriesGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -8058,14 +8632,14 @@ func (r ListDeliveriesWebhooksSubIdDeliveriesGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ListDeliveriesWebhooksSubIdDeliveriesGetResponse) StatusCode() int {
+func (r ListDeliveriesV1WebhooksSubIdDeliveriesGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse struct {
+type RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *WebhookDeliveryResponse
@@ -8073,7 +8647,7 @@ type RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse) Status() string {
+func (r RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -8081,14 +8655,14 @@ func (r RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse) Status(
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse) StatusCode() int {
+func (r RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type RotateSecretWebhooksSubIdRotateSecretPostResponse struct {
+type RotateSecretV1WebhooksSubIdRotateSecretPostResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *WebhookSubscriptionResponse
@@ -8096,7 +8670,7 @@ type RotateSecretWebhooksSubIdRotateSecretPostResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r RotateSecretWebhooksSubIdRotateSecretPostResponse) Status() string {
+func (r RotateSecretV1WebhooksSubIdRotateSecretPostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -8104,14 +8678,14 @@ func (r RotateSecretWebhooksSubIdRotateSecretPostResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r RotateSecretWebhooksSubIdRotateSecretPostResponse) StatusCode() int {
+func (r RotateSecretV1WebhooksSubIdRotateSecretPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetWhoamiWhoamiGetResponse struct {
+type GetWhoamiV1WhoamiGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *WhoamiResponse
@@ -8119,7 +8693,7 @@ type GetWhoamiWhoamiGetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetWhoamiWhoamiGetResponse) Status() string {
+func (r GetWhoamiV1WhoamiGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -8127,266 +8701,11 @@ func (r GetWhoamiWhoamiGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetWhoamiWhoamiGetResponse) StatusCode() int {
+func (r GetWhoamiV1WhoamiGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
-}
-
-// ListCallsCallsGetWithResponse request returning *ListCallsCallsGetResponse
-func (c *ClientWithResponses) ListCallsCallsGetWithResponse(ctx context.Context, params *ListCallsCallsGetParams, reqEditors ...RequestEditorFn) (*ListCallsCallsGetResponse, error) {
-	rsp, err := c.ListCallsCallsGet(ctx, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseListCallsCallsGetResponse(rsp)
-}
-
-// CreateCallCallsPostWithBodyWithResponse request with arbitrary body returning *CreateCallCallsPostResponse
-func (c *ClientWithResponses) CreateCallCallsPostWithBodyWithResponse(ctx context.Context, params *CreateCallCallsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateCallCallsPostResponse, error) {
-	rsp, err := c.CreateCallCallsPostWithBody(ctx, params, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseCreateCallCallsPostResponse(rsp)
-}
-
-func (c *ClientWithResponses) CreateCallCallsPostWithResponse(ctx context.Context, params *CreateCallCallsPostParams, body CreateCallCallsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateCallCallsPostResponse, error) {
-	rsp, err := c.CreateCallCallsPost(ctx, params, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseCreateCallCallsPostResponse(rsp)
-}
-
-// GetCallCallsCallIdGetWithResponse request returning *GetCallCallsCallIdGetResponse
-func (c *ClientWithResponses) GetCallCallsCallIdGetWithResponse(ctx context.Context, callId openapi_types.UUID, params *GetCallCallsCallIdGetParams, reqEditors ...RequestEditorFn) (*GetCallCallsCallIdGetResponse, error) {
-	rsp, err := c.GetCallCallsCallIdGet(ctx, callId, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetCallCallsCallIdGetResponse(rsp)
-}
-
-// ListContactsContactsGetWithResponse request returning *ListContactsContactsGetResponse
-func (c *ClientWithResponses) ListContactsContactsGetWithResponse(ctx context.Context, params *ListContactsContactsGetParams, reqEditors ...RequestEditorFn) (*ListContactsContactsGetResponse, error) {
-	rsp, err := c.ListContactsContactsGet(ctx, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseListContactsContactsGetResponse(rsp)
-}
-
-// CreateContactContactsPostWithBodyWithResponse request with arbitrary body returning *CreateContactContactsPostResponse
-func (c *ClientWithResponses) CreateContactContactsPostWithBodyWithResponse(ctx context.Context, params *CreateContactContactsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateContactContactsPostResponse, error) {
-	rsp, err := c.CreateContactContactsPostWithBody(ctx, params, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseCreateContactContactsPostResponse(rsp)
-}
-
-func (c *ClientWithResponses) CreateContactContactsPostWithResponse(ctx context.Context, params *CreateContactContactsPostParams, body CreateContactContactsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateContactContactsPostResponse, error) {
-	rsp, err := c.CreateContactContactsPost(ctx, params, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseCreateContactContactsPostResponse(rsp)
-}
-
-// DeleteContactContactsContactIdDeleteWithResponse request returning *DeleteContactContactsContactIdDeleteResponse
-func (c *ClientWithResponses) DeleteContactContactsContactIdDeleteWithResponse(ctx context.Context, contactId string, params *DeleteContactContactsContactIdDeleteParams, reqEditors ...RequestEditorFn) (*DeleteContactContactsContactIdDeleteResponse, error) {
-	rsp, err := c.DeleteContactContactsContactIdDelete(ctx, contactId, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDeleteContactContactsContactIdDeleteResponse(rsp)
-}
-
-// PatchContactContactsContactIdPatchWithBodyWithResponse request with arbitrary body returning *PatchContactContactsContactIdPatchResponse
-func (c *ClientWithResponses) PatchContactContactsContactIdPatchWithBodyWithResponse(ctx context.Context, contactId string, params *PatchContactContactsContactIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchContactContactsContactIdPatchResponse, error) {
-	rsp, err := c.PatchContactContactsContactIdPatchWithBody(ctx, contactId, params, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParsePatchContactContactsContactIdPatchResponse(rsp)
-}
-
-func (c *ClientWithResponses) PatchContactContactsContactIdPatchWithResponse(ctx context.Context, contactId string, params *PatchContactContactsContactIdPatchParams, body PatchContactContactsContactIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchContactContactsContactIdPatchResponse, error) {
-	rsp, err := c.PatchContactContactsContactIdPatch(ctx, contactId, params, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParsePatchContactContactsContactIdPatchResponse(rsp)
-}
-
-// UploadEmailAttachmentWithBodyWithResponse request with arbitrary body returning *UploadEmailAttachmentResponse
-func (c *ClientWithResponses) UploadEmailAttachmentWithBodyWithResponse(ctx context.Context, params *UploadEmailAttachmentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UploadEmailAttachmentResponse, error) {
-	rsp, err := c.UploadEmailAttachmentWithBody(ctx, params, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseUploadEmailAttachmentResponse(rsp)
-}
-
-// ListEmailDomainsEmailDomainsGetWithResponse request returning *ListEmailDomainsEmailDomainsGetResponse
-func (c *ClientWithResponses) ListEmailDomainsEmailDomainsGetWithResponse(ctx context.Context, params *ListEmailDomainsEmailDomainsGetParams, reqEditors ...RequestEditorFn) (*ListEmailDomainsEmailDomainsGetResponse, error) {
-	rsp, err := c.ListEmailDomainsEmailDomainsGet(ctx, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseListEmailDomainsEmailDomainsGetResponse(rsp)
-}
-
-// CreateEmailDomainEmailDomainsPostWithBodyWithResponse request with arbitrary body returning *CreateEmailDomainEmailDomainsPostResponse
-func (c *ClientWithResponses) CreateEmailDomainEmailDomainsPostWithBodyWithResponse(ctx context.Context, params *CreateEmailDomainEmailDomainsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateEmailDomainEmailDomainsPostResponse, error) {
-	rsp, err := c.CreateEmailDomainEmailDomainsPostWithBody(ctx, params, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseCreateEmailDomainEmailDomainsPostResponse(rsp)
-}
-
-func (c *ClientWithResponses) CreateEmailDomainEmailDomainsPostWithResponse(ctx context.Context, params *CreateEmailDomainEmailDomainsPostParams, body CreateEmailDomainEmailDomainsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateEmailDomainEmailDomainsPostResponse, error) {
-	rsp, err := c.CreateEmailDomainEmailDomainsPost(ctx, params, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseCreateEmailDomainEmailDomainsPostResponse(rsp)
-}
-
-// CheckDomainEmailDomainsCheckDomainGetWithResponse request returning *CheckDomainEmailDomainsCheckDomainGetResponse
-func (c *ClientWithResponses) CheckDomainEmailDomainsCheckDomainGetWithResponse(ctx context.Context, params *CheckDomainEmailDomainsCheckDomainGetParams, reqEditors ...RequestEditorFn) (*CheckDomainEmailDomainsCheckDomainGetResponse, error) {
-	rsp, err := c.CheckDomainEmailDomainsCheckDomainGet(ctx, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseCheckDomainEmailDomainsCheckDomainGetResponse(rsp)
-}
-
-// DeleteEmailDomainEmailDomainsDomainIdDeleteWithResponse request returning *DeleteEmailDomainEmailDomainsDomainIdDeleteResponse
-func (c *ClientWithResponses) DeleteEmailDomainEmailDomainsDomainIdDeleteWithResponse(ctx context.Context, domainId openapi_types.UUID, params *DeleteEmailDomainEmailDomainsDomainIdDeleteParams, reqEditors ...RequestEditorFn) (*DeleteEmailDomainEmailDomainsDomainIdDeleteResponse, error) {
-	rsp, err := c.DeleteEmailDomainEmailDomainsDomainIdDelete(ctx, domainId, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDeleteEmailDomainEmailDomainsDomainIdDeleteResponse(rsp)
-}
-
-// GetEmailDomainEmailDomainsDomainIdGetWithResponse request returning *GetEmailDomainEmailDomainsDomainIdGetResponse
-func (c *ClientWithResponses) GetEmailDomainEmailDomainsDomainIdGetWithResponse(ctx context.Context, domainId openapi_types.UUID, params *GetEmailDomainEmailDomainsDomainIdGetParams, reqEditors ...RequestEditorFn) (*GetEmailDomainEmailDomainsDomainIdGetResponse, error) {
-	rsp, err := c.GetEmailDomainEmailDomainsDomainIdGet(ctx, domainId, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetEmailDomainEmailDomainsDomainIdGetResponse(rsp)
-}
-
-// PatchEmailDomainEmailDomainsDomainIdPatchWithBodyWithResponse request with arbitrary body returning *PatchEmailDomainEmailDomainsDomainIdPatchResponse
-func (c *ClientWithResponses) PatchEmailDomainEmailDomainsDomainIdPatchWithBodyWithResponse(ctx context.Context, domainId openapi_types.UUID, params *PatchEmailDomainEmailDomainsDomainIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchEmailDomainEmailDomainsDomainIdPatchResponse, error) {
-	rsp, err := c.PatchEmailDomainEmailDomainsDomainIdPatchWithBody(ctx, domainId, params, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParsePatchEmailDomainEmailDomainsDomainIdPatchResponse(rsp)
-}
-
-func (c *ClientWithResponses) PatchEmailDomainEmailDomainsDomainIdPatchWithResponse(ctx context.Context, domainId openapi_types.UUID, params *PatchEmailDomainEmailDomainsDomainIdPatchParams, body PatchEmailDomainEmailDomainsDomainIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchEmailDomainEmailDomainsDomainIdPatchResponse, error) {
-	rsp, err := c.PatchEmailDomainEmailDomainsDomainIdPatch(ctx, domainId, params, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParsePatchEmailDomainEmailDomainsDomainIdPatchResponse(rsp)
-}
-
-// VerifyEmailDomainEmailDomainsDomainIdVerifyPostWithResponse request returning *VerifyEmailDomainEmailDomainsDomainIdVerifyPostResponse
-func (c *ClientWithResponses) VerifyEmailDomainEmailDomainsDomainIdVerifyPostWithResponse(ctx context.Context, domainId openapi_types.UUID, params *VerifyEmailDomainEmailDomainsDomainIdVerifyPostParams, reqEditors ...RequestEditorFn) (*VerifyEmailDomainEmailDomainsDomainIdVerifyPostResponse, error) {
-	rsp, err := c.VerifyEmailDomainEmailDomainsDomainIdVerifyPost(ctx, domainId, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseVerifyEmailDomainEmailDomainsDomainIdVerifyPostResponse(rsp)
-}
-
-// ListEmailsEmailsGetWithResponse request returning *ListEmailsEmailsGetResponse
-func (c *ClientWithResponses) ListEmailsEmailsGetWithResponse(ctx context.Context, params *ListEmailsEmailsGetParams, reqEditors ...RequestEditorFn) (*ListEmailsEmailsGetResponse, error) {
-	rsp, err := c.ListEmailsEmailsGet(ctx, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseListEmailsEmailsGetResponse(rsp)
-}
-
-// CreateEmailEmailsPostWithBodyWithResponse request with arbitrary body returning *CreateEmailEmailsPostResponse
-func (c *ClientWithResponses) CreateEmailEmailsPostWithBodyWithResponse(ctx context.Context, params *CreateEmailEmailsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateEmailEmailsPostResponse, error) {
-	rsp, err := c.CreateEmailEmailsPostWithBody(ctx, params, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseCreateEmailEmailsPostResponse(rsp)
-}
-
-func (c *ClientWithResponses) CreateEmailEmailsPostWithResponse(ctx context.Context, params *CreateEmailEmailsPostParams, body CreateEmailEmailsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateEmailEmailsPostResponse, error) {
-	rsp, err := c.CreateEmailEmailsPost(ctx, params, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseCreateEmailEmailsPostResponse(rsp)
-}
-
-// GetEmailStatsEmailsStatsGetWithResponse request returning *GetEmailStatsEmailsStatsGetResponse
-func (c *ClientWithResponses) GetEmailStatsEmailsStatsGetWithResponse(ctx context.Context, params *GetEmailStatsEmailsStatsGetParams, reqEditors ...RequestEditorFn) (*GetEmailStatsEmailsStatsGetResponse, error) {
-	rsp, err := c.GetEmailStatsEmailsStatsGet(ctx, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetEmailStatsEmailsStatsGetResponse(rsp)
-}
-
-// GetEmailEmailsEmailIdGetWithResponse request returning *GetEmailEmailsEmailIdGetResponse
-func (c *ClientWithResponses) GetEmailEmailsEmailIdGetWithResponse(ctx context.Context, emailId openapi_types.UUID, params *GetEmailEmailsEmailIdGetParams, reqEditors ...RequestEditorFn) (*GetEmailEmailsEmailIdGetResponse, error) {
-	rsp, err := c.GetEmailEmailsEmailIdGet(ctx, emailId, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetEmailEmailsEmailIdGetResponse(rsp)
-}
-
-// GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetWithResponse request returning *GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetResponse
-func (c *ClientWithResponses) GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetWithResponse(ctx context.Context, emailId openapi_types.UUID, attachmentId openapi_types.UUID, params *GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetParams, reqEditors ...RequestEditorFn) (*GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetResponse, error) {
-	rsp, err := c.GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGet(ctx, emailId, attachmentId, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetResponse(rsp)
-}
-
-// ListEmailEventsEmailsEmailIdEventsGetWithResponse request returning *ListEmailEventsEmailsEmailIdEventsGetResponse
-func (c *ClientWithResponses) ListEmailEventsEmailsEmailIdEventsGetWithResponse(ctx context.Context, emailId openapi_types.UUID, params *ListEmailEventsEmailsEmailIdEventsGetParams, reqEditors ...RequestEditorFn) (*ListEmailEventsEmailsEmailIdEventsGetResponse, error) {
-	rsp, err := c.ListEmailEventsEmailsEmailIdEventsGet(ctx, emailId, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseListEmailEventsEmailsEmailIdEventsGetResponse(rsp)
-}
-
-// GetEmailRawEmailsEmailIdRawGetWithResponse request returning *GetEmailRawEmailsEmailIdRawGetResponse
-func (c *ClientWithResponses) GetEmailRawEmailsEmailIdRawGetWithResponse(ctx context.Context, emailId openapi_types.UUID, params *GetEmailRawEmailsEmailIdRawGetParams, reqEditors ...RequestEditorFn) (*GetEmailRawEmailsEmailIdRawGetResponse, error) {
-	rsp, err := c.GetEmailRawEmailsEmailIdRawGet(ctx, emailId, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetEmailRawEmailsEmailIdRawGetResponse(rsp)
-}
-
-// ListEventsEventsGetWithResponse request returning *ListEventsEventsGetResponse
-func (c *ClientWithResponses) ListEventsEventsGetWithResponse(ctx context.Context, params *ListEventsEventsGetParams, reqEditors ...RequestEditorFn) (*ListEventsEventsGetResponse, error) {
-	rsp, err := c.ListEventsEventsGet(ctx, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseListEventsEventsGetResponse(rsp)
 }
 
 // HealthzHealthzGetWithResponse request returning *HealthzHealthzGetResponse
@@ -8398,83 +8717,338 @@ func (c *ClientWithResponses) HealthzHealthzGetWithResponse(ctx context.Context,
 	return ParseHealthzHealthzGetResponse(rsp)
 }
 
-// DeleteMemberPhoneMembersUserIdPhoneDeleteWithResponse request returning *DeleteMemberPhoneMembersUserIdPhoneDeleteResponse
-func (c *ClientWithResponses) DeleteMemberPhoneMembersUserIdPhoneDeleteWithResponse(ctx context.Context, userId string, params *DeleteMemberPhoneMembersUserIdPhoneDeleteParams, reqEditors ...RequestEditorFn) (*DeleteMemberPhoneMembersUserIdPhoneDeleteResponse, error) {
-	rsp, err := c.DeleteMemberPhoneMembersUserIdPhoneDelete(ctx, userId, params, reqEditors...)
+// ListCallsV1CallsGetWithResponse request returning *ListCallsV1CallsGetResponse
+func (c *ClientWithResponses) ListCallsV1CallsGetWithResponse(ctx context.Context, params *ListCallsV1CallsGetParams, reqEditors ...RequestEditorFn) (*ListCallsV1CallsGetResponse, error) {
+	rsp, err := c.ListCallsV1CallsGet(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseDeleteMemberPhoneMembersUserIdPhoneDeleteResponse(rsp)
+	return ParseListCallsV1CallsGetResponse(rsp)
 }
 
-// PutMemberPhoneMembersUserIdPhonePutWithBodyWithResponse request with arbitrary body returning *PutMemberPhoneMembersUserIdPhonePutResponse
-func (c *ClientWithResponses) PutMemberPhoneMembersUserIdPhonePutWithBodyWithResponse(ctx context.Context, userId string, params *PutMemberPhoneMembersUserIdPhonePutParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutMemberPhoneMembersUserIdPhonePutResponse, error) {
-	rsp, err := c.PutMemberPhoneMembersUserIdPhonePutWithBody(ctx, userId, params, contentType, body, reqEditors...)
+// CreateCallV1CallsPostWithBodyWithResponse request with arbitrary body returning *CreateCallV1CallsPostResponse
+func (c *ClientWithResponses) CreateCallV1CallsPostWithBodyWithResponse(ctx context.Context, params *CreateCallV1CallsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateCallV1CallsPostResponse, error) {
+	rsp, err := c.CreateCallV1CallsPostWithBody(ctx, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePutMemberPhoneMembersUserIdPhonePutResponse(rsp)
+	return ParseCreateCallV1CallsPostResponse(rsp)
 }
 
-func (c *ClientWithResponses) PutMemberPhoneMembersUserIdPhonePutWithResponse(ctx context.Context, userId string, params *PutMemberPhoneMembersUserIdPhonePutParams, body PutMemberPhoneMembersUserIdPhonePutJSONRequestBody, reqEditors ...RequestEditorFn) (*PutMemberPhoneMembersUserIdPhonePutResponse, error) {
-	rsp, err := c.PutMemberPhoneMembersUserIdPhonePut(ctx, userId, params, body, reqEditors...)
+func (c *ClientWithResponses) CreateCallV1CallsPostWithResponse(ctx context.Context, params *CreateCallV1CallsPostParams, body CreateCallV1CallsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateCallV1CallsPostResponse, error) {
+	rsp, err := c.CreateCallV1CallsPost(ctx, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePutMemberPhoneMembersUserIdPhonePutResponse(rsp)
+	return ParseCreateCallV1CallsPostResponse(rsp)
 }
 
-// ListNumbersNumbersGetWithResponse request returning *ListNumbersNumbersGetResponse
-func (c *ClientWithResponses) ListNumbersNumbersGetWithResponse(ctx context.Context, params *ListNumbersNumbersGetParams, reqEditors ...RequestEditorFn) (*ListNumbersNumbersGetResponse, error) {
-	rsp, err := c.ListNumbersNumbersGet(ctx, params, reqEditors...)
+// GetCallV1CallsCallIdGetWithResponse request returning *GetCallV1CallsCallIdGetResponse
+func (c *ClientWithResponses) GetCallV1CallsCallIdGetWithResponse(ctx context.Context, callId openapi_types.UUID, params *GetCallV1CallsCallIdGetParams, reqEditors ...RequestEditorFn) (*GetCallV1CallsCallIdGetResponse, error) {
+	rsp, err := c.GetCallV1CallsCallIdGet(ctx, callId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseListNumbersNumbersGetResponse(rsp)
+	return ParseGetCallV1CallsCallIdGetResponse(rsp)
 }
 
-// AcquireNumberNumbersPostWithBodyWithResponse request with arbitrary body returning *AcquireNumberNumbersPostResponse
-func (c *ClientWithResponses) AcquireNumberNumbersPostWithBodyWithResponse(ctx context.Context, params *AcquireNumberNumbersPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AcquireNumberNumbersPostResponse, error) {
-	rsp, err := c.AcquireNumberNumbersPostWithBody(ctx, params, contentType, body, reqEditors...)
+// ListContactsV1ContactsGetWithResponse request returning *ListContactsV1ContactsGetResponse
+func (c *ClientWithResponses) ListContactsV1ContactsGetWithResponse(ctx context.Context, params *ListContactsV1ContactsGetParams, reqEditors ...RequestEditorFn) (*ListContactsV1ContactsGetResponse, error) {
+	rsp, err := c.ListContactsV1ContactsGet(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseAcquireNumberNumbersPostResponse(rsp)
+	return ParseListContactsV1ContactsGetResponse(rsp)
 }
 
-func (c *ClientWithResponses) AcquireNumberNumbersPostWithResponse(ctx context.Context, params *AcquireNumberNumbersPostParams, body AcquireNumberNumbersPostJSONRequestBody, reqEditors ...RequestEditorFn) (*AcquireNumberNumbersPostResponse, error) {
-	rsp, err := c.AcquireNumberNumbersPost(ctx, params, body, reqEditors...)
+// CreateContactV1ContactsPostWithBodyWithResponse request with arbitrary body returning *CreateContactV1ContactsPostResponse
+func (c *ClientWithResponses) CreateContactV1ContactsPostWithBodyWithResponse(ctx context.Context, params *CreateContactV1ContactsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateContactV1ContactsPostResponse, error) {
+	rsp, err := c.CreateContactV1ContactsPostWithBody(ctx, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseAcquireNumberNumbersPostResponse(rsp)
+	return ParseCreateContactV1ContactsPostResponse(rsp)
 }
 
-// ReleaseNumberNumbersNumberIdDeleteWithResponse request returning *ReleaseNumberNumbersNumberIdDeleteResponse
-func (c *ClientWithResponses) ReleaseNumberNumbersNumberIdDeleteWithResponse(ctx context.Context, numberId openapi_types.UUID, params *ReleaseNumberNumbersNumberIdDeleteParams, reqEditors ...RequestEditorFn) (*ReleaseNumberNumbersNumberIdDeleteResponse, error) {
-	rsp, err := c.ReleaseNumberNumbersNumberIdDelete(ctx, numberId, params, reqEditors...)
+func (c *ClientWithResponses) CreateContactV1ContactsPostWithResponse(ctx context.Context, params *CreateContactV1ContactsPostParams, body CreateContactV1ContactsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateContactV1ContactsPostResponse, error) {
+	rsp, err := c.CreateContactV1ContactsPost(ctx, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseReleaseNumberNumbersNumberIdDeleteResponse(rsp)
+	return ParseCreateContactV1ContactsPostResponse(rsp)
 }
 
-// GetNumberNumbersNumberIdGetWithResponse request returning *GetNumberNumbersNumberIdGetResponse
-func (c *ClientWithResponses) GetNumberNumbersNumberIdGetWithResponse(ctx context.Context, numberId openapi_types.UUID, params *GetNumberNumbersNumberIdGetParams, reqEditors ...RequestEditorFn) (*GetNumberNumbersNumberIdGetResponse, error) {
-	rsp, err := c.GetNumberNumbersNumberIdGet(ctx, numberId, params, reqEditors...)
+// DeleteContactV1ContactsContactIdDeleteWithResponse request returning *DeleteContactV1ContactsContactIdDeleteResponse
+func (c *ClientWithResponses) DeleteContactV1ContactsContactIdDeleteWithResponse(ctx context.Context, contactId string, params *DeleteContactV1ContactsContactIdDeleteParams, reqEditors ...RequestEditorFn) (*DeleteContactV1ContactsContactIdDeleteResponse, error) {
+	rsp, err := c.DeleteContactV1ContactsContactIdDelete(ctx, contactId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetNumberNumbersNumberIdGetResponse(rsp)
+	return ParseDeleteContactV1ContactsContactIdDeleteResponse(rsp)
 }
 
-// EnableSmsNumbersNumberIdEnableSmsPostWithResponse request returning *EnableSmsNumbersNumberIdEnableSmsPostResponse
-func (c *ClientWithResponses) EnableSmsNumbersNumberIdEnableSmsPostWithResponse(ctx context.Context, numberId openapi_types.UUID, params *EnableSmsNumbersNumberIdEnableSmsPostParams, reqEditors ...RequestEditorFn) (*EnableSmsNumbersNumberIdEnableSmsPostResponse, error) {
-	rsp, err := c.EnableSmsNumbersNumberIdEnableSmsPost(ctx, numberId, params, reqEditors...)
+// PatchContactV1ContactsContactIdPatchWithBodyWithResponse request with arbitrary body returning *PatchContactV1ContactsContactIdPatchResponse
+func (c *ClientWithResponses) PatchContactV1ContactsContactIdPatchWithBodyWithResponse(ctx context.Context, contactId string, params *PatchContactV1ContactsContactIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchContactV1ContactsContactIdPatchResponse, error) {
+	rsp, err := c.PatchContactV1ContactsContactIdPatchWithBody(ctx, contactId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseEnableSmsNumbersNumberIdEnableSmsPostResponse(rsp)
+	return ParsePatchContactV1ContactsContactIdPatchResponse(rsp)
+}
+
+func (c *ClientWithResponses) PatchContactV1ContactsContactIdPatchWithResponse(ctx context.Context, contactId string, params *PatchContactV1ContactsContactIdPatchParams, body PatchContactV1ContactsContactIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchContactV1ContactsContactIdPatchResponse, error) {
+	rsp, err := c.PatchContactV1ContactsContactIdPatch(ctx, contactId, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePatchContactV1ContactsContactIdPatchResponse(rsp)
+}
+
+// UploadEmailAttachmentWithBodyWithResponse request with arbitrary body returning *UploadEmailAttachmentResponse
+func (c *ClientWithResponses) UploadEmailAttachmentWithBodyWithResponse(ctx context.Context, params *UploadEmailAttachmentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UploadEmailAttachmentResponse, error) {
+	rsp, err := c.UploadEmailAttachmentWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUploadEmailAttachmentResponse(rsp)
+}
+
+// ListEmailDomainsV1EmailDomainsGetWithResponse request returning *ListEmailDomainsV1EmailDomainsGetResponse
+func (c *ClientWithResponses) ListEmailDomainsV1EmailDomainsGetWithResponse(ctx context.Context, params *ListEmailDomainsV1EmailDomainsGetParams, reqEditors ...RequestEditorFn) (*ListEmailDomainsV1EmailDomainsGetResponse, error) {
+	rsp, err := c.ListEmailDomainsV1EmailDomainsGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListEmailDomainsV1EmailDomainsGetResponse(rsp)
+}
+
+// CreateEmailDomainV1EmailDomainsPostWithBodyWithResponse request with arbitrary body returning *CreateEmailDomainV1EmailDomainsPostResponse
+func (c *ClientWithResponses) CreateEmailDomainV1EmailDomainsPostWithBodyWithResponse(ctx context.Context, params *CreateEmailDomainV1EmailDomainsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateEmailDomainV1EmailDomainsPostResponse, error) {
+	rsp, err := c.CreateEmailDomainV1EmailDomainsPostWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateEmailDomainV1EmailDomainsPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateEmailDomainV1EmailDomainsPostWithResponse(ctx context.Context, params *CreateEmailDomainV1EmailDomainsPostParams, body CreateEmailDomainV1EmailDomainsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateEmailDomainV1EmailDomainsPostResponse, error) {
+	rsp, err := c.CreateEmailDomainV1EmailDomainsPost(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateEmailDomainV1EmailDomainsPostResponse(rsp)
+}
+
+// CheckDomainV1EmailDomainsCheckDomainGetWithResponse request returning *CheckDomainV1EmailDomainsCheckDomainGetResponse
+func (c *ClientWithResponses) CheckDomainV1EmailDomainsCheckDomainGetWithResponse(ctx context.Context, params *CheckDomainV1EmailDomainsCheckDomainGetParams, reqEditors ...RequestEditorFn) (*CheckDomainV1EmailDomainsCheckDomainGetResponse, error) {
+	rsp, err := c.CheckDomainV1EmailDomainsCheckDomainGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCheckDomainV1EmailDomainsCheckDomainGetResponse(rsp)
+}
+
+// DeleteEmailDomainV1EmailDomainsDomainIdDeleteWithResponse request returning *DeleteEmailDomainV1EmailDomainsDomainIdDeleteResponse
+func (c *ClientWithResponses) DeleteEmailDomainV1EmailDomainsDomainIdDeleteWithResponse(ctx context.Context, domainId openapi_types.UUID, params *DeleteEmailDomainV1EmailDomainsDomainIdDeleteParams, reqEditors ...RequestEditorFn) (*DeleteEmailDomainV1EmailDomainsDomainIdDeleteResponse, error) {
+	rsp, err := c.DeleteEmailDomainV1EmailDomainsDomainIdDelete(ctx, domainId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteEmailDomainV1EmailDomainsDomainIdDeleteResponse(rsp)
+}
+
+// GetEmailDomainV1EmailDomainsDomainIdGetWithResponse request returning *GetEmailDomainV1EmailDomainsDomainIdGetResponse
+func (c *ClientWithResponses) GetEmailDomainV1EmailDomainsDomainIdGetWithResponse(ctx context.Context, domainId openapi_types.UUID, params *GetEmailDomainV1EmailDomainsDomainIdGetParams, reqEditors ...RequestEditorFn) (*GetEmailDomainV1EmailDomainsDomainIdGetResponse, error) {
+	rsp, err := c.GetEmailDomainV1EmailDomainsDomainIdGet(ctx, domainId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetEmailDomainV1EmailDomainsDomainIdGetResponse(rsp)
+}
+
+// PatchEmailDomainV1EmailDomainsDomainIdPatchWithBodyWithResponse request with arbitrary body returning *PatchEmailDomainV1EmailDomainsDomainIdPatchResponse
+func (c *ClientWithResponses) PatchEmailDomainV1EmailDomainsDomainIdPatchWithBodyWithResponse(ctx context.Context, domainId openapi_types.UUID, params *PatchEmailDomainV1EmailDomainsDomainIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchEmailDomainV1EmailDomainsDomainIdPatchResponse, error) {
+	rsp, err := c.PatchEmailDomainV1EmailDomainsDomainIdPatchWithBody(ctx, domainId, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePatchEmailDomainV1EmailDomainsDomainIdPatchResponse(rsp)
+}
+
+func (c *ClientWithResponses) PatchEmailDomainV1EmailDomainsDomainIdPatchWithResponse(ctx context.Context, domainId openapi_types.UUID, params *PatchEmailDomainV1EmailDomainsDomainIdPatchParams, body PatchEmailDomainV1EmailDomainsDomainIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchEmailDomainV1EmailDomainsDomainIdPatchResponse, error) {
+	rsp, err := c.PatchEmailDomainV1EmailDomainsDomainIdPatch(ctx, domainId, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePatchEmailDomainV1EmailDomainsDomainIdPatchResponse(rsp)
+}
+
+// VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostWithResponse request returning *VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostResponse
+func (c *ClientWithResponses) VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostWithResponse(ctx context.Context, domainId openapi_types.UUID, params *VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostParams, reqEditors ...RequestEditorFn) (*VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostResponse, error) {
+	rsp, err := c.VerifyEmailDomainV1EmailDomainsDomainIdVerifyPost(ctx, domainId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseVerifyEmailDomainV1EmailDomainsDomainIdVerifyPostResponse(rsp)
+}
+
+// ListEmailsV1EmailsGetWithResponse request returning *ListEmailsV1EmailsGetResponse
+func (c *ClientWithResponses) ListEmailsV1EmailsGetWithResponse(ctx context.Context, params *ListEmailsV1EmailsGetParams, reqEditors ...RequestEditorFn) (*ListEmailsV1EmailsGetResponse, error) {
+	rsp, err := c.ListEmailsV1EmailsGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListEmailsV1EmailsGetResponse(rsp)
+}
+
+// CreateEmailV1EmailsPostWithBodyWithResponse request with arbitrary body returning *CreateEmailV1EmailsPostResponse
+func (c *ClientWithResponses) CreateEmailV1EmailsPostWithBodyWithResponse(ctx context.Context, params *CreateEmailV1EmailsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateEmailV1EmailsPostResponse, error) {
+	rsp, err := c.CreateEmailV1EmailsPostWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateEmailV1EmailsPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateEmailV1EmailsPostWithResponse(ctx context.Context, params *CreateEmailV1EmailsPostParams, body CreateEmailV1EmailsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateEmailV1EmailsPostResponse, error) {
+	rsp, err := c.CreateEmailV1EmailsPost(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateEmailV1EmailsPostResponse(rsp)
+}
+
+// GetEmailStatsV1EmailsStatsGetWithResponse request returning *GetEmailStatsV1EmailsStatsGetResponse
+func (c *ClientWithResponses) GetEmailStatsV1EmailsStatsGetWithResponse(ctx context.Context, params *GetEmailStatsV1EmailsStatsGetParams, reqEditors ...RequestEditorFn) (*GetEmailStatsV1EmailsStatsGetResponse, error) {
+	rsp, err := c.GetEmailStatsV1EmailsStatsGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetEmailStatsV1EmailsStatsGetResponse(rsp)
+}
+
+// GetEmailV1EmailsEmailIdGetWithResponse request returning *GetEmailV1EmailsEmailIdGetResponse
+func (c *ClientWithResponses) GetEmailV1EmailsEmailIdGetWithResponse(ctx context.Context, emailId openapi_types.UUID, params *GetEmailV1EmailsEmailIdGetParams, reqEditors ...RequestEditorFn) (*GetEmailV1EmailsEmailIdGetResponse, error) {
+	rsp, err := c.GetEmailV1EmailsEmailIdGet(ctx, emailId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetEmailV1EmailsEmailIdGetResponse(rsp)
+}
+
+// GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetWithResponse request returning *GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetResponse
+func (c *ClientWithResponses) GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetWithResponse(ctx context.Context, emailId openapi_types.UUID, attachmentId openapi_types.UUID, params *GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetParams, reqEditors ...RequestEditorFn) (*GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetResponse, error) {
+	rsp, err := c.GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGet(ctx, emailId, attachmentId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetResponse(rsp)
+}
+
+// ListEmailEventsV1EmailsEmailIdEventsGetWithResponse request returning *ListEmailEventsV1EmailsEmailIdEventsGetResponse
+func (c *ClientWithResponses) ListEmailEventsV1EmailsEmailIdEventsGetWithResponse(ctx context.Context, emailId openapi_types.UUID, params *ListEmailEventsV1EmailsEmailIdEventsGetParams, reqEditors ...RequestEditorFn) (*ListEmailEventsV1EmailsEmailIdEventsGetResponse, error) {
+	rsp, err := c.ListEmailEventsV1EmailsEmailIdEventsGet(ctx, emailId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListEmailEventsV1EmailsEmailIdEventsGetResponse(rsp)
+}
+
+// GetEmailRawV1EmailsEmailIdRawGetWithResponse request returning *GetEmailRawV1EmailsEmailIdRawGetResponse
+func (c *ClientWithResponses) GetEmailRawV1EmailsEmailIdRawGetWithResponse(ctx context.Context, emailId openapi_types.UUID, params *GetEmailRawV1EmailsEmailIdRawGetParams, reqEditors ...RequestEditorFn) (*GetEmailRawV1EmailsEmailIdRawGetResponse, error) {
+	rsp, err := c.GetEmailRawV1EmailsEmailIdRawGet(ctx, emailId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetEmailRawV1EmailsEmailIdRawGetResponse(rsp)
+}
+
+// ListEventsV1EventsGetWithResponse request returning *ListEventsV1EventsGetResponse
+func (c *ClientWithResponses) ListEventsV1EventsGetWithResponse(ctx context.Context, params *ListEventsV1EventsGetParams, reqEditors ...RequestEditorFn) (*ListEventsV1EventsGetResponse, error) {
+	rsp, err := c.ListEventsV1EventsGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListEventsV1EventsGetResponse(rsp)
+}
+
+// DeleteMemberPhoneV1MembersUserIdPhoneDeleteWithResponse request returning *DeleteMemberPhoneV1MembersUserIdPhoneDeleteResponse
+func (c *ClientWithResponses) DeleteMemberPhoneV1MembersUserIdPhoneDeleteWithResponse(ctx context.Context, userId string, params *DeleteMemberPhoneV1MembersUserIdPhoneDeleteParams, reqEditors ...RequestEditorFn) (*DeleteMemberPhoneV1MembersUserIdPhoneDeleteResponse, error) {
+	rsp, err := c.DeleteMemberPhoneV1MembersUserIdPhoneDelete(ctx, userId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteMemberPhoneV1MembersUserIdPhoneDeleteResponse(rsp)
+}
+
+// PutMemberPhoneV1MembersUserIdPhonePutWithBodyWithResponse request with arbitrary body returning *PutMemberPhoneV1MembersUserIdPhonePutResponse
+func (c *ClientWithResponses) PutMemberPhoneV1MembersUserIdPhonePutWithBodyWithResponse(ctx context.Context, userId string, params *PutMemberPhoneV1MembersUserIdPhonePutParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutMemberPhoneV1MembersUserIdPhonePutResponse, error) {
+	rsp, err := c.PutMemberPhoneV1MembersUserIdPhonePutWithBody(ctx, userId, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePutMemberPhoneV1MembersUserIdPhonePutResponse(rsp)
+}
+
+func (c *ClientWithResponses) PutMemberPhoneV1MembersUserIdPhonePutWithResponse(ctx context.Context, userId string, params *PutMemberPhoneV1MembersUserIdPhonePutParams, body PutMemberPhoneV1MembersUserIdPhonePutJSONRequestBody, reqEditors ...RequestEditorFn) (*PutMemberPhoneV1MembersUserIdPhonePutResponse, error) {
+	rsp, err := c.PutMemberPhoneV1MembersUserIdPhonePut(ctx, userId, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePutMemberPhoneV1MembersUserIdPhonePutResponse(rsp)
+}
+
+// ListNumbersV1NumbersGetWithResponse request returning *ListNumbersV1NumbersGetResponse
+func (c *ClientWithResponses) ListNumbersV1NumbersGetWithResponse(ctx context.Context, params *ListNumbersV1NumbersGetParams, reqEditors ...RequestEditorFn) (*ListNumbersV1NumbersGetResponse, error) {
+	rsp, err := c.ListNumbersV1NumbersGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListNumbersV1NumbersGetResponse(rsp)
+}
+
+// AcquireNumberV1NumbersPostWithBodyWithResponse request with arbitrary body returning *AcquireNumberV1NumbersPostResponse
+func (c *ClientWithResponses) AcquireNumberV1NumbersPostWithBodyWithResponse(ctx context.Context, params *AcquireNumberV1NumbersPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AcquireNumberV1NumbersPostResponse, error) {
+	rsp, err := c.AcquireNumberV1NumbersPostWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAcquireNumberV1NumbersPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) AcquireNumberV1NumbersPostWithResponse(ctx context.Context, params *AcquireNumberV1NumbersPostParams, body AcquireNumberV1NumbersPostJSONRequestBody, reqEditors ...RequestEditorFn) (*AcquireNumberV1NumbersPostResponse, error) {
+	rsp, err := c.AcquireNumberV1NumbersPost(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAcquireNumberV1NumbersPostResponse(rsp)
+}
+
+// ReleaseNumberV1NumbersNumberIdDeleteWithResponse request returning *ReleaseNumberV1NumbersNumberIdDeleteResponse
+func (c *ClientWithResponses) ReleaseNumberV1NumbersNumberIdDeleteWithResponse(ctx context.Context, numberId openapi_types.UUID, params *ReleaseNumberV1NumbersNumberIdDeleteParams, reqEditors ...RequestEditorFn) (*ReleaseNumberV1NumbersNumberIdDeleteResponse, error) {
+	rsp, err := c.ReleaseNumberV1NumbersNumberIdDelete(ctx, numberId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseReleaseNumberV1NumbersNumberIdDeleteResponse(rsp)
+}
+
+// GetNumberV1NumbersNumberIdGetWithResponse request returning *GetNumberV1NumbersNumberIdGetResponse
+func (c *ClientWithResponses) GetNumberV1NumbersNumberIdGetWithResponse(ctx context.Context, numberId openapi_types.UUID, params *GetNumberV1NumbersNumberIdGetParams, reqEditors ...RequestEditorFn) (*GetNumberV1NumbersNumberIdGetResponse, error) {
+	rsp, err := c.GetNumberV1NumbersNumberIdGet(ctx, numberId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetNumberV1NumbersNumberIdGetResponse(rsp)
+}
+
+// EnableSmsV1NumbersNumberIdEnableSmsPostWithResponse request returning *EnableSmsV1NumbersNumberIdEnableSmsPostResponse
+func (c *ClientWithResponses) EnableSmsV1NumbersNumberIdEnableSmsPostWithResponse(ctx context.Context, numberId openapi_types.UUID, params *EnableSmsV1NumbersNumberIdEnableSmsPostParams, reqEditors ...RequestEditorFn) (*EnableSmsV1NumbersNumberIdEnableSmsPostResponse, error) {
+	rsp, err := c.EnableSmsV1NumbersNumberIdEnableSmsPost(ctx, numberId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEnableSmsV1NumbersNumberIdEnableSmsPostResponse(rsp)
 }
 
 // ListProvidersWithResponse request returning *ListProvidersResponse
@@ -8546,200 +9120,226 @@ func (c *ClientWithResponses) DeleteProviderWithResponse(ctx context.Context, la
 	return ParseDeleteProviderResponse(rsp)
 }
 
-// ListSmsSmsGetWithResponse request returning *ListSmsSmsGetResponse
-func (c *ClientWithResponses) ListSmsSmsGetWithResponse(ctx context.Context, params *ListSmsSmsGetParams, reqEditors ...RequestEditorFn) (*ListSmsSmsGetResponse, error) {
-	rsp, err := c.ListSmsSmsGet(ctx, params, reqEditors...)
+// ListSmsV1SmsGetWithResponse request returning *ListSmsV1SmsGetResponse
+func (c *ClientWithResponses) ListSmsV1SmsGetWithResponse(ctx context.Context, params *ListSmsV1SmsGetParams, reqEditors ...RequestEditorFn) (*ListSmsV1SmsGetResponse, error) {
+	rsp, err := c.ListSmsV1SmsGet(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseListSmsSmsGetResponse(rsp)
+	return ParseListSmsV1SmsGetResponse(rsp)
 }
 
-// CreateSmsSmsPostWithBodyWithResponse request with arbitrary body returning *CreateSmsSmsPostResponse
-func (c *ClientWithResponses) CreateSmsSmsPostWithBodyWithResponse(ctx context.Context, params *CreateSmsSmsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSmsSmsPostResponse, error) {
-	rsp, err := c.CreateSmsSmsPostWithBody(ctx, params, contentType, body, reqEditors...)
+// CreateSmsV1SmsPostWithBodyWithResponse request with arbitrary body returning *CreateSmsV1SmsPostResponse
+func (c *ClientWithResponses) CreateSmsV1SmsPostWithBodyWithResponse(ctx context.Context, params *CreateSmsV1SmsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSmsV1SmsPostResponse, error) {
+	rsp, err := c.CreateSmsV1SmsPostWithBody(ctx, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseCreateSmsSmsPostResponse(rsp)
+	return ParseCreateSmsV1SmsPostResponse(rsp)
 }
 
-func (c *ClientWithResponses) CreateSmsSmsPostWithResponse(ctx context.Context, params *CreateSmsSmsPostParams, body CreateSmsSmsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateSmsSmsPostResponse, error) {
-	rsp, err := c.CreateSmsSmsPost(ctx, params, body, reqEditors...)
+func (c *ClientWithResponses) CreateSmsV1SmsPostWithResponse(ctx context.Context, params *CreateSmsV1SmsPostParams, body CreateSmsV1SmsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateSmsV1SmsPostResponse, error) {
+	rsp, err := c.CreateSmsV1SmsPost(ctx, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseCreateSmsSmsPostResponse(rsp)
+	return ParseCreateSmsV1SmsPostResponse(rsp)
 }
 
-// GetSenderIdSmsSenderIdGetWithResponse request returning *GetSenderIdSmsSenderIdGetResponse
-func (c *ClientWithResponses) GetSenderIdSmsSenderIdGetWithResponse(ctx context.Context, params *GetSenderIdSmsSenderIdGetParams, reqEditors ...RequestEditorFn) (*GetSenderIdSmsSenderIdGetResponse, error) {
-	rsp, err := c.GetSenderIdSmsSenderIdGet(ctx, params, reqEditors...)
+// GetSenderIdV1SmsSenderIdGetWithResponse request returning *GetSenderIdV1SmsSenderIdGetResponse
+func (c *ClientWithResponses) GetSenderIdV1SmsSenderIdGetWithResponse(ctx context.Context, params *GetSenderIdV1SmsSenderIdGetParams, reqEditors ...RequestEditorFn) (*GetSenderIdV1SmsSenderIdGetResponse, error) {
+	rsp, err := c.GetSenderIdV1SmsSenderIdGet(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetSenderIdSmsSenderIdGetResponse(rsp)
+	return ParseGetSenderIdV1SmsSenderIdGetResponse(rsp)
 }
 
-// PatchSenderIdSmsSenderIdPatchWithBodyWithResponse request with arbitrary body returning *PatchSenderIdSmsSenderIdPatchResponse
-func (c *ClientWithResponses) PatchSenderIdSmsSenderIdPatchWithBodyWithResponse(ctx context.Context, params *PatchSenderIdSmsSenderIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchSenderIdSmsSenderIdPatchResponse, error) {
-	rsp, err := c.PatchSenderIdSmsSenderIdPatchWithBody(ctx, params, contentType, body, reqEditors...)
+// PatchSenderIdV1SmsSenderIdPatchWithBodyWithResponse request with arbitrary body returning *PatchSenderIdV1SmsSenderIdPatchResponse
+func (c *ClientWithResponses) PatchSenderIdV1SmsSenderIdPatchWithBodyWithResponse(ctx context.Context, params *PatchSenderIdV1SmsSenderIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchSenderIdV1SmsSenderIdPatchResponse, error) {
+	rsp, err := c.PatchSenderIdV1SmsSenderIdPatchWithBody(ctx, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePatchSenderIdSmsSenderIdPatchResponse(rsp)
+	return ParsePatchSenderIdV1SmsSenderIdPatchResponse(rsp)
 }
 
-func (c *ClientWithResponses) PatchSenderIdSmsSenderIdPatchWithResponse(ctx context.Context, params *PatchSenderIdSmsSenderIdPatchParams, body PatchSenderIdSmsSenderIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchSenderIdSmsSenderIdPatchResponse, error) {
-	rsp, err := c.PatchSenderIdSmsSenderIdPatch(ctx, params, body, reqEditors...)
+func (c *ClientWithResponses) PatchSenderIdV1SmsSenderIdPatchWithResponse(ctx context.Context, params *PatchSenderIdV1SmsSenderIdPatchParams, body PatchSenderIdV1SmsSenderIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchSenderIdV1SmsSenderIdPatchResponse, error) {
+	rsp, err := c.PatchSenderIdV1SmsSenderIdPatch(ctx, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePatchSenderIdSmsSenderIdPatchResponse(rsp)
+	return ParsePatchSenderIdV1SmsSenderIdPatchResponse(rsp)
 }
 
-// ListSmsSuppressionsSmsSuppressionsGetWithResponse request returning *ListSmsSuppressionsSmsSuppressionsGetResponse
-func (c *ClientWithResponses) ListSmsSuppressionsSmsSuppressionsGetWithResponse(ctx context.Context, params *ListSmsSuppressionsSmsSuppressionsGetParams, reqEditors ...RequestEditorFn) (*ListSmsSuppressionsSmsSuppressionsGetResponse, error) {
-	rsp, err := c.ListSmsSuppressionsSmsSuppressionsGet(ctx, params, reqEditors...)
+// ListSmsSuppressionsV1SmsSuppressionsGetWithResponse request returning *ListSmsSuppressionsV1SmsSuppressionsGetResponse
+func (c *ClientWithResponses) ListSmsSuppressionsV1SmsSuppressionsGetWithResponse(ctx context.Context, params *ListSmsSuppressionsV1SmsSuppressionsGetParams, reqEditors ...RequestEditorFn) (*ListSmsSuppressionsV1SmsSuppressionsGetResponse, error) {
+	rsp, err := c.ListSmsSuppressionsV1SmsSuppressionsGet(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseListSmsSuppressionsSmsSuppressionsGetResponse(rsp)
+	return ParseListSmsSuppressionsV1SmsSuppressionsGetResponse(rsp)
 }
 
-// DeleteSmsSuppressionSmsSuppressionsNumberDeleteWithResponse request returning *DeleteSmsSuppressionSmsSuppressionsNumberDeleteResponse
-func (c *ClientWithResponses) DeleteSmsSuppressionSmsSuppressionsNumberDeleteWithResponse(ctx context.Context, number string, params *DeleteSmsSuppressionSmsSuppressionsNumberDeleteParams, reqEditors ...RequestEditorFn) (*DeleteSmsSuppressionSmsSuppressionsNumberDeleteResponse, error) {
-	rsp, err := c.DeleteSmsSuppressionSmsSuppressionsNumberDelete(ctx, number, params, reqEditors...)
+// DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteWithResponse request returning *DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteResponse
+func (c *ClientWithResponses) DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteWithResponse(ctx context.Context, number string, params *DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteParams, reqEditors ...RequestEditorFn) (*DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteResponse, error) {
+	rsp, err := c.DeleteSmsSuppressionV1SmsSuppressionsNumberDelete(ctx, number, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseDeleteSmsSuppressionSmsSuppressionsNumberDeleteResponse(rsp)
+	return ParseDeleteSmsSuppressionV1SmsSuppressionsNumberDeleteResponse(rsp)
 }
 
-// GetSmsSmsSmsIdGetWithResponse request returning *GetSmsSmsSmsIdGetResponse
-func (c *ClientWithResponses) GetSmsSmsSmsIdGetWithResponse(ctx context.Context, smsId openapi_types.UUID, params *GetSmsSmsSmsIdGetParams, reqEditors ...RequestEditorFn) (*GetSmsSmsSmsIdGetResponse, error) {
-	rsp, err := c.GetSmsSmsSmsIdGet(ctx, smsId, params, reqEditors...)
+// GetSmsV1SmsSmsIdGetWithResponse request returning *GetSmsV1SmsSmsIdGetResponse
+func (c *ClientWithResponses) GetSmsV1SmsSmsIdGetWithResponse(ctx context.Context, smsId openapi_types.UUID, params *GetSmsV1SmsSmsIdGetParams, reqEditors ...RequestEditorFn) (*GetSmsV1SmsSmsIdGetResponse, error) {
+	rsp, err := c.GetSmsV1SmsSmsIdGet(ctx, smsId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetSmsSmsSmsIdGetResponse(rsp)
+	return ParseGetSmsV1SmsSmsIdGetResponse(rsp)
 }
 
-// UnsubscribeUnsubscribeGetWithResponse request returning *UnsubscribeUnsubscribeGetResponse
-func (c *ClientWithResponses) UnsubscribeUnsubscribeGetWithResponse(ctx context.Context, params *UnsubscribeUnsubscribeGetParams, reqEditors ...RequestEditorFn) (*UnsubscribeUnsubscribeGetResponse, error) {
-	rsp, err := c.UnsubscribeUnsubscribeGet(ctx, params, reqEditors...)
+// UnsubscribeV1UnsubscribeGetWithResponse request returning *UnsubscribeV1UnsubscribeGetResponse
+func (c *ClientWithResponses) UnsubscribeV1UnsubscribeGetWithResponse(ctx context.Context, params *UnsubscribeV1UnsubscribeGetParams, reqEditors ...RequestEditorFn) (*UnsubscribeV1UnsubscribeGetResponse, error) {
+	rsp, err := c.UnsubscribeV1UnsubscribeGet(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseUnsubscribeUnsubscribeGetResponse(rsp)
+	return ParseUnsubscribeV1UnsubscribeGetResponse(rsp)
 }
 
-// ListSubscriptionsWebhooksGetWithResponse request returning *ListSubscriptionsWebhooksGetResponse
-func (c *ClientWithResponses) ListSubscriptionsWebhooksGetWithResponse(ctx context.Context, params *ListSubscriptionsWebhooksGetParams, reqEditors ...RequestEditorFn) (*ListSubscriptionsWebhooksGetResponse, error) {
-	rsp, err := c.ListSubscriptionsWebhooksGet(ctx, params, reqEditors...)
+// ListSubscriptionsV1WebhooksGetWithResponse request returning *ListSubscriptionsV1WebhooksGetResponse
+func (c *ClientWithResponses) ListSubscriptionsV1WebhooksGetWithResponse(ctx context.Context, params *ListSubscriptionsV1WebhooksGetParams, reqEditors ...RequestEditorFn) (*ListSubscriptionsV1WebhooksGetResponse, error) {
+	rsp, err := c.ListSubscriptionsV1WebhooksGet(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseListSubscriptionsWebhooksGetResponse(rsp)
+	return ParseListSubscriptionsV1WebhooksGetResponse(rsp)
 }
 
-// CreateSubscriptionWebhooksPostWithBodyWithResponse request with arbitrary body returning *CreateSubscriptionWebhooksPostResponse
-func (c *ClientWithResponses) CreateSubscriptionWebhooksPostWithBodyWithResponse(ctx context.Context, params *CreateSubscriptionWebhooksPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSubscriptionWebhooksPostResponse, error) {
-	rsp, err := c.CreateSubscriptionWebhooksPostWithBody(ctx, params, contentType, body, reqEditors...)
+// CreateSubscriptionV1WebhooksPostWithBodyWithResponse request with arbitrary body returning *CreateSubscriptionV1WebhooksPostResponse
+func (c *ClientWithResponses) CreateSubscriptionV1WebhooksPostWithBodyWithResponse(ctx context.Context, params *CreateSubscriptionV1WebhooksPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSubscriptionV1WebhooksPostResponse, error) {
+	rsp, err := c.CreateSubscriptionV1WebhooksPostWithBody(ctx, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseCreateSubscriptionWebhooksPostResponse(rsp)
+	return ParseCreateSubscriptionV1WebhooksPostResponse(rsp)
 }
 
-func (c *ClientWithResponses) CreateSubscriptionWebhooksPostWithResponse(ctx context.Context, params *CreateSubscriptionWebhooksPostParams, body CreateSubscriptionWebhooksPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateSubscriptionWebhooksPostResponse, error) {
-	rsp, err := c.CreateSubscriptionWebhooksPost(ctx, params, body, reqEditors...)
+func (c *ClientWithResponses) CreateSubscriptionV1WebhooksPostWithResponse(ctx context.Context, params *CreateSubscriptionV1WebhooksPostParams, body CreateSubscriptionV1WebhooksPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateSubscriptionV1WebhooksPostResponse, error) {
+	rsp, err := c.CreateSubscriptionV1WebhooksPost(ctx, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseCreateSubscriptionWebhooksPostResponse(rsp)
+	return ParseCreateSubscriptionV1WebhooksPostResponse(rsp)
 }
 
-// DeleteSubscriptionWebhooksSubIdDeleteWithResponse request returning *DeleteSubscriptionWebhooksSubIdDeleteResponse
-func (c *ClientWithResponses) DeleteSubscriptionWebhooksSubIdDeleteWithResponse(ctx context.Context, subId openapi_types.UUID, params *DeleteSubscriptionWebhooksSubIdDeleteParams, reqEditors ...RequestEditorFn) (*DeleteSubscriptionWebhooksSubIdDeleteResponse, error) {
-	rsp, err := c.DeleteSubscriptionWebhooksSubIdDelete(ctx, subId, params, reqEditors...)
+// DeleteSubscriptionV1WebhooksSubIdDeleteWithResponse request returning *DeleteSubscriptionV1WebhooksSubIdDeleteResponse
+func (c *ClientWithResponses) DeleteSubscriptionV1WebhooksSubIdDeleteWithResponse(ctx context.Context, subId openapi_types.UUID, params *DeleteSubscriptionV1WebhooksSubIdDeleteParams, reqEditors ...RequestEditorFn) (*DeleteSubscriptionV1WebhooksSubIdDeleteResponse, error) {
+	rsp, err := c.DeleteSubscriptionV1WebhooksSubIdDelete(ctx, subId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseDeleteSubscriptionWebhooksSubIdDeleteResponse(rsp)
+	return ParseDeleteSubscriptionV1WebhooksSubIdDeleteResponse(rsp)
 }
 
-// GetSubscriptionWebhooksSubIdGetWithResponse request returning *GetSubscriptionWebhooksSubIdGetResponse
-func (c *ClientWithResponses) GetSubscriptionWebhooksSubIdGetWithResponse(ctx context.Context, subId openapi_types.UUID, params *GetSubscriptionWebhooksSubIdGetParams, reqEditors ...RequestEditorFn) (*GetSubscriptionWebhooksSubIdGetResponse, error) {
-	rsp, err := c.GetSubscriptionWebhooksSubIdGet(ctx, subId, params, reqEditors...)
+// GetSubscriptionV1WebhooksSubIdGetWithResponse request returning *GetSubscriptionV1WebhooksSubIdGetResponse
+func (c *ClientWithResponses) GetSubscriptionV1WebhooksSubIdGetWithResponse(ctx context.Context, subId openapi_types.UUID, params *GetSubscriptionV1WebhooksSubIdGetParams, reqEditors ...RequestEditorFn) (*GetSubscriptionV1WebhooksSubIdGetResponse, error) {
+	rsp, err := c.GetSubscriptionV1WebhooksSubIdGet(ctx, subId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetSubscriptionWebhooksSubIdGetResponse(rsp)
+	return ParseGetSubscriptionV1WebhooksSubIdGetResponse(rsp)
 }
 
-// PatchSubscriptionWebhooksSubIdPatchWithBodyWithResponse request with arbitrary body returning *PatchSubscriptionWebhooksSubIdPatchResponse
-func (c *ClientWithResponses) PatchSubscriptionWebhooksSubIdPatchWithBodyWithResponse(ctx context.Context, subId openapi_types.UUID, params *PatchSubscriptionWebhooksSubIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchSubscriptionWebhooksSubIdPatchResponse, error) {
-	rsp, err := c.PatchSubscriptionWebhooksSubIdPatchWithBody(ctx, subId, params, contentType, body, reqEditors...)
+// PatchSubscriptionV1WebhooksSubIdPatchWithBodyWithResponse request with arbitrary body returning *PatchSubscriptionV1WebhooksSubIdPatchResponse
+func (c *ClientWithResponses) PatchSubscriptionV1WebhooksSubIdPatchWithBodyWithResponse(ctx context.Context, subId openapi_types.UUID, params *PatchSubscriptionV1WebhooksSubIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchSubscriptionV1WebhooksSubIdPatchResponse, error) {
+	rsp, err := c.PatchSubscriptionV1WebhooksSubIdPatchWithBody(ctx, subId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePatchSubscriptionWebhooksSubIdPatchResponse(rsp)
+	return ParsePatchSubscriptionV1WebhooksSubIdPatchResponse(rsp)
 }
 
-func (c *ClientWithResponses) PatchSubscriptionWebhooksSubIdPatchWithResponse(ctx context.Context, subId openapi_types.UUID, params *PatchSubscriptionWebhooksSubIdPatchParams, body PatchSubscriptionWebhooksSubIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchSubscriptionWebhooksSubIdPatchResponse, error) {
-	rsp, err := c.PatchSubscriptionWebhooksSubIdPatch(ctx, subId, params, body, reqEditors...)
+func (c *ClientWithResponses) PatchSubscriptionV1WebhooksSubIdPatchWithResponse(ctx context.Context, subId openapi_types.UUID, params *PatchSubscriptionV1WebhooksSubIdPatchParams, body PatchSubscriptionV1WebhooksSubIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchSubscriptionV1WebhooksSubIdPatchResponse, error) {
+	rsp, err := c.PatchSubscriptionV1WebhooksSubIdPatch(ctx, subId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePatchSubscriptionWebhooksSubIdPatchResponse(rsp)
+	return ParsePatchSubscriptionV1WebhooksSubIdPatchResponse(rsp)
 }
 
-// ListDeliveriesWebhooksSubIdDeliveriesGetWithResponse request returning *ListDeliveriesWebhooksSubIdDeliveriesGetResponse
-func (c *ClientWithResponses) ListDeliveriesWebhooksSubIdDeliveriesGetWithResponse(ctx context.Context, subId openapi_types.UUID, params *ListDeliveriesWebhooksSubIdDeliveriesGetParams, reqEditors ...RequestEditorFn) (*ListDeliveriesWebhooksSubIdDeliveriesGetResponse, error) {
-	rsp, err := c.ListDeliveriesWebhooksSubIdDeliveriesGet(ctx, subId, params, reqEditors...)
+// ListDeliveriesV1WebhooksSubIdDeliveriesGetWithResponse request returning *ListDeliveriesV1WebhooksSubIdDeliveriesGetResponse
+func (c *ClientWithResponses) ListDeliveriesV1WebhooksSubIdDeliveriesGetWithResponse(ctx context.Context, subId openapi_types.UUID, params *ListDeliveriesV1WebhooksSubIdDeliveriesGetParams, reqEditors ...RequestEditorFn) (*ListDeliveriesV1WebhooksSubIdDeliveriesGetResponse, error) {
+	rsp, err := c.ListDeliveriesV1WebhooksSubIdDeliveriesGet(ctx, subId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseListDeliveriesWebhooksSubIdDeliveriesGetResponse(rsp)
+	return ParseListDeliveriesV1WebhooksSubIdDeliveriesGetResponse(rsp)
 }
 
-// RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostWithResponse request returning *RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse
-func (c *ClientWithResponses) RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostWithResponse(ctx context.Context, subId openapi_types.UUID, deliveryId openapi_types.UUID, params *RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostParams, reqEditors ...RequestEditorFn) (*RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse, error) {
-	rsp, err := c.RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPost(ctx, subId, deliveryId, params, reqEditors...)
+// RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostWithResponse request returning *RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse
+func (c *ClientWithResponses) RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostWithResponse(ctx context.Context, subId openapi_types.UUID, deliveryId openapi_types.UUID, params *RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostParams, reqEditors ...RequestEditorFn) (*RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse, error) {
+	rsp, err := c.RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPost(ctx, subId, deliveryId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseRedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse(rsp)
+	return ParseRedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse(rsp)
 }
 
-// RotateSecretWebhooksSubIdRotateSecretPostWithResponse request returning *RotateSecretWebhooksSubIdRotateSecretPostResponse
-func (c *ClientWithResponses) RotateSecretWebhooksSubIdRotateSecretPostWithResponse(ctx context.Context, subId openapi_types.UUID, params *RotateSecretWebhooksSubIdRotateSecretPostParams, reqEditors ...RequestEditorFn) (*RotateSecretWebhooksSubIdRotateSecretPostResponse, error) {
-	rsp, err := c.RotateSecretWebhooksSubIdRotateSecretPost(ctx, subId, params, reqEditors...)
+// RotateSecretV1WebhooksSubIdRotateSecretPostWithResponse request returning *RotateSecretV1WebhooksSubIdRotateSecretPostResponse
+func (c *ClientWithResponses) RotateSecretV1WebhooksSubIdRotateSecretPostWithResponse(ctx context.Context, subId openapi_types.UUID, params *RotateSecretV1WebhooksSubIdRotateSecretPostParams, reqEditors ...RequestEditorFn) (*RotateSecretV1WebhooksSubIdRotateSecretPostResponse, error) {
+	rsp, err := c.RotateSecretV1WebhooksSubIdRotateSecretPost(ctx, subId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseRotateSecretWebhooksSubIdRotateSecretPostResponse(rsp)
+	return ParseRotateSecretV1WebhooksSubIdRotateSecretPostResponse(rsp)
 }
 
-// GetWhoamiWhoamiGetWithResponse request returning *GetWhoamiWhoamiGetResponse
-func (c *ClientWithResponses) GetWhoamiWhoamiGetWithResponse(ctx context.Context, params *GetWhoamiWhoamiGetParams, reqEditors ...RequestEditorFn) (*GetWhoamiWhoamiGetResponse, error) {
-	rsp, err := c.GetWhoamiWhoamiGet(ctx, params, reqEditors...)
+// GetWhoamiV1WhoamiGetWithResponse request returning *GetWhoamiV1WhoamiGetResponse
+func (c *ClientWithResponses) GetWhoamiV1WhoamiGetWithResponse(ctx context.Context, params *GetWhoamiV1WhoamiGetParams, reqEditors ...RequestEditorFn) (*GetWhoamiV1WhoamiGetResponse, error) {
+	rsp, err := c.GetWhoamiV1WhoamiGet(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetWhoamiWhoamiGetResponse(rsp)
+	return ParseGetWhoamiV1WhoamiGetResponse(rsp)
 }
 
-// ParseListCallsCallsGetResponse parses an HTTP response from a ListCallsCallsGetWithResponse call
-func ParseListCallsCallsGetResponse(rsp *http.Response) (*ListCallsCallsGetResponse, error) {
+// ParseHealthzHealthzGetResponse parses an HTTP response from a HealthzHealthzGetWithResponse call
+func ParseHealthzHealthzGetResponse(rsp *http.Response) (*HealthzHealthzGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ListCallsCallsGetResponse{
+	response := &HealthzHealthzGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]string
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListCallsV1CallsGetResponse parses an HTTP response from a ListCallsV1CallsGetWithResponse call
+func ParseListCallsV1CallsGetResponse(rsp *http.Response) (*ListCallsV1CallsGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListCallsV1CallsGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -8764,15 +9364,15 @@ func ParseListCallsCallsGetResponse(rsp *http.Response) (*ListCallsCallsGetRespo
 	return response, nil
 }
 
-// ParseCreateCallCallsPostResponse parses an HTTP response from a CreateCallCallsPostWithResponse call
-func ParseCreateCallCallsPostResponse(rsp *http.Response) (*CreateCallCallsPostResponse, error) {
+// ParseCreateCallV1CallsPostResponse parses an HTTP response from a CreateCallV1CallsPostWithResponse call
+func ParseCreateCallV1CallsPostResponse(rsp *http.Response) (*CreateCallV1CallsPostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &CreateCallCallsPostResponse{
+	response := &CreateCallV1CallsPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -8797,15 +9397,15 @@ func ParseCreateCallCallsPostResponse(rsp *http.Response) (*CreateCallCallsPostR
 	return response, nil
 }
 
-// ParseGetCallCallsCallIdGetResponse parses an HTTP response from a GetCallCallsCallIdGetWithResponse call
-func ParseGetCallCallsCallIdGetResponse(rsp *http.Response) (*GetCallCallsCallIdGetResponse, error) {
+// ParseGetCallV1CallsCallIdGetResponse parses an HTTP response from a GetCallV1CallsCallIdGetWithResponse call
+func ParseGetCallV1CallsCallIdGetResponse(rsp *http.Response) (*GetCallV1CallsCallIdGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetCallCallsCallIdGetResponse{
+	response := &GetCallV1CallsCallIdGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -8830,15 +9430,15 @@ func ParseGetCallCallsCallIdGetResponse(rsp *http.Response) (*GetCallCallsCallId
 	return response, nil
 }
 
-// ParseListContactsContactsGetResponse parses an HTTP response from a ListContactsContactsGetWithResponse call
-func ParseListContactsContactsGetResponse(rsp *http.Response) (*ListContactsContactsGetResponse, error) {
+// ParseListContactsV1ContactsGetResponse parses an HTTP response from a ListContactsV1ContactsGetWithResponse call
+func ParseListContactsV1ContactsGetResponse(rsp *http.Response) (*ListContactsV1ContactsGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ListContactsContactsGetResponse{
+	response := &ListContactsV1ContactsGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -8863,15 +9463,15 @@ func ParseListContactsContactsGetResponse(rsp *http.Response) (*ListContactsCont
 	return response, nil
 }
 
-// ParseCreateContactContactsPostResponse parses an HTTP response from a CreateContactContactsPostWithResponse call
-func ParseCreateContactContactsPostResponse(rsp *http.Response) (*CreateContactContactsPostResponse, error) {
+// ParseCreateContactV1ContactsPostResponse parses an HTTP response from a CreateContactV1ContactsPostWithResponse call
+func ParseCreateContactV1ContactsPostResponse(rsp *http.Response) (*CreateContactV1ContactsPostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &CreateContactContactsPostResponse{
+	response := &CreateContactV1ContactsPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -8896,15 +9496,15 @@ func ParseCreateContactContactsPostResponse(rsp *http.Response) (*CreateContactC
 	return response, nil
 }
 
-// ParseDeleteContactContactsContactIdDeleteResponse parses an HTTP response from a DeleteContactContactsContactIdDeleteWithResponse call
-func ParseDeleteContactContactsContactIdDeleteResponse(rsp *http.Response) (*DeleteContactContactsContactIdDeleteResponse, error) {
+// ParseDeleteContactV1ContactsContactIdDeleteResponse parses an HTTP response from a DeleteContactV1ContactsContactIdDeleteWithResponse call
+func ParseDeleteContactV1ContactsContactIdDeleteResponse(rsp *http.Response) (*DeleteContactV1ContactsContactIdDeleteResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &DeleteContactContactsContactIdDeleteResponse{
+	response := &DeleteContactV1ContactsContactIdDeleteResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -8922,15 +9522,15 @@ func ParseDeleteContactContactsContactIdDeleteResponse(rsp *http.Response) (*Del
 	return response, nil
 }
 
-// ParsePatchContactContactsContactIdPatchResponse parses an HTTP response from a PatchContactContactsContactIdPatchWithResponse call
-func ParsePatchContactContactsContactIdPatchResponse(rsp *http.Response) (*PatchContactContactsContactIdPatchResponse, error) {
+// ParsePatchContactV1ContactsContactIdPatchResponse parses an HTTP response from a PatchContactV1ContactsContactIdPatchWithResponse call
+func ParsePatchContactV1ContactsContactIdPatchResponse(rsp *http.Response) (*PatchContactV1ContactsContactIdPatchResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PatchContactContactsContactIdPatchResponse{
+	response := &PatchContactV1ContactsContactIdPatchResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -8988,15 +9588,15 @@ func ParseUploadEmailAttachmentResponse(rsp *http.Response) (*UploadEmailAttachm
 	return response, nil
 }
 
-// ParseListEmailDomainsEmailDomainsGetResponse parses an HTTP response from a ListEmailDomainsEmailDomainsGetWithResponse call
-func ParseListEmailDomainsEmailDomainsGetResponse(rsp *http.Response) (*ListEmailDomainsEmailDomainsGetResponse, error) {
+// ParseListEmailDomainsV1EmailDomainsGetResponse parses an HTTP response from a ListEmailDomainsV1EmailDomainsGetWithResponse call
+func ParseListEmailDomainsV1EmailDomainsGetResponse(rsp *http.Response) (*ListEmailDomainsV1EmailDomainsGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ListEmailDomainsEmailDomainsGetResponse{
+	response := &ListEmailDomainsV1EmailDomainsGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9021,15 +9621,15 @@ func ParseListEmailDomainsEmailDomainsGetResponse(rsp *http.Response) (*ListEmai
 	return response, nil
 }
 
-// ParseCreateEmailDomainEmailDomainsPostResponse parses an HTTP response from a CreateEmailDomainEmailDomainsPostWithResponse call
-func ParseCreateEmailDomainEmailDomainsPostResponse(rsp *http.Response) (*CreateEmailDomainEmailDomainsPostResponse, error) {
+// ParseCreateEmailDomainV1EmailDomainsPostResponse parses an HTTP response from a CreateEmailDomainV1EmailDomainsPostWithResponse call
+func ParseCreateEmailDomainV1EmailDomainsPostResponse(rsp *http.Response) (*CreateEmailDomainV1EmailDomainsPostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &CreateEmailDomainEmailDomainsPostResponse{
+	response := &CreateEmailDomainV1EmailDomainsPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9054,15 +9654,15 @@ func ParseCreateEmailDomainEmailDomainsPostResponse(rsp *http.Response) (*Create
 	return response, nil
 }
 
-// ParseCheckDomainEmailDomainsCheckDomainGetResponse parses an HTTP response from a CheckDomainEmailDomainsCheckDomainGetWithResponse call
-func ParseCheckDomainEmailDomainsCheckDomainGetResponse(rsp *http.Response) (*CheckDomainEmailDomainsCheckDomainGetResponse, error) {
+// ParseCheckDomainV1EmailDomainsCheckDomainGetResponse parses an HTTP response from a CheckDomainV1EmailDomainsCheckDomainGetWithResponse call
+func ParseCheckDomainV1EmailDomainsCheckDomainGetResponse(rsp *http.Response) (*CheckDomainV1EmailDomainsCheckDomainGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &CheckDomainEmailDomainsCheckDomainGetResponse{
+	response := &CheckDomainV1EmailDomainsCheckDomainGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9087,15 +9687,15 @@ func ParseCheckDomainEmailDomainsCheckDomainGetResponse(rsp *http.Response) (*Ch
 	return response, nil
 }
 
-// ParseDeleteEmailDomainEmailDomainsDomainIdDeleteResponse parses an HTTP response from a DeleteEmailDomainEmailDomainsDomainIdDeleteWithResponse call
-func ParseDeleteEmailDomainEmailDomainsDomainIdDeleteResponse(rsp *http.Response) (*DeleteEmailDomainEmailDomainsDomainIdDeleteResponse, error) {
+// ParseDeleteEmailDomainV1EmailDomainsDomainIdDeleteResponse parses an HTTP response from a DeleteEmailDomainV1EmailDomainsDomainIdDeleteWithResponse call
+func ParseDeleteEmailDomainV1EmailDomainsDomainIdDeleteResponse(rsp *http.Response) (*DeleteEmailDomainV1EmailDomainsDomainIdDeleteResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &DeleteEmailDomainEmailDomainsDomainIdDeleteResponse{
+	response := &DeleteEmailDomainV1EmailDomainsDomainIdDeleteResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9113,48 +9713,15 @@ func ParseDeleteEmailDomainEmailDomainsDomainIdDeleteResponse(rsp *http.Response
 	return response, nil
 }
 
-// ParseGetEmailDomainEmailDomainsDomainIdGetResponse parses an HTTP response from a GetEmailDomainEmailDomainsDomainIdGetWithResponse call
-func ParseGetEmailDomainEmailDomainsDomainIdGetResponse(rsp *http.Response) (*GetEmailDomainEmailDomainsDomainIdGetResponse, error) {
+// ParseGetEmailDomainV1EmailDomainsDomainIdGetResponse parses an HTTP response from a GetEmailDomainV1EmailDomainsDomainIdGetWithResponse call
+func ParseGetEmailDomainV1EmailDomainsDomainIdGetResponse(rsp *http.Response) (*GetEmailDomainV1EmailDomainsDomainIdGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetEmailDomainEmailDomainsDomainIdGetResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest EmailDomainResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
-		var dest HTTPValidationError
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON422 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParsePatchEmailDomainEmailDomainsDomainIdPatchResponse parses an HTTP response from a PatchEmailDomainEmailDomainsDomainIdPatchWithResponse call
-func ParsePatchEmailDomainEmailDomainsDomainIdPatchResponse(rsp *http.Response) (*PatchEmailDomainEmailDomainsDomainIdPatchResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &PatchEmailDomainEmailDomainsDomainIdPatchResponse{
+	response := &GetEmailDomainV1EmailDomainsDomainIdGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9179,15 +9746,15 @@ func ParsePatchEmailDomainEmailDomainsDomainIdPatchResponse(rsp *http.Response) 
 	return response, nil
 }
 
-// ParseVerifyEmailDomainEmailDomainsDomainIdVerifyPostResponse parses an HTTP response from a VerifyEmailDomainEmailDomainsDomainIdVerifyPostWithResponse call
-func ParseVerifyEmailDomainEmailDomainsDomainIdVerifyPostResponse(rsp *http.Response) (*VerifyEmailDomainEmailDomainsDomainIdVerifyPostResponse, error) {
+// ParsePatchEmailDomainV1EmailDomainsDomainIdPatchResponse parses an HTTP response from a PatchEmailDomainV1EmailDomainsDomainIdPatchWithResponse call
+func ParsePatchEmailDomainV1EmailDomainsDomainIdPatchResponse(rsp *http.Response) (*PatchEmailDomainV1EmailDomainsDomainIdPatchResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &VerifyEmailDomainEmailDomainsDomainIdVerifyPostResponse{
+	response := &PatchEmailDomainV1EmailDomainsDomainIdPatchResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9212,15 +9779,48 @@ func ParseVerifyEmailDomainEmailDomainsDomainIdVerifyPostResponse(rsp *http.Resp
 	return response, nil
 }
 
-// ParseListEmailsEmailsGetResponse parses an HTTP response from a ListEmailsEmailsGetWithResponse call
-func ParseListEmailsEmailsGetResponse(rsp *http.Response) (*ListEmailsEmailsGetResponse, error) {
+// ParseVerifyEmailDomainV1EmailDomainsDomainIdVerifyPostResponse parses an HTTP response from a VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostWithResponse call
+func ParseVerifyEmailDomainV1EmailDomainsDomainIdVerifyPostResponse(rsp *http.Response) (*VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ListEmailsEmailsGetResponse{
+	response := &VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest EmailDomainResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListEmailsV1EmailsGetResponse parses an HTTP response from a ListEmailsV1EmailsGetWithResponse call
+func ParseListEmailsV1EmailsGetResponse(rsp *http.Response) (*ListEmailsV1EmailsGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListEmailsV1EmailsGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9245,15 +9845,15 @@ func ParseListEmailsEmailsGetResponse(rsp *http.Response) (*ListEmailsEmailsGetR
 	return response, nil
 }
 
-// ParseCreateEmailEmailsPostResponse parses an HTTP response from a CreateEmailEmailsPostWithResponse call
-func ParseCreateEmailEmailsPostResponse(rsp *http.Response) (*CreateEmailEmailsPostResponse, error) {
+// ParseCreateEmailV1EmailsPostResponse parses an HTTP response from a CreateEmailV1EmailsPostWithResponse call
+func ParseCreateEmailV1EmailsPostResponse(rsp *http.Response) (*CreateEmailV1EmailsPostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &CreateEmailEmailsPostResponse{
+	response := &CreateEmailV1EmailsPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9278,15 +9878,15 @@ func ParseCreateEmailEmailsPostResponse(rsp *http.Response) (*CreateEmailEmailsP
 	return response, nil
 }
 
-// ParseGetEmailStatsEmailsStatsGetResponse parses an HTTP response from a GetEmailStatsEmailsStatsGetWithResponse call
-func ParseGetEmailStatsEmailsStatsGetResponse(rsp *http.Response) (*GetEmailStatsEmailsStatsGetResponse, error) {
+// ParseGetEmailStatsV1EmailsStatsGetResponse parses an HTTP response from a GetEmailStatsV1EmailsStatsGetWithResponse call
+func ParseGetEmailStatsV1EmailsStatsGetResponse(rsp *http.Response) (*GetEmailStatsV1EmailsStatsGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetEmailStatsEmailsStatsGetResponse{
+	response := &GetEmailStatsV1EmailsStatsGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9311,15 +9911,15 @@ func ParseGetEmailStatsEmailsStatsGetResponse(rsp *http.Response) (*GetEmailStat
 	return response, nil
 }
 
-// ParseGetEmailEmailsEmailIdGetResponse parses an HTTP response from a GetEmailEmailsEmailIdGetWithResponse call
-func ParseGetEmailEmailsEmailIdGetResponse(rsp *http.Response) (*GetEmailEmailsEmailIdGetResponse, error) {
+// ParseGetEmailV1EmailsEmailIdGetResponse parses an HTTP response from a GetEmailV1EmailsEmailIdGetWithResponse call
+func ParseGetEmailV1EmailsEmailIdGetResponse(rsp *http.Response) (*GetEmailV1EmailsEmailIdGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetEmailEmailsEmailIdGetResponse{
+	response := &GetEmailV1EmailsEmailIdGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9344,15 +9944,15 @@ func ParseGetEmailEmailsEmailIdGetResponse(rsp *http.Response) (*GetEmailEmailsE
 	return response, nil
 }
 
-// ParseGetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetResponse parses an HTTP response from a GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetWithResponse call
-func ParseGetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetResponse(rsp *http.Response) (*GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetResponse, error) {
+// ParseGetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetResponse parses an HTTP response from a GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetWithResponse call
+func ParseGetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetResponse(rsp *http.Response) (*GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetResponse{
+	response := &GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9377,15 +9977,15 @@ func ParseGetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetResponse(rsp 
 	return response, nil
 }
 
-// ParseListEmailEventsEmailsEmailIdEventsGetResponse parses an HTTP response from a ListEmailEventsEmailsEmailIdEventsGetWithResponse call
-func ParseListEmailEventsEmailsEmailIdEventsGetResponse(rsp *http.Response) (*ListEmailEventsEmailsEmailIdEventsGetResponse, error) {
+// ParseListEmailEventsV1EmailsEmailIdEventsGetResponse parses an HTTP response from a ListEmailEventsV1EmailsEmailIdEventsGetWithResponse call
+func ParseListEmailEventsV1EmailsEmailIdEventsGetResponse(rsp *http.Response) (*ListEmailEventsV1EmailsEmailIdEventsGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ListEmailEventsEmailsEmailIdEventsGetResponse{
+	response := &ListEmailEventsV1EmailsEmailIdEventsGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9410,15 +10010,15 @@ func ParseListEmailEventsEmailsEmailIdEventsGetResponse(rsp *http.Response) (*Li
 	return response, nil
 }
 
-// ParseGetEmailRawEmailsEmailIdRawGetResponse parses an HTTP response from a GetEmailRawEmailsEmailIdRawGetWithResponse call
-func ParseGetEmailRawEmailsEmailIdRawGetResponse(rsp *http.Response) (*GetEmailRawEmailsEmailIdRawGetResponse, error) {
+// ParseGetEmailRawV1EmailsEmailIdRawGetResponse parses an HTTP response from a GetEmailRawV1EmailsEmailIdRawGetWithResponse call
+func ParseGetEmailRawV1EmailsEmailIdRawGetResponse(rsp *http.Response) (*GetEmailRawV1EmailsEmailIdRawGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetEmailRawEmailsEmailIdRawGetResponse{
+	response := &GetEmailRawV1EmailsEmailIdRawGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9443,15 +10043,15 @@ func ParseGetEmailRawEmailsEmailIdRawGetResponse(rsp *http.Response) (*GetEmailR
 	return response, nil
 }
 
-// ParseListEventsEventsGetResponse parses an HTTP response from a ListEventsEventsGetWithResponse call
-func ParseListEventsEventsGetResponse(rsp *http.Response) (*ListEventsEventsGetResponse, error) {
+// ParseListEventsV1EventsGetResponse parses an HTTP response from a ListEventsV1EventsGetWithResponse call
+func ParseListEventsV1EventsGetResponse(rsp *http.Response) (*ListEventsV1EventsGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ListEventsEventsGetResponse{
+	response := &ListEventsV1EventsGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9476,41 +10076,15 @@ func ParseListEventsEventsGetResponse(rsp *http.Response) (*ListEventsEventsGetR
 	return response, nil
 }
 
-// ParseHealthzHealthzGetResponse parses an HTTP response from a HealthzHealthzGetWithResponse call
-func ParseHealthzHealthzGetResponse(rsp *http.Response) (*HealthzHealthzGetResponse, error) {
+// ParseDeleteMemberPhoneV1MembersUserIdPhoneDeleteResponse parses an HTTP response from a DeleteMemberPhoneV1MembersUserIdPhoneDeleteWithResponse call
+func ParseDeleteMemberPhoneV1MembersUserIdPhoneDeleteResponse(rsp *http.Response) (*DeleteMemberPhoneV1MembersUserIdPhoneDeleteResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &HealthzHealthzGetResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest map[string]string
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseDeleteMemberPhoneMembersUserIdPhoneDeleteResponse parses an HTTP response from a DeleteMemberPhoneMembersUserIdPhoneDeleteWithResponse call
-func ParseDeleteMemberPhoneMembersUserIdPhoneDeleteResponse(rsp *http.Response) (*DeleteMemberPhoneMembersUserIdPhoneDeleteResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &DeleteMemberPhoneMembersUserIdPhoneDeleteResponse{
+	response := &DeleteMemberPhoneV1MembersUserIdPhoneDeleteResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9528,15 +10102,15 @@ func ParseDeleteMemberPhoneMembersUserIdPhoneDeleteResponse(rsp *http.Response) 
 	return response, nil
 }
 
-// ParsePutMemberPhoneMembersUserIdPhonePutResponse parses an HTTP response from a PutMemberPhoneMembersUserIdPhonePutWithResponse call
-func ParsePutMemberPhoneMembersUserIdPhonePutResponse(rsp *http.Response) (*PutMemberPhoneMembersUserIdPhonePutResponse, error) {
+// ParsePutMemberPhoneV1MembersUserIdPhonePutResponse parses an HTTP response from a PutMemberPhoneV1MembersUserIdPhonePutWithResponse call
+func ParsePutMemberPhoneV1MembersUserIdPhonePutResponse(rsp *http.Response) (*PutMemberPhoneV1MembersUserIdPhonePutResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PutMemberPhoneMembersUserIdPhonePutResponse{
+	response := &PutMemberPhoneV1MembersUserIdPhonePutResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9561,15 +10135,15 @@ func ParsePutMemberPhoneMembersUserIdPhonePutResponse(rsp *http.Response) (*PutM
 	return response, nil
 }
 
-// ParseListNumbersNumbersGetResponse parses an HTTP response from a ListNumbersNumbersGetWithResponse call
-func ParseListNumbersNumbersGetResponse(rsp *http.Response) (*ListNumbersNumbersGetResponse, error) {
+// ParseListNumbersV1NumbersGetResponse parses an HTTP response from a ListNumbersV1NumbersGetWithResponse call
+func ParseListNumbersV1NumbersGetResponse(rsp *http.Response) (*ListNumbersV1NumbersGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ListNumbersNumbersGetResponse{
+	response := &ListNumbersV1NumbersGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9594,15 +10168,15 @@ func ParseListNumbersNumbersGetResponse(rsp *http.Response) (*ListNumbersNumbers
 	return response, nil
 }
 
-// ParseAcquireNumberNumbersPostResponse parses an HTTP response from a AcquireNumberNumbersPostWithResponse call
-func ParseAcquireNumberNumbersPostResponse(rsp *http.Response) (*AcquireNumberNumbersPostResponse, error) {
+// ParseAcquireNumberV1NumbersPostResponse parses an HTTP response from a AcquireNumberV1NumbersPostWithResponse call
+func ParseAcquireNumberV1NumbersPostResponse(rsp *http.Response) (*AcquireNumberV1NumbersPostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &AcquireNumberNumbersPostResponse{
+	response := &AcquireNumberV1NumbersPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9627,15 +10201,15 @@ func ParseAcquireNumberNumbersPostResponse(rsp *http.Response) (*AcquireNumberNu
 	return response, nil
 }
 
-// ParseReleaseNumberNumbersNumberIdDeleteResponse parses an HTTP response from a ReleaseNumberNumbersNumberIdDeleteWithResponse call
-func ParseReleaseNumberNumbersNumberIdDeleteResponse(rsp *http.Response) (*ReleaseNumberNumbersNumberIdDeleteResponse, error) {
+// ParseReleaseNumberV1NumbersNumberIdDeleteResponse parses an HTTP response from a ReleaseNumberV1NumbersNumberIdDeleteWithResponse call
+func ParseReleaseNumberV1NumbersNumberIdDeleteResponse(rsp *http.Response) (*ReleaseNumberV1NumbersNumberIdDeleteResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ReleaseNumberNumbersNumberIdDeleteResponse{
+	response := &ReleaseNumberV1NumbersNumberIdDeleteResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9653,15 +10227,15 @@ func ParseReleaseNumberNumbersNumberIdDeleteResponse(rsp *http.Response) (*Relea
 	return response, nil
 }
 
-// ParseGetNumberNumbersNumberIdGetResponse parses an HTTP response from a GetNumberNumbersNumberIdGetWithResponse call
-func ParseGetNumberNumbersNumberIdGetResponse(rsp *http.Response) (*GetNumberNumbersNumberIdGetResponse, error) {
+// ParseGetNumberV1NumbersNumberIdGetResponse parses an HTTP response from a GetNumberV1NumbersNumberIdGetWithResponse call
+func ParseGetNumberV1NumbersNumberIdGetResponse(rsp *http.Response) (*GetNumberV1NumbersNumberIdGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetNumberNumbersNumberIdGetResponse{
+	response := &GetNumberV1NumbersNumberIdGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9686,15 +10260,15 @@ func ParseGetNumberNumbersNumberIdGetResponse(rsp *http.Response) (*GetNumberNum
 	return response, nil
 }
 
-// ParseEnableSmsNumbersNumberIdEnableSmsPostResponse parses an HTTP response from a EnableSmsNumbersNumberIdEnableSmsPostWithResponse call
-func ParseEnableSmsNumbersNumberIdEnableSmsPostResponse(rsp *http.Response) (*EnableSmsNumbersNumberIdEnableSmsPostResponse, error) {
+// ParseEnableSmsV1NumbersNumberIdEnableSmsPostResponse parses an HTTP response from a EnableSmsV1NumbersNumberIdEnableSmsPostWithResponse call
+func ParseEnableSmsV1NumbersNumberIdEnableSmsPostResponse(rsp *http.Response) (*EnableSmsV1NumbersNumberIdEnableSmsPostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &EnableSmsNumbersNumberIdEnableSmsPostResponse{
+	response := &EnableSmsV1NumbersNumberIdEnableSmsPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9877,15 +10451,15 @@ func ParseDeleteProviderResponse(rsp *http.Response) (*DeleteProviderResponse, e
 	return response, nil
 }
 
-// ParseListSmsSmsGetResponse parses an HTTP response from a ListSmsSmsGetWithResponse call
-func ParseListSmsSmsGetResponse(rsp *http.Response) (*ListSmsSmsGetResponse, error) {
+// ParseListSmsV1SmsGetResponse parses an HTTP response from a ListSmsV1SmsGetWithResponse call
+func ParseListSmsV1SmsGetResponse(rsp *http.Response) (*ListSmsV1SmsGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ListSmsSmsGetResponse{
+	response := &ListSmsV1SmsGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9910,15 +10484,15 @@ func ParseListSmsSmsGetResponse(rsp *http.Response) (*ListSmsSmsGetResponse, err
 	return response, nil
 }
 
-// ParseCreateSmsSmsPostResponse parses an HTTP response from a CreateSmsSmsPostWithResponse call
-func ParseCreateSmsSmsPostResponse(rsp *http.Response) (*CreateSmsSmsPostResponse, error) {
+// ParseCreateSmsV1SmsPostResponse parses an HTTP response from a CreateSmsV1SmsPostWithResponse call
+func ParseCreateSmsV1SmsPostResponse(rsp *http.Response) (*CreateSmsV1SmsPostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &CreateSmsSmsPostResponse{
+	response := &CreateSmsV1SmsPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9943,15 +10517,15 @@ func ParseCreateSmsSmsPostResponse(rsp *http.Response) (*CreateSmsSmsPostRespons
 	return response, nil
 }
 
-// ParseGetSenderIdSmsSenderIdGetResponse parses an HTTP response from a GetSenderIdSmsSenderIdGetWithResponse call
-func ParseGetSenderIdSmsSenderIdGetResponse(rsp *http.Response) (*GetSenderIdSmsSenderIdGetResponse, error) {
+// ParseGetSenderIdV1SmsSenderIdGetResponse parses an HTTP response from a GetSenderIdV1SmsSenderIdGetWithResponse call
+func ParseGetSenderIdV1SmsSenderIdGetResponse(rsp *http.Response) (*GetSenderIdV1SmsSenderIdGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetSenderIdSmsSenderIdGetResponse{
+	response := &GetSenderIdV1SmsSenderIdGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -9976,15 +10550,15 @@ func ParseGetSenderIdSmsSenderIdGetResponse(rsp *http.Response) (*GetSenderIdSms
 	return response, nil
 }
 
-// ParsePatchSenderIdSmsSenderIdPatchResponse parses an HTTP response from a PatchSenderIdSmsSenderIdPatchWithResponse call
-func ParsePatchSenderIdSmsSenderIdPatchResponse(rsp *http.Response) (*PatchSenderIdSmsSenderIdPatchResponse, error) {
+// ParsePatchSenderIdV1SmsSenderIdPatchResponse parses an HTTP response from a PatchSenderIdV1SmsSenderIdPatchWithResponse call
+func ParsePatchSenderIdV1SmsSenderIdPatchResponse(rsp *http.Response) (*PatchSenderIdV1SmsSenderIdPatchResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PatchSenderIdSmsSenderIdPatchResponse{
+	response := &PatchSenderIdV1SmsSenderIdPatchResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -10009,15 +10583,15 @@ func ParsePatchSenderIdSmsSenderIdPatchResponse(rsp *http.Response) (*PatchSende
 	return response, nil
 }
 
-// ParseListSmsSuppressionsSmsSuppressionsGetResponse parses an HTTP response from a ListSmsSuppressionsSmsSuppressionsGetWithResponse call
-func ParseListSmsSuppressionsSmsSuppressionsGetResponse(rsp *http.Response) (*ListSmsSuppressionsSmsSuppressionsGetResponse, error) {
+// ParseListSmsSuppressionsV1SmsSuppressionsGetResponse parses an HTTP response from a ListSmsSuppressionsV1SmsSuppressionsGetWithResponse call
+func ParseListSmsSuppressionsV1SmsSuppressionsGetResponse(rsp *http.Response) (*ListSmsSuppressionsV1SmsSuppressionsGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ListSmsSuppressionsSmsSuppressionsGetResponse{
+	response := &ListSmsSuppressionsV1SmsSuppressionsGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -10042,15 +10616,15 @@ func ParseListSmsSuppressionsSmsSuppressionsGetResponse(rsp *http.Response) (*Li
 	return response, nil
 }
 
-// ParseDeleteSmsSuppressionSmsSuppressionsNumberDeleteResponse parses an HTTP response from a DeleteSmsSuppressionSmsSuppressionsNumberDeleteWithResponse call
-func ParseDeleteSmsSuppressionSmsSuppressionsNumberDeleteResponse(rsp *http.Response) (*DeleteSmsSuppressionSmsSuppressionsNumberDeleteResponse, error) {
+// ParseDeleteSmsSuppressionV1SmsSuppressionsNumberDeleteResponse parses an HTTP response from a DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteWithResponse call
+func ParseDeleteSmsSuppressionV1SmsSuppressionsNumberDeleteResponse(rsp *http.Response) (*DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &DeleteSmsSuppressionSmsSuppressionsNumberDeleteResponse{
+	response := &DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -10068,15 +10642,15 @@ func ParseDeleteSmsSuppressionSmsSuppressionsNumberDeleteResponse(rsp *http.Resp
 	return response, nil
 }
 
-// ParseGetSmsSmsSmsIdGetResponse parses an HTTP response from a GetSmsSmsSmsIdGetWithResponse call
-func ParseGetSmsSmsSmsIdGetResponse(rsp *http.Response) (*GetSmsSmsSmsIdGetResponse, error) {
+// ParseGetSmsV1SmsSmsIdGetResponse parses an HTTP response from a GetSmsV1SmsSmsIdGetWithResponse call
+func ParseGetSmsV1SmsSmsIdGetResponse(rsp *http.Response) (*GetSmsV1SmsSmsIdGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetSmsSmsSmsIdGetResponse{
+	response := &GetSmsV1SmsSmsIdGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -10101,15 +10675,15 @@ func ParseGetSmsSmsSmsIdGetResponse(rsp *http.Response) (*GetSmsSmsSmsIdGetRespo
 	return response, nil
 }
 
-// ParseUnsubscribeUnsubscribeGetResponse parses an HTTP response from a UnsubscribeUnsubscribeGetWithResponse call
-func ParseUnsubscribeUnsubscribeGetResponse(rsp *http.Response) (*UnsubscribeUnsubscribeGetResponse, error) {
+// ParseUnsubscribeV1UnsubscribeGetResponse parses an HTTP response from a UnsubscribeV1UnsubscribeGetWithResponse call
+func ParseUnsubscribeV1UnsubscribeGetResponse(rsp *http.Response) (*UnsubscribeV1UnsubscribeGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &UnsubscribeUnsubscribeGetResponse{
+	response := &UnsubscribeV1UnsubscribeGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -10127,15 +10701,15 @@ func ParseUnsubscribeUnsubscribeGetResponse(rsp *http.Response) (*UnsubscribeUns
 	return response, nil
 }
 
-// ParseListSubscriptionsWebhooksGetResponse parses an HTTP response from a ListSubscriptionsWebhooksGetWithResponse call
-func ParseListSubscriptionsWebhooksGetResponse(rsp *http.Response) (*ListSubscriptionsWebhooksGetResponse, error) {
+// ParseListSubscriptionsV1WebhooksGetResponse parses an HTTP response from a ListSubscriptionsV1WebhooksGetWithResponse call
+func ParseListSubscriptionsV1WebhooksGetResponse(rsp *http.Response) (*ListSubscriptionsV1WebhooksGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ListSubscriptionsWebhooksGetResponse{
+	response := &ListSubscriptionsV1WebhooksGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -10160,15 +10734,15 @@ func ParseListSubscriptionsWebhooksGetResponse(rsp *http.Response) (*ListSubscri
 	return response, nil
 }
 
-// ParseCreateSubscriptionWebhooksPostResponse parses an HTTP response from a CreateSubscriptionWebhooksPostWithResponse call
-func ParseCreateSubscriptionWebhooksPostResponse(rsp *http.Response) (*CreateSubscriptionWebhooksPostResponse, error) {
+// ParseCreateSubscriptionV1WebhooksPostResponse parses an HTTP response from a CreateSubscriptionV1WebhooksPostWithResponse call
+func ParseCreateSubscriptionV1WebhooksPostResponse(rsp *http.Response) (*CreateSubscriptionV1WebhooksPostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &CreateSubscriptionWebhooksPostResponse{
+	response := &CreateSubscriptionV1WebhooksPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -10193,15 +10767,15 @@ func ParseCreateSubscriptionWebhooksPostResponse(rsp *http.Response) (*CreateSub
 	return response, nil
 }
 
-// ParseDeleteSubscriptionWebhooksSubIdDeleteResponse parses an HTTP response from a DeleteSubscriptionWebhooksSubIdDeleteWithResponse call
-func ParseDeleteSubscriptionWebhooksSubIdDeleteResponse(rsp *http.Response) (*DeleteSubscriptionWebhooksSubIdDeleteResponse, error) {
+// ParseDeleteSubscriptionV1WebhooksSubIdDeleteResponse parses an HTTP response from a DeleteSubscriptionV1WebhooksSubIdDeleteWithResponse call
+func ParseDeleteSubscriptionV1WebhooksSubIdDeleteResponse(rsp *http.Response) (*DeleteSubscriptionV1WebhooksSubIdDeleteResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &DeleteSubscriptionWebhooksSubIdDeleteResponse{
+	response := &DeleteSubscriptionV1WebhooksSubIdDeleteResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -10219,48 +10793,15 @@ func ParseDeleteSubscriptionWebhooksSubIdDeleteResponse(rsp *http.Response) (*De
 	return response, nil
 }
 
-// ParseGetSubscriptionWebhooksSubIdGetResponse parses an HTTP response from a GetSubscriptionWebhooksSubIdGetWithResponse call
-func ParseGetSubscriptionWebhooksSubIdGetResponse(rsp *http.Response) (*GetSubscriptionWebhooksSubIdGetResponse, error) {
+// ParseGetSubscriptionV1WebhooksSubIdGetResponse parses an HTTP response from a GetSubscriptionV1WebhooksSubIdGetWithResponse call
+func ParseGetSubscriptionV1WebhooksSubIdGetResponse(rsp *http.Response) (*GetSubscriptionV1WebhooksSubIdGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetSubscriptionWebhooksSubIdGetResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest WebhookSubscriptionResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
-		var dest HTTPValidationError
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON422 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParsePatchSubscriptionWebhooksSubIdPatchResponse parses an HTTP response from a PatchSubscriptionWebhooksSubIdPatchWithResponse call
-func ParsePatchSubscriptionWebhooksSubIdPatchResponse(rsp *http.Response) (*PatchSubscriptionWebhooksSubIdPatchResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &PatchSubscriptionWebhooksSubIdPatchResponse{
+	response := &GetSubscriptionV1WebhooksSubIdGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -10285,15 +10826,48 @@ func ParsePatchSubscriptionWebhooksSubIdPatchResponse(rsp *http.Response) (*Patc
 	return response, nil
 }
 
-// ParseListDeliveriesWebhooksSubIdDeliveriesGetResponse parses an HTTP response from a ListDeliveriesWebhooksSubIdDeliveriesGetWithResponse call
-func ParseListDeliveriesWebhooksSubIdDeliveriesGetResponse(rsp *http.Response) (*ListDeliveriesWebhooksSubIdDeliveriesGetResponse, error) {
+// ParsePatchSubscriptionV1WebhooksSubIdPatchResponse parses an HTTP response from a PatchSubscriptionV1WebhooksSubIdPatchWithResponse call
+func ParsePatchSubscriptionV1WebhooksSubIdPatchResponse(rsp *http.Response) (*PatchSubscriptionV1WebhooksSubIdPatchResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ListDeliveriesWebhooksSubIdDeliveriesGetResponse{
+	response := &PatchSubscriptionV1WebhooksSubIdPatchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest WebhookSubscriptionResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListDeliveriesV1WebhooksSubIdDeliveriesGetResponse parses an HTTP response from a ListDeliveriesV1WebhooksSubIdDeliveriesGetWithResponse call
+func ParseListDeliveriesV1WebhooksSubIdDeliveriesGetResponse(rsp *http.Response) (*ListDeliveriesV1WebhooksSubIdDeliveriesGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListDeliveriesV1WebhooksSubIdDeliveriesGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -10318,15 +10892,15 @@ func ParseListDeliveriesWebhooksSubIdDeliveriesGetResponse(rsp *http.Response) (
 	return response, nil
 }
 
-// ParseRedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse parses an HTTP response from a RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostWithResponse call
-func ParseRedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse(rsp *http.Response) (*RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse, error) {
+// ParseRedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse parses an HTTP response from a RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostWithResponse call
+func ParseRedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse(rsp *http.Response) (*RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &RedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse{
+	response := &RedeliverV1WebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -10351,15 +10925,15 @@ func ParseRedeliverWebhooksSubIdDeliveriesDeliveryIdRedeliverPostResponse(rsp *h
 	return response, nil
 }
 
-// ParseRotateSecretWebhooksSubIdRotateSecretPostResponse parses an HTTP response from a RotateSecretWebhooksSubIdRotateSecretPostWithResponse call
-func ParseRotateSecretWebhooksSubIdRotateSecretPostResponse(rsp *http.Response) (*RotateSecretWebhooksSubIdRotateSecretPostResponse, error) {
+// ParseRotateSecretV1WebhooksSubIdRotateSecretPostResponse parses an HTTP response from a RotateSecretV1WebhooksSubIdRotateSecretPostWithResponse call
+func ParseRotateSecretV1WebhooksSubIdRotateSecretPostResponse(rsp *http.Response) (*RotateSecretV1WebhooksSubIdRotateSecretPostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &RotateSecretWebhooksSubIdRotateSecretPostResponse{
+	response := &RotateSecretV1WebhooksSubIdRotateSecretPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -10384,15 +10958,15 @@ func ParseRotateSecretWebhooksSubIdRotateSecretPostResponse(rsp *http.Response) 
 	return response, nil
 }
 
-// ParseGetWhoamiWhoamiGetResponse parses an HTTP response from a GetWhoamiWhoamiGetWithResponse call
-func ParseGetWhoamiWhoamiGetResponse(rsp *http.Response) (*GetWhoamiWhoamiGetResponse, error) {
+// ParseGetWhoamiV1WhoamiGetResponse parses an HTTP response from a GetWhoamiV1WhoamiGetWithResponse call
+func ParseGetWhoamiV1WhoamiGetResponse(rsp *http.Response) (*GetWhoamiV1WhoamiGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetWhoamiWhoamiGetResponse{
+	response := &GetWhoamiV1WhoamiGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/cli/internal/cmd/call.go
+++ b/cli/internal/cmd/call.go
@@ -146,7 +146,7 @@ func runCall(cmd *cobra.Command, opts *Options, f *callFlags, toNumber string) e
 		return err
 	}
 
-	resp, err := apiClient.CreateCallCallsPostWithResponse(ctx, &client.CreateCallCallsPostParams{}, body)
+	resp, err := apiClient.CreateCallV1CallsPostWithResponse(ctx, &client.CreateCallV1CallsPostParams{}, body)
 	if err != nil {
 		return fmt.Errorf("call API: %w", err)
 	}

--- a/cli/internal/cmd/call_list.go
+++ b/cli/internal/cmd/call_list.go
@@ -47,16 +47,16 @@ func runCallList(ctx context.Context, opts *Options, f *callListFlags) error {
 
 	items, next, err := walkCursor(f.all, f.cursor, opts.Stderr, "calls",
 		func(cursor string) (cursorPage[client.CallResponse], error) {
-			params := &client.ListCallsCallsGetParams{
+			params := &client.ListCallsV1CallsGetParams{
 				Limit:  &f.limit,
 				Cursor: strPtr(cursor),
 				To:     strPtr(f.to),
 			}
 			if f.status != "" {
-				s := client.ListCallsCallsGetParamsStatus(f.status)
+				s := client.ListCallsV1CallsGetParamsStatus(f.status)
 				params.Status = &s
 			}
-			resp, err := apiClient.ListCallsCallsGetWithResponse(ctx, params)
+			resp, err := apiClient.ListCallsV1CallsGetWithResponse(ctx, params)
 			if err != nil {
 				return cursorPage[client.CallResponse]{}, fmt.Errorf("call API: %w", err)
 			}

--- a/cli/internal/cmd/call_status.go
+++ b/cli/internal/cmd/call_status.go
@@ -43,8 +43,8 @@ func runCallStatus(ctx context.Context, opts *Options, idStr string) error {
 		return printCallStatus(opts, prefetched)
 	}
 
-	resp, err := apiClient.GetCallCallsCallIdGetWithResponse(
-		ctx, parsed, &client.GetCallCallsCallIdGetParams{},
+	resp, err := apiClient.GetCallV1CallsCallIdGetWithResponse(
+		ctx, parsed, &client.GetCallV1CallsCallIdGetParams{},
 	)
 	if err != nil {
 		return fmt.Errorf("call API: %w", err)

--- a/cli/internal/cmd/call_status_test.go
+++ b/cli/internal/cmd/call_status_test.go
@@ -45,7 +45,7 @@ func TestCallStatus_HappyPath(t *testing.T) {
 	if !strings.Contains(stdout, "Recording: recordings/abc.wav") {
 		t.Errorf("missing recording in stdout: %q", stdout)
 	}
-	if srv.lastReq.URL.Path != "/calls/"+resp.Id.String() {
+	if srv.lastReq.URL.Path != "/v1/calls/"+resp.Id.String() {
 		t.Errorf("path = %s", srv.lastReq.URL.Path)
 	}
 	if srv.lastReq.Method != http.MethodGet {
@@ -109,8 +109,8 @@ func TestCallStatus_PrefixResolution(t *testing.T) {
 	if got := atomic.LoadInt32(&srv.hits); got != 1 {
 		t.Errorf("expected 1 request (list only, no follow-up GET), got %d", got)
 	}
-	if srv.lastReq.URL.Path != "/calls" {
-		t.Errorf("path = %s; want /calls", srv.lastReq.URL.Path)
+	if srv.lastReq.URL.Path != "/v1/calls" {
+		t.Errorf("path = %s; want /v1/calls", srv.lastReq.URL.Path)
 	}
 	if !strings.Contains(stdout, fullID) {
 		t.Errorf("stdout missing resolved UUID:\n%s", stdout)

--- a/cli/internal/cmd/call_test.go
+++ b/cli/internal/cmd/call_test.go
@@ -96,7 +96,7 @@ func TestCallSubcommand_ModeA_HappyPath(t *testing.T) {
 	if got := atomic.LoadInt32(&srv.hits); got != 1 {
 		t.Fatalf("expected 1 request, got %d", got)
 	}
-	if srv.lastReq.Method != http.MethodPost || srv.lastReq.URL.Path != "/calls" {
+	if srv.lastReq.Method != http.MethodPost || srv.lastReq.URL.Path != "/v1/calls" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	if h := srv.lastReq.Header.Get("Authorization"); h != "Bearer sk_test" {

--- a/cli/internal/cmd/contacts.go
+++ b/cli/internal/cmd/contacts.go
@@ -89,12 +89,12 @@ func runContactsList(ctx context.Context, opts *Options, f *contactsListFlags) e
 
 	items, next, err := walkCursor(f.all, f.cursor, opts.Stderr, "contacts",
 		func(cursor string) (cursorPage[client.ContactEntry], error) {
-			params := &client.ListContactsContactsGetParams{
+			params := &client.ListContactsV1ContactsGetParams{
 				Q:      strPtr(f.q),
 				Cursor: strPtr(cursor),
 				Limit:  &f.limit,
 			}
-			resp, err := apiClient.ListContactsContactsGetWithResponse(ctx, params)
+			resp, err := apiClient.ListContactsV1ContactsGetWithResponse(ctx, params)
 			if err != nil {
 				return cursorPage[client.ContactEntry]{}, fmt.Errorf("contacts API: %w", err)
 			}
@@ -163,7 +163,7 @@ func runContactsCreate(ctx context.Context, cmd *cobra.Command, opts *Options, f
 		return err
 	}
 
-	resp, err := apiClient.CreateContactContactsPostWithResponse(ctx, &client.CreateContactContactsPostParams{}, body)
+	resp, err := apiClient.CreateContactV1ContactsPostWithResponse(ctx, &client.CreateContactV1ContactsPostParams{}, body)
 	if err != nil {
 		return fmt.Errorf("contacts API: %w", err)
 	}
@@ -226,7 +226,7 @@ func runContactsUpdate(ctx context.Context, cmd *cobra.Command, opts *Options, f
 		return err
 	}
 
-	resp, err := apiClient.PatchContactContactsContactIdPatchWithResponse(ctx, id, &client.PatchContactContactsContactIdPatchParams{}, body)
+	resp, err := apiClient.PatchContactV1ContactsContactIdPatchWithResponse(ctx, id, &client.PatchContactV1ContactsContactIdPatchParams{}, body)
 	if err != nil {
 		return fmt.Errorf("contacts API: %w", err)
 	}
@@ -262,7 +262,7 @@ func runContactsDelete(ctx context.Context, opts *Options, id string) error {
 		return err
 	}
 
-	resp, err := apiClient.DeleteContactContactsContactIdDeleteWithResponse(ctx, id, &client.DeleteContactContactsContactIdDeleteParams{})
+	resp, err := apiClient.DeleteContactV1ContactsContactIdDeleteWithResponse(ctx, id, &client.DeleteContactV1ContactsContactIdDeleteParams{})
 	if err != nil {
 		return fmt.Errorf("contacts API: %w", err)
 	}
@@ -311,7 +311,7 @@ func runContactsSetPhone(ctx context.Context, opts *Options, f *contactsSetPhone
 	}
 
 	body := client.MemberPhonePut{PhoneE164: f.phone}
-	resp, err := apiClient.PutMemberPhoneMembersUserIdPhonePutWithResponse(ctx, userID, &client.PutMemberPhoneMembersUserIdPhonePutParams{}, body)
+	resp, err := apiClient.PutMemberPhoneV1MembersUserIdPhonePutWithResponse(ctx, userID, &client.PutMemberPhoneV1MembersUserIdPhonePutParams{}, body)
 	if err != nil {
 		return fmt.Errorf("members API: %w", err)
 	}
@@ -347,7 +347,7 @@ func runContactsClearPhone(ctx context.Context, opts *Options, userID string) er
 		return err
 	}
 
-	resp, err := apiClient.DeleteMemberPhoneMembersUserIdPhoneDeleteWithResponse(ctx, userID, &client.DeleteMemberPhoneMembersUserIdPhoneDeleteParams{})
+	resp, err := apiClient.DeleteMemberPhoneV1MembersUserIdPhoneDeleteWithResponse(ctx, userID, &client.DeleteMemberPhoneV1MembersUserIdPhoneDeleteParams{})
 	if err != nil {
 		return fmt.Errorf("members API: %w", err)
 	}

--- a/cli/internal/cmd/contacts_test.go
+++ b/cli/internal/cmd/contacts_test.go
@@ -53,7 +53,7 @@ func TestContactsList_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodGet || srv.lastReq.URL.Path != "/contacts" {
+	if srv.lastReq.Method != http.MethodGet || srv.lastReq.URL.Path != "/v1/contacts" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	if !strings.Contains(stdout, "Jane Doe") || !strings.Contains(stdout, "Alice Admin") {
@@ -112,7 +112,7 @@ func TestContactsCreate_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodPost || srv.lastReq.URL.Path != "/contacts" {
+	if srv.lastReq.Method != http.MethodPost || srv.lastReq.URL.Path != "/v1/contacts" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	if h := srv.lastReq.Header.Get("Idempotency-Key"); h == "" {
@@ -256,7 +256,7 @@ func TestContactsUpdate_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodPatch || srv.lastReq.URL.Path != "/contacts/"+id {
+	if srv.lastReq.Method != http.MethodPatch || srv.lastReq.URL.Path != "/v1/contacts/"+id {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 
@@ -348,7 +348,7 @@ func TestContactsDelete_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodDelete || srv.lastReq.URL.Path != "/contacts/"+id {
+	if srv.lastReq.Method != http.MethodDelete || srv.lastReq.URL.Path != "/v1/contacts/"+id {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	if !strings.Contains(stdout, "deleted") {
@@ -392,7 +392,7 @@ func TestContactsDelete_MemberIDPassesThrough(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from server")
 	}
-	if srv.lastReq.URL.Path != "/contacts/member:22222222-2222-2222-2222-222222222222" {
+	if srv.lastReq.URL.Path != "/v1/contacts/member:22222222-2222-2222-2222-222222222222" {
 		t.Errorf("unexpected route: %s", srv.lastReq.URL.Path)
 	}
 }
@@ -411,7 +411,7 @@ func TestContactsSetPhone_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodPut || srv.lastReq.URL.Path != "/members/me/phone" {
+	if srv.lastReq.Method != http.MethodPut || srv.lastReq.URL.Path != "/v1/members/me/phone" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 
@@ -438,7 +438,7 @@ func TestContactsSetPhone_ExplicitUserID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.URL.Path != "/members/"+userID+"/phone" {
+	if srv.lastReq.URL.Path != "/v1/members/"+userID+"/phone" {
 		t.Fatalf("unexpected route: %s", srv.lastReq.URL.Path)
 	}
 }
@@ -471,7 +471,7 @@ func TestContactsClearPhone_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodDelete || srv.lastReq.URL.Path != "/members/me/phone" {
+	if srv.lastReq.Method != http.MethodDelete || srv.lastReq.URL.Path != "/v1/members/me/phone" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	if !strings.Contains(stdout, "cleared") {
@@ -490,7 +490,7 @@ func TestContactsClearPhone_ExplicitUserID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.URL.Path != "/members/"+userID+"/phone" {
+	if srv.lastReq.URL.Path != "/v1/members/"+userID+"/phone" {
 		t.Fatalf("unexpected route: %s", srv.lastReq.URL.Path)
 	}
 }

--- a/cli/internal/cmd/email.go
+++ b/cli/internal/cmd/email.go
@@ -214,7 +214,7 @@ func runEmailSend(ctx context.Context, cmd *cobra.Command, opts *Options, f *ema
 	}
 
 	// Deliberately the raw (non-WithResponse) client method here, not
-	// CreateEmailEmailsPostWithResponse: its generated parser eagerly
+	// CreateEmailV1EmailsPostWithResponse: its generated parser eagerly
 	// unmarshals ANY non-2xx JSON body into the OpenAPI-declared
 	// HTTPValidationError shape ({"detail": []ValidationError}) and
 	// discards the raw body if that unmarshal fails — which it does for
@@ -223,8 +223,8 @@ func runEmailSend(ctx context.Context, cmd *cobra.Command, opts *Options, f *ema
 	// verification", etc.), surfacing a raw Go json.Unmarshal error
 	// instead of the real message. Parsing the response ourselves keeps
 	// the real body available for apiError's safe fallback.
-	httpResp, err := apiClient.CreateEmailEmailsPost(
-		ctx, &client.CreateEmailEmailsPostParams{}, body,
+	httpResp, err := apiClient.CreateEmailV1EmailsPost(
+		ctx, &client.CreateEmailV1EmailsPostParams{}, body,
 	)
 	if err != nil {
 		return fmt.Errorf("email API: %w", err)

--- a/cli/internal/cmd/email_attachment.go
+++ b/cli/internal/cmd/email_attachment.go
@@ -64,9 +64,9 @@ func runEmailAttachment(ctx context.Context, cmd *cobra.Command, opts *Options, 
 		return err
 	}
 
-	resp, err := apiClient.GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGet(
+	resp, err := apiClient.GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGet(
 		ctx, openapi_types.UUID(emailID), openapi_types.UUID(attachID),
-		&client.GetEmailAttachmentEmailsEmailIdAttachmentsAttachmentIdGetParams{},
+		&client.GetEmailAttachmentV1EmailsEmailIdAttachmentsAttachmentIdGetParams{},
 	)
 	if err != nil {
 		return fmt.Errorf("attachment API: %w", err)
@@ -101,8 +101,8 @@ func resolveAttachmentID(ctx context.Context, apiClient *client.ClientWithRespon
 		return parsed, nil
 	}
 
-	parent, err := apiClient.GetEmailEmailsEmailIdGetWithResponse(
-		ctx, openapi_types.UUID(emailID), &client.GetEmailEmailsEmailIdGetParams{},
+	parent, err := apiClient.GetEmailV1EmailsEmailIdGetWithResponse(
+		ctx, openapi_types.UUID(emailID), &client.GetEmailV1EmailsEmailIdGetParams{},
 	)
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("email API: %w", err)

--- a/cli/internal/cmd/email_attachment_test.go
+++ b/cli/internal/cmd/email_attachment_test.go
@@ -35,7 +35,7 @@ func newAttachServer(t *testing.T, attID, payload string) *fakeServer {
 				"requested_at":"2026-06-28T00:00:00Z",
 				"attachments":[{"id":"`+attID+`","filename":"f.pdf","content_type":"application/pdf","size_bytes":4}]
 			}`)
-		case r.URL.Path == "/emails":
+		case r.URL.Path == "/v1/emails":
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_, _ = io.WriteString(w, `{"items":[{"id":"44444444-4444-4444-4444-444444444444"}],"next_cursor":null}`)

--- a/cli/internal/cmd/email_attachment_upload_test.go
+++ b/cli/internal/cmd/email_attachment_upload_test.go
@@ -32,7 +32,7 @@ func TestEmailAttachmentUpload_HappyPath(t *testing.T) {
 	if !strings.Contains(stdout, "11111111-1111-1111-1111-111111111111") {
 		t.Errorf("stdout missing id: %q", stdout)
 	}
-	if srv.lastReq.URL.Path != "/email-attachments" {
+	if srv.lastReq.URL.Path != "/v1/email-attachments" {
 		t.Fatalf("unexpected route: %s", srv.lastReq.URL.Path)
 	}
 }

--- a/cli/internal/cmd/email_domain.go
+++ b/cli/internal/cmd/email_domain.go
@@ -111,8 +111,8 @@ func runEmailDomainRegister(
 		return err
 	}
 
-	resp, err := apiClient.CreateEmailDomainEmailDomainsPostWithResponse(
-		ctx, &client.CreateEmailDomainEmailDomainsPostParams{}, body,
+	resp, err := apiClient.CreateEmailDomainV1EmailDomainsPostWithResponse(
+		ctx, &client.CreateEmailDomainV1EmailDomainsPostParams{}, body,
 	)
 	if err != nil {
 		return fmt.Errorf("email-domain API: %w", err)
@@ -156,11 +156,11 @@ func runEmailDomainList(
 	if err != nil {
 		return err
 	}
-	params := &client.ListEmailDomainsEmailDomainsGetParams{
+	params := &client.ListEmailDomainsV1EmailDomainsGetParams{
 		Limit:  &f.limit,
 		Cursor: strPtr(f.cursor),
 	}
-	resp, err := apiClient.ListEmailDomainsEmailDomainsGetWithResponse(ctx, params)
+	resp, err := apiClient.ListEmailDomainsV1EmailDomainsGetWithResponse(ctx, params)
 	if err != nil {
 		return fmt.Errorf("email-domain API: %w", err)
 	}
@@ -199,10 +199,10 @@ func runEmailDomainGet(ctx context.Context, opts *Options, id uuid.UUID) error {
 	if err != nil {
 		return err
 	}
-	resp, err := apiClient.GetEmailDomainEmailDomainsDomainIdGetWithResponse(
+	resp, err := apiClient.GetEmailDomainV1EmailDomainsDomainIdGetWithResponse(
 		ctx,
 		openapi_types.UUID(id),
-		&client.GetEmailDomainEmailDomainsDomainIdGetParams{},
+		&client.GetEmailDomainV1EmailDomainsDomainIdGetParams{},
 	)
 	if err != nil {
 		return fmt.Errorf("email-domain API: %w", err)
@@ -242,10 +242,10 @@ func runEmailDomainVerify(ctx context.Context, opts *Options, id uuid.UUID) erro
 	if err != nil {
 		return err
 	}
-	resp, err := apiClient.VerifyEmailDomainEmailDomainsDomainIdVerifyPostWithResponse(
+	resp, err := apiClient.VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostWithResponse(
 		ctx,
 		openapi_types.UUID(id),
-		&client.VerifyEmailDomainEmailDomainsDomainIdVerifyPostParams{},
+		&client.VerifyEmailDomainV1EmailDomainsDomainIdVerifyPostParams{},
 	)
 	if err != nil {
 		return fmt.Errorf("email-domain API: %w", err)
@@ -286,10 +286,10 @@ func runEmailDomainDelete(ctx context.Context, opts *Options, id uuid.UUID) erro
 	if err != nil {
 		return err
 	}
-	resp, err := apiClient.DeleteEmailDomainEmailDomainsDomainIdDelete(
+	resp, err := apiClient.DeleteEmailDomainV1EmailDomainsDomainIdDelete(
 		ctx,
 		openapi_types.UUID(id),
-		&client.DeleteEmailDomainEmailDomainsDomainIdDeleteParams{},
+		&client.DeleteEmailDomainV1EmailDomainsDomainIdDeleteParams{},
 	)
 	if err != nil {
 		return fmt.Errorf("email-domain API: %w", err)

--- a/cli/internal/cmd/email_domain_test.go
+++ b/cli/internal/cmd/email_domain_test.go
@@ -64,7 +64,7 @@ func TestEmailDomain_RegisterHailMail(t *testing.T) {
 	if got := atomic.LoadInt32(&srv.hits); got != 1 {
 		t.Fatalf("expected 1 request, got %d", got)
 	}
-	if srv.lastReq.URL.Path != "/email-domains" {
+	if srv.lastReq.URL.Path != "/v1/email-domains" {
 		t.Fatalf("unexpected path: %s", srv.lastReq.URL.Path)
 	}
 
@@ -190,7 +190,7 @@ func TestEmailDomain_Verify(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.URL.Path != "/email-domains/"+id+"/verify" {
+	if srv.lastReq.URL.Path != "/v1/email-domains/"+id+"/verify" {
 		t.Fatalf("unexpected path: %s", srv.lastReq.URL.Path)
 	}
 	if srv.lastReq.Method != http.MethodPost {

--- a/cli/internal/cmd/email_events.go
+++ b/cli/internal/cmd/email_events.go
@@ -70,11 +70,11 @@ func runEmailEvents(ctx context.Context, opts *Options, f *emailEventsFlags, inp
 func fetchEmailEventsPage(
 	ctx context.Context, apiClient *client.ClientWithResponses, id uuid.UUID, limit int, cursor string,
 ) (*client.EmailEventListResponse, error) {
-	params := &client.ListEmailEventsEmailsEmailIdEventsGetParams{Limit: &limit}
+	params := &client.ListEmailEventsV1EmailsEmailIdEventsGetParams{Limit: &limit}
 	if cursor != "" {
 		params.Cursor = &cursor
 	}
-	resp, err := apiClient.ListEmailEventsEmailsEmailIdEventsGetWithResponse(ctx, id, params)
+	resp, err := apiClient.ListEmailEventsV1EmailsEmailIdEventsGetWithResponse(ctx, id, params)
 	if err != nil {
 		return nil, fmt.Errorf("email API: %w", err)
 	}

--- a/cli/internal/cmd/email_get.go
+++ b/cli/internal/cmd/email_get.go
@@ -34,10 +34,10 @@ func runEmailGet(ctx context.Context, opts *Options, idStr string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := apiClient.GetEmailEmailsEmailIdGetWithResponse(
+	resp, err := apiClient.GetEmailV1EmailsEmailIdGetWithResponse(
 		ctx,
 		openapi_types.UUID(id),
-		&client.GetEmailEmailsEmailIdGetParams{},
+		&client.GetEmailV1EmailsEmailIdGetParams{},
 	)
 	if err != nil {
 		return fmt.Errorf("email API: %w", err)

--- a/cli/internal/cmd/email_list.go
+++ b/cli/internal/cmd/email_list.go
@@ -47,19 +47,19 @@ func runEmailList(ctx context.Context, opts *Options, f *emailListFlags) error {
 
 	items, next, err := walkCursor(f.all, f.cursor, opts.Stderr, "emails",
 		func(cursor string) (cursorPage[client.EmailSummary], error) {
-			params := &client.ListEmailsEmailsGetParams{
+			params := &client.ListEmailsV1EmailsGetParams{
 				Limit:  &f.limit,
 				Cursor: strPtr(cursor),
 			}
 			if f.status != "" {
-				s := client.ListEmailsEmailsGetParamsStatus(f.status)
+				s := client.ListEmailsV1EmailsGetParamsStatus(f.status)
 				params.Status = &s
 			}
 			if f.direction != "" {
-				d := client.ListEmailsEmailsGetParamsDirection(f.direction)
+				d := client.ListEmailsV1EmailsGetParamsDirection(f.direction)
 				params.Direction = &d
 			}
-			resp, err := apiClient.ListEmailsEmailsGetWithResponse(ctx, params)
+			resp, err := apiClient.ListEmailsV1EmailsGetWithResponse(ctx, params)
 			if err != nil {
 				return cursorPage[client.EmailSummary]{}, fmt.Errorf("email API: %w", err)
 			}

--- a/cli/internal/cmd/email_raw.go
+++ b/cli/internal/cmd/email_raw.go
@@ -57,8 +57,8 @@ func runEmailRaw(ctx context.Context, cmd *cobra.Command, opts *Options, input, 
 	if err != nil {
 		return err
 	}
-	resp, err := apiClient.GetEmailRawEmailsEmailIdRawGet(
-		ctx, openapi_types.UUID(id), &client.GetEmailRawEmailsEmailIdRawGetParams{},
+	resp, err := apiClient.GetEmailRawV1EmailsEmailIdRawGet(
+		ctx, openapi_types.UUID(id), &client.GetEmailRawV1EmailsEmailIdRawGetParams{},
 	)
 	if err != nil {
 		return fmt.Errorf("email raw API: %w", err)

--- a/cli/internal/cmd/email_stats.go
+++ b/cli/internal/cmd/email_stats.go
@@ -41,7 +41,7 @@ func runEmailStats(ctx context.Context, opts *Options, f *emailStatsFlags) error
 		return err
 	}
 
-	params := &client.GetEmailStatsEmailsStatsGetParams{}
+	params := &client.GetEmailStatsV1EmailsStatsGetParams{}
 	if f.from != "" {
 		t, err := time.Parse(time.RFC3339, f.from)
 		if err != nil {
@@ -57,11 +57,11 @@ func runEmailStats(ctx context.Context, opts *Options, f *emailStatsFlags) error
 		params.To = &t
 	}
 	if f.bucket != "" {
-		b := client.GetEmailStatsEmailsStatsGetParamsBucket(f.bucket)
+		b := client.GetEmailStatsV1EmailsStatsGetParamsBucket(f.bucket)
 		params.Bucket = &b
 	}
 
-	resp, err := apiClient.GetEmailStatsEmailsStatsGetWithResponse(ctx, params)
+	resp, err := apiClient.GetEmailStatsV1EmailsStatsGetWithResponse(ctx, params)
 	if err != nil {
 		return fmt.Errorf("email API: %w", err)
 	}

--- a/cli/internal/cmd/email_stats_test.go
+++ b/cli/internal/cmd/email_stats_test.go
@@ -13,7 +13,7 @@ func TestEmailStatsRendersTotalsAndRates(t *testing.T) {
 	srv.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&srv.hits, 1)
 		srv.lastReq = r.Clone(r.Context())
-		if r.URL.Path != "/emails/stats" {
+		if r.URL.Path != "/v1/emails/stats" {
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/cli/internal/cmd/email_test.go
+++ b/cli/internal/cmd/email_test.go
@@ -59,7 +59,7 @@ func TestEmailSend_HappyPath(t *testing.T) {
 	if got := atomic.LoadInt32(&srv.hits); got != 1 {
 		t.Fatalf("expected 1 request, got %d", got)
 	}
-	if srv.lastReq.Method != http.MethodPost || srv.lastReq.URL.Path != "/emails" {
+	if srv.lastReq.Method != http.MethodPost || srv.lastReq.URL.Path != "/v1/emails" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	if h := srv.lastReq.Header.Get("Authorization"); h != "Bearer sk_test" {
@@ -367,7 +367,7 @@ func TestEmailSend_AttachFlag(t *testing.T) {
 
 	mux := http.NewServeMux()
 	var sendBody []byte
-	mux.HandleFunc("/email-attachments", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v1/email-attachments", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -377,7 +377,7 @@ func TestEmailSend_AttachFlag(t *testing.T) {
 			"size_bytes":   9,
 		})
 	})
-	mux.HandleFunc("/emails", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v1/emails", func(w http.ResponseWriter, r *http.Request) {
 		sendBody, _ = io.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)

--- a/cli/internal/cmd/number.go
+++ b/cli/internal/cmd/number.go
@@ -95,8 +95,8 @@ func runNumberAcquire(ctx context.Context, cmd *cobra.Command, opts *Options, f 
 		return err
 	}
 
-	resp, err := apiClient.AcquireNumberNumbersPostWithResponse(
-		ctx, &client.AcquireNumberNumbersPostParams{}, body,
+	resp, err := apiClient.AcquireNumberV1NumbersPostWithResponse(
+		ctx, &client.AcquireNumberV1NumbersPostParams{}, body,
 	)
 	if err != nil {
 		return fmt.Errorf("numbers API: %w", err)
@@ -138,11 +138,11 @@ func runNumberList(ctx context.Context, opts *Options, f *numberListFlags) error
 	if err != nil {
 		return err
 	}
-	params := &client.ListNumbersNumbersGetParams{
+	params := &client.ListNumbersV1NumbersGetParams{
 		Limit:  &f.limit,
 		Cursor: strPtr(f.cursor),
 	}
-	resp, err := apiClient.ListNumbersNumbersGetWithResponse(ctx, params)
+	resp, err := apiClient.ListNumbersV1NumbersGetWithResponse(ctx, params)
 	if err != nil {
 		return fmt.Errorf("numbers API: %w", err)
 	}
@@ -180,10 +180,10 @@ func runNumberGet(ctx context.Context, opts *Options, id uuid.UUID) error {
 	if err != nil {
 		return err
 	}
-	resp, err := apiClient.GetNumberNumbersNumberIdGetWithResponse(
+	resp, err := apiClient.GetNumberV1NumbersNumberIdGetWithResponse(
 		ctx,
 		openapi_types.UUID(id),
-		&client.GetNumberNumbersNumberIdGetParams{},
+		&client.GetNumberV1NumbersNumberIdGetParams{},
 	)
 	if err != nil {
 		return fmt.Errorf("numbers API: %w", err)
@@ -225,10 +225,10 @@ func runNumberEnableSms(ctx context.Context, opts *Options, id uuid.UUID) error 
 	if err != nil {
 		return err
 	}
-	resp, err := apiClient.EnableSmsNumbersNumberIdEnableSmsPostWithResponse(
+	resp, err := apiClient.EnableSmsV1NumbersNumberIdEnableSmsPostWithResponse(
 		ctx,
 		openapi_types.UUID(id),
-		&client.EnableSmsNumbersNumberIdEnableSmsPostParams{},
+		&client.EnableSmsV1NumbersNumberIdEnableSmsPostParams{},
 	)
 	if err != nil {
 		return fmt.Errorf("numbers API: %w", err)

--- a/cli/internal/cmd/number_test.go
+++ b/cli/internal/cmd/number_test.go
@@ -42,7 +42,7 @@ func TestNumberAcquire_HappyPath(t *testing.T) {
 	if got := atomic.LoadInt32(&srv.hits); got != 1 {
 		t.Fatalf("expected 1 request, got %d", got)
 	}
-	if srv.lastReq.Method != http.MethodPost || srv.lastReq.URL.Path != "/numbers" {
+	if srv.lastReq.Method != http.MethodPost || srv.lastReq.URL.Path != "/v1/numbers" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	if h := srv.lastReq.Header.Get("Idempotency-Key"); h == "" {
@@ -154,7 +154,7 @@ func TestNumberList_RendersTable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.URL.Path != "/numbers" {
+	if srv.lastReq.URL.Path != "/v1/numbers" {
 		t.Fatalf("unexpected path: %s", srv.lastReq.URL.Path)
 	}
 	for _, want := range []string{"ID", "E164", "TYPE", "CAPABILITIES", "STATE", "+15551110001", "+15551110002"} {
@@ -192,7 +192,7 @@ func TestNumberGet_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodGet || srv.lastReq.URL.Path != "/numbers/"+resp.Id.String() {
+	if srv.lastReq.Method != http.MethodGet || srv.lastReq.URL.Path != "/v1/numbers/"+resp.Id.String() {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	if !strings.Contains(stdout, "+14155551234") {
@@ -230,7 +230,7 @@ func TestNumberEnableSms_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodPost || srv.lastReq.URL.Path != "/numbers/"+resp.Id.String()+"/enable-sms" {
+	if srv.lastReq.Method != http.MethodPost || srv.lastReq.URL.Path != "/v1/numbers/"+resp.Id.String()+"/enable-sms" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	if !strings.Contains(stdout, sid) {

--- a/cli/internal/cmd/providers_test.go
+++ b/cli/internal/cmd/providers_test.go
@@ -69,7 +69,7 @@ func TestProvidersList_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodGet || srv.lastReq.URL.Path != "/providers" {
+	if srv.lastReq.Method != http.MethodGet || srv.lastReq.URL.Path != "/v1/providers" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	for _, want := range []string{"LAYER", "PROVIDER", "openai-compatible", "…ABCD", "my-model"} {
@@ -113,7 +113,7 @@ func TestProvidersSet_RequestBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodPut || srv.lastReq.URL.Path != "/providers/llm" {
+	if srv.lastReq.Method != http.MethodPut || srv.lastReq.URL.Path != "/v1/providers/llm" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 
@@ -320,7 +320,7 @@ func TestProvidersDelete_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodDelete || srv.lastReq.URL.Path != "/providers/tts/cartesia" {
+	if srv.lastReq.Method != http.MethodDelete || srv.lastReq.URL.Path != "/v1/providers/tts/cartesia" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	if !strings.Contains(stdout, "deleted") {
@@ -355,7 +355,7 @@ func TestProvidersActivate_RequestBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodPost || srv.lastReq.URL.Path != "/providers/tts/activate" {
+	if srv.lastReq.Method != http.MethodPost || srv.lastReq.URL.Path != "/v1/providers/tts/activate" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	if body := decodeBody(t, srv.lastBody); body["provider"] != "cartesia" {
@@ -390,7 +390,7 @@ func TestProvidersTest_EmptyBodyByDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodPost || srv.lastReq.URL.Path != "/providers/llm/validate" {
+	if srv.lastReq.Method != http.MethodPost || srv.lastReq.URL.Path != "/v1/providers/llm/validate" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	if body := decodeBody(t, srv.lastBody); len(body) != 0 {

--- a/cli/internal/cmd/resolve.go
+++ b/cli/internal/cmd/resolve.go
@@ -108,7 +108,7 @@ func resolveIDPrefix[T any](
 func resolveCallID(ctx context.Context, apiClient *client.ClientWithResponses, input string) (uuid.UUID, *client.CallResponse, error) {
 	return resolveIDPrefix(ctx, input, "call",
 		func(ctx context.Context, limit int) ([]client.CallResponse, error) {
-			resp, err := apiClient.ListCallsCallsGetWithResponse(ctx, &client.ListCallsCallsGetParams{Limit: &limit})
+			resp, err := apiClient.ListCallsV1CallsGetWithResponse(ctx, &client.ListCallsV1CallsGetParams{Limit: &limit})
 			if err != nil {
 				return nil, err
 			}
@@ -124,7 +124,7 @@ func resolveCallID(ctx context.Context, apiClient *client.ClientWithResponses, i
 func resolveEmailID(ctx context.Context, apiClient *client.ClientWithResponses, input string) (uuid.UUID, error) {
 	id, _, err := resolveIDPrefix(ctx, input, "email",
 		func(ctx context.Context, limit int) ([]client.EmailSummary, error) {
-			resp, err := apiClient.ListEmailsEmailsGetWithResponse(ctx, &client.ListEmailsEmailsGetParams{Limit: &limit})
+			resp, err := apiClient.ListEmailsV1EmailsGetWithResponse(ctx, &client.ListEmailsV1EmailsGetParams{Limit: &limit})
 			if err != nil {
 				return nil, err
 			}
@@ -141,7 +141,7 @@ func resolveEmailID(ctx context.Context, apiClient *client.ClientWithResponses, 
 func resolveNumberID(ctx context.Context, apiClient *client.ClientWithResponses, input string) (uuid.UUID, error) {
 	id, _, err := resolveIDPrefix(ctx, input, "number",
 		func(ctx context.Context, limit int) ([]client.PhoneNumberResponse, error) {
-			resp, err := apiClient.ListNumbersNumbersGetWithResponse(ctx, &client.ListNumbersNumbersGetParams{Limit: &limit})
+			resp, err := apiClient.ListNumbersV1NumbersGetWithResponse(ctx, &client.ListNumbersV1NumbersGetParams{Limit: &limit})
 			if err != nil {
 				return nil, err
 			}
@@ -158,7 +158,7 @@ func resolveNumberID(ctx context.Context, apiClient *client.ClientWithResponses,
 func resolveEmailDomainID(ctx context.Context, apiClient *client.ClientWithResponses, input string) (uuid.UUID, error) {
 	id, _, err := resolveIDPrefix(ctx, input, "email-domain",
 		func(ctx context.Context, limit int) ([]client.EmailDomainResponse, error) {
-			resp, err := apiClient.ListEmailDomainsEmailDomainsGetWithResponse(ctx, &client.ListEmailDomainsEmailDomainsGetParams{Limit: &limit})
+			resp, err := apiClient.ListEmailDomainsV1EmailDomainsGetWithResponse(ctx, &client.ListEmailDomainsV1EmailDomainsGetParams{Limit: &limit})
 			if err != nil {
 				return nil, err
 			}

--- a/cli/internal/cmd/sms.go
+++ b/cli/internal/cmd/sms.go
@@ -86,7 +86,7 @@ func runSms(ctx context.Context, cmd *cobra.Command, opts *Options, f *smsFlags,
 		return err
 	}
 
-	resp, err := apiClient.CreateSmsSmsPostWithResponse(ctx, &client.CreateSmsSmsPostParams{}, body)
+	resp, err := apiClient.CreateSmsV1SmsPostWithResponse(ctx, &client.CreateSmsV1SmsPostParams{}, body)
 	if err != nil {
 		return fmt.Errorf("sms API: %w", err)
 	}
@@ -158,7 +158,7 @@ func runSmsStatus(ctx context.Context, opts *Options, idStr string) error {
 		return err
 	}
 
-	resp, err := apiClient.GetSmsSmsSmsIdGetWithResponse(ctx, id, &client.GetSmsSmsSmsIdGetParams{})
+	resp, err := apiClient.GetSmsV1SmsSmsIdGetWithResponse(ctx, id, &client.GetSmsV1SmsSmsIdGetParams{})
 	if err != nil {
 		return fmt.Errorf("sms API: %w", err)
 	}
@@ -203,17 +203,17 @@ func runSmsList(ctx context.Context, opts *Options, f *smsListFlags) error {
 		return err
 	}
 
-	params := &client.ListSmsSmsGetParams{
+	params := &client.ListSmsV1SmsGetParams{
 		Limit:  &f.limit,
 		Cursor: strPtr(f.cursor),
 		To:     strPtr(f.to),
 	}
 	if f.status != "" {
-		s := client.ListSmsSmsGetParamsStatus(f.status)
+		s := client.ListSmsV1SmsGetParamsStatus(f.status)
 		params.Status = &s
 	}
 
-	resp, err := apiClient.ListSmsSmsGetWithResponse(ctx, params)
+	resp, err := apiClient.ListSmsV1SmsGetWithResponse(ctx, params)
 	if err != nil {
 		return fmt.Errorf("sms API: %w", err)
 	}
@@ -276,7 +276,7 @@ func newSmsSuppressionsListCmd(opts *Options) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			resp, err := apiClient.ListSmsSuppressionsSmsSuppressionsGetWithResponse(ctx, &client.ListSmsSuppressionsSmsSuppressionsGetParams{
+			resp, err := apiClient.ListSmsSuppressionsV1SmsSuppressionsGetWithResponse(ctx, &client.ListSmsSuppressionsV1SmsSuppressionsGetParams{
 				Limit:  &limit,
 				Cursor: strPtr(cursor),
 			})
@@ -327,7 +327,7 @@ func newSmsSenderIdGetCmd(opts *Options) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			resp, err := apiClient.GetSenderIdSmsSenderIdGetWithResponse(ctx, &client.GetSenderIdSmsSenderIdGetParams{})
+			resp, err := apiClient.GetSenderIdV1SmsSenderIdGetWithResponse(ctx, &client.GetSenderIdV1SmsSenderIdGetParams{})
 			if err != nil {
 				return fmt.Errorf("sms sender-id API: %w", err)
 			}
@@ -377,7 +377,7 @@ either an empty value or --clear:
 				return err
 			}
 			body := client.SenderIdPatch{CustomSenderId: value}
-			resp, err := apiClient.PatchSenderIdSmsSenderIdPatchWithResponse(ctx, &client.PatchSenderIdSmsSenderIdPatchParams{}, body)
+			resp, err := apiClient.PatchSenderIdV1SmsSenderIdPatchWithResponse(ctx, &client.PatchSenderIdV1SmsSenderIdPatchParams{}, body)
 			if err != nil {
 				return fmt.Errorf("sms sender-id API: %w", err)
 			}
@@ -430,7 +430,7 @@ func newSmsSuppressionsDeleteCmd(opts *Options) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			resp, err := apiClient.DeleteSmsSuppressionSmsSuppressionsNumberDeleteWithResponse(ctx, args[0], &client.DeleteSmsSuppressionSmsSuppressionsNumberDeleteParams{})
+			resp, err := apiClient.DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteWithResponse(ctx, args[0], &client.DeleteSmsSuppressionV1SmsSuppressionsNumberDeleteParams{})
 			if err != nil {
 				return fmt.Errorf("sms suppressions API: %w", err)
 			}

--- a/cli/internal/cmd/sms_test.go
+++ b/cli/internal/cmd/sms_test.go
@@ -48,7 +48,7 @@ func TestSmsSubcommand_HappyPath(t *testing.T) {
 	if got := atomic.LoadInt32(&srv.hits); got != 1 {
 		t.Fatalf("expected 1 request, got %d", got)
 	}
-	if srv.lastReq.Method != http.MethodPost || srv.lastReq.URL.Path != "/sms" {
+	if srv.lastReq.Method != http.MethodPost || srv.lastReq.URL.Path != "/v1/sms" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	if h := srv.lastReq.Header.Get("Authorization"); h != "Bearer sk_test" {
@@ -318,7 +318,7 @@ func TestSmsStatus_HappyPath(t *testing.T) {
 	if !strings.Contains(stdout, "Provider:  "+sid) {
 		t.Errorf("missing provider sid in stdout: %q", stdout)
 	}
-	if srv.lastReq.URL.Path != "/sms/"+resp.Id.String() {
+	if srv.lastReq.URL.Path != "/v1/sms/"+resp.Id.String() {
 		t.Errorf("path = %s", srv.lastReq.URL.Path)
 	}
 	if srv.lastReq.Method != http.MethodGet {
@@ -447,7 +447,7 @@ func TestSmsSuppressionsList_RendersRows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodGet || srv.lastReq.URL.Path != "/sms/suppressions" {
+	if srv.lastReq.Method != http.MethodGet || srv.lastReq.URL.Path != "/v1/sms/suppressions" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	for _, want := range []string{"+15551110001", "stop_keyword", "inbound_sms", "+15551110002", "manual", "api"} {
@@ -504,7 +504,7 @@ func TestSmsSuppressionsDelete_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodDelete || srv.lastReq.URL.Path != "/sms/suppressions/+15551110001" {
+	if srv.lastReq.Method != http.MethodDelete || srv.lastReq.URL.Path != "/v1/sms/suppressions/+15551110001" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	if !strings.Contains(stdout, "Removed +15551110001") {
@@ -560,7 +560,7 @@ func TestSmsSenderIdGet_ShowsCustomAndDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodGet || srv.lastReq.URL.Path != "/sms/sender-id" {
+	if srv.lastReq.Method != http.MethodGet || srv.lastReq.URL.Path != "/v1/sms/sender-id" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	if !strings.Contains(stdout, "ACME") || !strings.Contains(stdout, "HAIL") {
@@ -594,7 +594,7 @@ func TestSmsSenderIdSet_SendsValue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if srv.lastReq.Method != http.MethodPatch || srv.lastReq.URL.Path != "/sms/sender-id" {
+	if srv.lastReq.Method != http.MethodPatch || srv.lastReq.URL.Path != "/v1/sms/sender-id" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	var body client.SenderIdPatch

--- a/cli/internal/cmd/tail.go
+++ b/cli/internal/cmd/tail.go
@@ -246,8 +246,8 @@ func runTail(ctx context.Context, opts *Options, f *tailFlags) error {
 	interval := time.Duration(f.intervalMS) * time.Millisecond
 	// Generous limit so a single fetch can drain a long backlog.
 	limit := 1000
-	buildParams := func(cur string) *client.ListEventsEventsGetParams {
-		return &client.ListEventsEventsGetParams{
+	buildParams := func(cur string) *client.ListEventsV1EventsGetParams {
+		return &client.ListEventsV1EventsGetParams{
 			Limit:  &limit,
 			Cursor: strPtr(cur),
 			Id:     strPtr(idWire),
@@ -255,7 +255,7 @@ func runTail(ctx context.Context, opts *Options, f *tailFlags) error {
 		}
 	}
 	fetch := func(cur string) (*client.EventStreamResponse, error) {
-		resp, err := apiClient.ListEventsEventsGetWithResponse(tailCtx, buildParams(cur))
+		resp, err := apiClient.ListEventsV1EventsGetWithResponse(tailCtx, buildParams(cur))
 		if err != nil {
 			if tailCtx.Err() != nil {
 				return nil, errInterrupted

--- a/cli/internal/cmd/tail_test.go
+++ b/cli/internal/cmd/tail_test.go
@@ -110,7 +110,7 @@ func TestTail_HappyPath_OrgWide(t *testing.T) {
 	if got := atomic.LoadInt32(&hits); got < 2 {
 		t.Errorf("expected at least 2 polls, got %d", got)
 	}
-	if lastReq == nil || lastReq.URL.Path != "/events" {
+	if lastReq == nil || lastReq.URL.Path != "/v1/events" {
 		t.Errorf("expected request path /events, got %v", lastReq)
 	}
 	for _, want := range []string{
@@ -689,7 +689,7 @@ func TestTail_ShortPrefixResolvesViaCallsList(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		switch {
-		case strings.HasPrefix(r.URL.Path, "/calls"):
+		case strings.HasPrefix(r.URL.Path, "/v1/calls"):
 			_ = json.NewEncoder(w).Encode(client.CallListResponse{
 				Items: []client.CallResponse{sampleCall(uuid.UUID(callA).String(), "+15551234567", client.CallResponseStatusCompleted)},
 			})

--- a/cli/internal/cmd/whoami.go
+++ b/cli/internal/cmd/whoami.go
@@ -37,8 +37,8 @@ func runWhoami(ctx context.Context, opts *Options) error {
 	if err != nil {
 		return err
 	}
-	resp, err := apiClient.GetWhoamiWhoamiGetWithResponse(
-		ctx, &client.GetWhoamiWhoamiGetParams{},
+	resp, err := apiClient.GetWhoamiV1WhoamiGetWithResponse(
+		ctx, &client.GetWhoamiV1WhoamiGetParams{},
 	)
 	if err != nil {
 		return fmt.Errorf("whoami API: %w", err)

--- a/cli/internal/cmd/whoami_test.go
+++ b/cli/internal/cmd/whoami_test.go
@@ -27,7 +27,7 @@ func TestWhoami_PrintsEmailOrgAndAuthKind(t *testing.T) {
 	if got := atomic.LoadInt32(&srv.hits); got != 1 {
 		t.Fatalf("expected 1 request, got %d", got)
 	}
-	if srv.lastReq.Method != http.MethodGet || srv.lastReq.URL.Path != "/whoami" {
+	if srv.lastReq.Method != http.MethodGet || srv.lastReq.URL.Path != "/v1/whoami" {
 		t.Fatalf("unexpected route: %s %s", srv.lastReq.Method, srv.lastReq.URL.Path)
 	}
 	for _, want := range []string{

--- a/core/hailhq/core/config.py
+++ b/core/hailhq/core/config.py
@@ -245,6 +245,16 @@ class Settings(BaseSettings):
     agent_global_sms_per_hour: int = 30
     agent_global_voice_per_hour: int = 15
 
+    # General per-caller HTTP request-rate ceiling (api/hailhq/api/ratelimit.py).
+    # Distinct from the agent_* velocity caps above: those are a DB-backed,
+    # per-org, per-channel *send* cap for agent-origin orgs only; this is an
+    # in-memory request-rate limiter across every customer-facing route, for
+    # every caller. 300/min = 5 req/sec sustained per caller — generous for
+    # legitimate agent/automation traffic, still bounds a runaway loop. This
+    # is a starting point, not a researched-and-final threshold — tune
+    # post-launch same as the velocity caps above.
+    api_rate_limit_per_minute: int = 300
+
     # SMS compliance auto-replies (HELP/STOP/START). OFF by default: Twilio's
     # own opt-out handling already auto-replies to these keywords, so enabling
     # Hail replies on top would double-text. Enable only when Twilio's default

--- a/core/hailhq/core/schemas.py
+++ b/core/hailhq/core/schemas.py
@@ -183,11 +183,42 @@ class ConsentAttestationMixin(BaseModel):
 class CallCreate(ConsentAttestationMixin):
     model_config = ConfigDict(extra="forbid")
 
-    to: str
-    from_: str | None = Field(default=None, alias="from")
-    system_prompt: str | None = None
-    llm: LLMConfig | None = None
-    first_message: str | None = None
+    to: str = Field(
+        description="Recipient phone number, E.164 format (e.g. +14155551234)."
+    )
+    from_: str | None = Field(
+        default=None,
+        alias="from",
+        description=(
+            "Caller-id phone number, E.164 format. Must be a number owned "
+            "by the organization with the voice capability. Omitted: an "
+            "active org-owned number is used if one exists, else a number "
+            "is claimed from the shared pool."
+        ),
+    )
+    system_prompt: str | None = Field(
+        default=None,
+        description=(
+            "Task instructions for the agent, sent as its leading system "
+            "message. At least one of system_prompt or llm is required; "
+            "both together is also valid."
+        ),
+    )
+    llm: LLMConfig | None = Field(
+        default=None,
+        description=(
+            "BYO LLM endpoint the call runs on instead of Hail's default "
+            "model. At least one of system_prompt or llm is required; both "
+            "together is also valid."
+        ),
+    )
+    first_message: str | None = Field(
+        default=None,
+        description=(
+            "Opening line the agent speaks first. Omitted: the agent waits "
+            "for the callee to speak first."
+        ),
+    )
     ai_disclosure: bool = Field(
         default=True,
         description=(
@@ -202,9 +233,28 @@ class CallCreate(ConsentAttestationMixin):
             "itself as an AI if asked."
         ),
     )
-    voice_config: VoiceConfig = Field(default_factory=VoiceConfig)
-    conversation_id: UUID | None = None
-    metadata: dict = Field(default_factory=dict)
+    voice_config: VoiceConfig = Field(
+        default_factory=VoiceConfig,
+        description=(
+            "TTS voice, VAD, turn-detection, and spoken-language settings "
+            "for this call."
+        ),
+    )
+    conversation_id: UUID | None = Field(
+        default=None,
+        description=(
+            "Groups this call with other calls/emails/SMS into one "
+            "conversation thread. Omitted: the call is not linked to a "
+            "conversation."
+        ),
+    )
+    metadata: dict = Field(
+        default_factory=dict,
+        description=(
+            "Free-form JSON object attached to the call and echoed back on "
+            "reads. Not interpreted by Hail."
+        ),
+    )
     tools: list[str] | None = Field(
         default=None,
         description=(
@@ -258,36 +308,97 @@ NumberType = Literal["local", "mobile", "toll_free", "national"]
 class CallResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-    id: UUID
-    organization_id: UUID
-    conversation_id: UUID | None
-    from_e164: str
-    to_e164: str
-    direction: Literal["outbound", "inbound"]
-    status: CallStatus
-    end_reason: str | None
-    provider_call_sid: str | None
-    livekit_room: str | None
-    initial_prompt: str | None
-    recording_s3_key: str | None
-    requested_at: datetime
-    started_at: datetime | None
-    answered_at: datetime | None
-    ended_at: datetime | None
+    id: UUID = Field(description="Unique identifier for this call.")
+    organization_id: UUID = Field(
+        description="Organization that placed or received this call."
+    )
+    conversation_id: UUID | None = Field(
+        description=(
+            "Conversation thread this call is grouped into, if any. Null "
+            "when the call was not linked to a conversation."
+        )
+    )
+    from_e164: str = Field(description="Caller-id phone number used, E.164 format.")
+    to_e164: str = Field(description="Recipient phone number, E.164 format.")
+    direction: Literal["outbound", "inbound"] = Field(
+        description="'outbound' for calls Hail placed, 'inbound' for calls received."
+    )
+    status: CallStatus = Field(
+        description=(
+            "Current call-progress state: 'queued', 'dialing', 'ringing', "
+            "'in_progress', or one of the terminal states 'completed', "
+            "'failed', 'busy', 'no_answer', 'canceled'."
+        )
+    )
+    end_reason: str | None = Field(
+        description=(
+            "Machine-readable reason the call reached a terminal status "
+            "(e.g. 'normal_hangup', 'user_rejected', 'sip_trunk_failure'). "
+            "Null while the call is still in progress."
+        )
+    )
+    provider_call_sid: str | None = Field(
+        description="The telephony provider's identifier for this call leg, if assigned."
+    )
+    livekit_room: str | None = Field(
+        description="Name of the LiveKit room hosting this call's media session, if one was created."
+    )
+    initial_prompt: str | None = Field(
+        description="The system_prompt this call was created with, if any."
+    )
+    recording_s3_key: str | None = Field(
+        description="Internal storage key for the call recording. Not a directly fetchable URL."
+    )
+    requested_at: datetime = Field(
+        description="When the call was requested, ISO 8601 timestamp."
+    )
+    started_at: datetime | None = Field(
+        description="When dialing began, ISO 8601 timestamp. Null until the call starts."
+    )
+    answered_at: datetime | None = Field(
+        description="When the callee answered, ISO 8601 timestamp. Null if never answered."
+    )
+    ended_at: datetime | None = Field(
+        description="When the call ended, ISO 8601 timestamp. Null while still in progress."
+    )
 
 
 class CallListResponse(BaseModel):
-    items: list[CallResponse]
-    next_cursor: str | None = None
+    items: list[CallResponse] = Field(description="Calls in this page, newest first.")
+    next_cursor: str | None = Field(
+        default=None,
+        description="Opaque cursor for the next page. Null when there are no more results.",
+    )
 
 
 class SmsCreate(ConsentAttestationMixin):
     model_config = ConfigDict(extra="forbid")
 
-    to: str
-    from_: str | None = Field(default=None, alias="from")
-    body: str = Field(min_length=1, max_length=1600)
-    metadata: dict = Field(default_factory=dict)
+    to: str = Field(
+        description="Recipient phone number, E.164 format (e.g. +14155551234)."
+    )
+    from_: str | None = Field(
+        default=None,
+        alias="from",
+        description=(
+            "Sender phone number, E.164 format. Must be a number owned by "
+            "the organization with the SMS capability. Omitted: an active "
+            "org-owned number is used if one exists, else a number is "
+            "claimed from the shared pool."
+        ),
+    )
+    body: str = Field(
+        min_length=1,
+        max_length=1600,
+        description="Message text. Long bodies are split into multiple carrier segments.",
+    )
+    metadata: dict = Field(
+        default_factory=dict,
+        description=(
+            "Free-form JSON object attached to the message and echoed back "
+            "on reads. Not interpreted by Hail."
+        ),
+    )
 
     _validate_e164 = field_validator("to", "from_")(_e164_or_error)
 
@@ -298,23 +409,45 @@ SmsStatus = Literal["queued", "sent", "delivered", "failed", "undelivered", "rec
 class SmsResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-    id: UUID
-    organization_id: UUID
-    from_e164: str
-    to_e164: str
-    direction: Literal["outbound", "inbound"]
-    status: SmsStatus
-    body: str
-    provider_message_sid: str | None
-    segment_count: int
-    error_code: str | None
-    requested_at: datetime
-    sent_at: datetime | None
+    id: UUID = Field(description="Unique identifier for this message.")
+    organization_id: UUID = Field(
+        description="Organization that sent or received this message."
+    )
+    from_e164: str = Field(description="Sender phone number, E.164 format.")
+    to_e164: str = Field(description="Recipient phone number, E.164 format.")
+    direction: Literal["outbound", "inbound"] = Field(
+        description="'outbound' for messages Hail sent, 'inbound' for messages received."
+    )
+    status: SmsStatus = Field(
+        description=(
+            "Delivery status: 'queued', 'sent', 'delivered', 'failed', "
+            "'undelivered', or 'received' (inbound messages)."
+        )
+    )
+    body: str = Field(description="Message text.")
+    provider_message_sid: str | None = Field(
+        description="The carrier/provider's identifier for this message, if assigned."
+    )
+    segment_count: int = Field(
+        description="Number of carrier SMS segments the body was split into."
+    )
+    error_code: str | None = Field(
+        description="Carrier error code if delivery failed. Null on success or while pending."
+    )
+    requested_at: datetime = Field(
+        description="When the send was requested, ISO 8601 timestamp."
+    )
+    sent_at: datetime | None = Field(
+        description="When the message was handed to the carrier, ISO 8601 timestamp. Null until sent."
+    )
 
 
 class SmsListResponse(BaseModel):
-    items: list[SmsResponse]
-    next_cursor: str | None = None
+    items: list[SmsResponse] = Field(description="Messages in this page, newest first.")
+    next_cursor: str | None = Field(
+        default=None,
+        description="Opaque cursor for the next page. Null when there are no more results.",
+    )
 
 
 # ``\Z`` (not ``$``) so a trailing newline is rejected: in Python ``$`` also
@@ -326,7 +459,15 @@ SENDER_ID_RE = re.compile(r"^[A-Za-z0-9]{2,11}\Z")
 class SenderIdPatch(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    custom_sender_id: str | None = None
+    custom_sender_id: str | None = Field(
+        default=None,
+        description=(
+            "Alphanumeric sender id (2-11 characters, letters/digits only) "
+            "to use on alphanumeric-eligible corridors instead of a phone "
+            "number. Explicit null clears it, reverting to the platform "
+            "default."
+        ),
+    )
 
     @field_validator("custom_sender_id")
     @classmethod
@@ -339,15 +480,30 @@ class SenderIdPatch(BaseModel):
 
 
 class SenderIdResponse(BaseModel):
-    custom_sender_id: str | None
-    effective_default: str = PLATFORM_DEFAULT_SENDER_ID
+    custom_sender_id: str | None = Field(
+        description="The organization's configured alphanumeric sender id. Null if none is set."
+    )
+    effective_default: str = Field(
+        default=PLATFORM_DEFAULT_SENDER_ID,
+        description=(
+            "The platform's alphanumeric sender id, used on eligible "
+            "corridors when custom_sender_id is null."
+        ),
+    )
 
 
 class NumberAcquireRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    country_code: str = Field(min_length=2, max_length=2)
-    number_type: NumberType = "local"
+    country_code: str = Field(
+        min_length=2,
+        max_length=2,
+        description="ISO alpha-2 country code to acquire a number in (e.g. 'US'). Case-insensitive.",
+    )
+    number_type: NumberType = Field(
+        default="local",
+        description="Kind of number to acquire: 'local', 'mobile', 'toll_free', or 'national'.",
+    )
 
     @field_validator("country_code")
     @classmethod
@@ -360,19 +516,35 @@ class NumberAcquireRequest(BaseModel):
 class PhoneNumberResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-    id: UUID
-    e164: str
-    country_code: str
-    number_type: str
-    capabilities: list[str]
-    provisioning_state: str
-    is_dedicated: bool
-    messaging_service_sid: str | None = None
+    id: UUID = Field(description="Unique identifier for this number.")
+    e164: str = Field(description="The phone number, E.164 format.")
+    country_code: str = Field(
+        description="ISO alpha-2 country code this number belongs to."
+    )
+    number_type: str = Field(
+        description="Kind of number: 'local', 'mobile', 'toll_free', or 'national'."
+    )
+    capabilities: list[str] = Field(
+        description="Channels this number supports, e.g. ['voice'], ['sms'], or both."
+    )
+    provisioning_state: str = Field(
+        description="'pending', 'active', 'failed', or 'released'."
+    )
+    is_dedicated: bool = Field(
+        description="True if this number is owned by the organization. False for shared-pool numbers."
+    )
+    messaging_service_sid: str | None = Field(
+        default=None,
+        description="Provider messaging-service identifier once SMS has been enabled on this number. Null until then.",
+    )
 
 
 class PhoneNumberListResponse(BaseModel):
-    items: list[PhoneNumberResponse]
-    next_cursor: str | None = None
+    items: list[PhoneNumberResponse] = Field(description="Numbers in this page.")
+    next_cursor: str | None = Field(
+        default=None,
+        description="Opaque cursor for the next page. Null when there are no more results.",
+    )
 
 
 class SuppressionResponse(BaseModel):
@@ -387,8 +559,13 @@ class SuppressionResponse(BaseModel):
 
 
 class SuppressionListResponse(BaseModel):
-    items: list[SuppressionResponse]
-    next_cursor: str | None = None
+    items: list[SuppressionResponse] = Field(
+        description="Suppressed recipients in this page."
+    )
+    next_cursor: str | None = Field(
+        default=None,
+        description="Opaque cursor for the next page. Null when there are no more results.",
+    )
 
 
 class EventResponse(BaseModel):
@@ -407,12 +584,22 @@ class EventResponse(BaseModel):
 
 
 class EventStreamResponse(BaseModel):
-    items: list[EventResponse]
-    next_cursor: str | None = None
+    items: list[EventResponse] = Field(description="Events in this page, oldest first.")
+    next_cursor: str | None = Field(
+        default=None,
+        description="Opaque cursor for the next page. Null when there are no more results.",
+    )
     # Only populated when the ``id`` query filter resolves to a call (e.g.
     # ``id=call:<uuid>``). Org-wide tails and non-call resource types leave
     # this null — there's no single "the" status to report.
-    call_status: CallStatus | None = None
+    call_status: CallStatus | None = Field(
+        default=None,
+        description=(
+            "Current status of the call named by the id filter (e.g. "
+            "id=call:<uuid>). Null for org-wide tails and non-call filters, "
+            "since there is no single call to report a status for."
+        ),
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -466,10 +653,20 @@ class DnsRecordSchema(BaseModel):
 
 
 class DomainCheckResponse(BaseModel):
-    domain: str
-    in_use: bool
-    existing_mx: list[str]
-    suggested_domain: str
+    domain: str = Field(description="The apex domain that was checked, lowercased.")
+    in_use: bool = Field(
+        description="True if the domain already has MX records — it receives mail elsewhere."
+    )
+    existing_mx: list[str] = Field(
+        description="MX hostnames currently published for the domain. Empty when in_use is false."
+    )
+    suggested_domain: str = Field(
+        description=(
+            "Domain to use for a custom sending identity: the apex domain "
+            "if it is not already receiving mail, or an 'inbox.' subdomain "
+            "if it is (so setup doesn't collide with existing mail)."
+        )
+    )
 
 
 class EmailDomainCreate(BaseModel):
@@ -485,10 +682,33 @@ class EmailDomainCreate(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    kind: EmailDomainKind
-    domain: str | None = None
-    local_prefix_user: str | None = None
-    local_prefix_org: str | None = None
+    kind: EmailDomainKind = Field(
+        description=(
+            "'hail_mail' for a Hail-hosted address (domain omitted, "
+            "composed from the prefix fields), or 'custom' to send from "
+            "your own domain (domain required, prefix fields omitted)."
+        )
+    )
+    domain: str | None = Field(
+        default=None,
+        description="DNS domain to send from (e.g. 'acme.com'). Required for kind='custom'; must be omitted for kind='hail_mail'.",
+    )
+    local_prefix_user: str | None = Field(
+        default=None,
+        description=(
+            "User-chosen local-part prefix for a hail_mail address. Only "
+            "valid for kind='hail_mail'. Falls back to "
+            "HAIL_MAIL_DEFAULT_USER_PREFIX if omitted."
+        ),
+    )
+    local_prefix_org: str | None = Field(
+        default=None,
+        description=(
+            "Org-chosen local-part prefix for a hail_mail address. Only "
+            "valid for kind='hail_mail'. Falls back to "
+            "HAIL_MAIL_DEFAULT_ORG_PREFIX if omitted."
+        ),
+    )
 
     @field_validator("domain")
     @classmethod
@@ -556,11 +776,26 @@ class EmailDomainPatch(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    local_prefix_user: str | None = None
-    local_prefix_org: str | None = None
-    inbound_enabled: bool | None = None
-    forward_to: list[str] | None = None
-    forward_rate_per_hour: int | None = None
+    local_prefix_user: str | None = Field(
+        default=None,
+        description="New user local-part prefix. Only valid on kind='hail_mail' rows. Omit to leave unchanged.",
+    )
+    local_prefix_org: str | None = Field(
+        default=None,
+        description="New org local-part prefix. Only valid on kind='hail_mail' rows. Omit to leave unchanged.",
+    )
+    inbound_enabled: bool | None = Field(
+        default=None,
+        description="Whether to accept inbound mail on this domain. Requires forward_to (or an existing one) when true. Omit to leave unchanged.",
+    )
+    forward_to: list[str] | None = Field(
+        default=None,
+        description="Email addresses to forward inbound mail to. Omit to leave unchanged.",
+    )
+    forward_rate_per_hour: int | None = Field(
+        default=None,
+        description="Cap on forwarded messages per hour. Omit to leave unchanged.",
+    )
 
     @field_validator("local_prefix_user", "local_prefix_org")
     @classmethod
@@ -613,57 +848,149 @@ class EmailDomainResponse(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    id: UUID
-    organization_id: UUID
-    kind: EmailDomainKind
-    domain: str
-    local_prefix_user: str | None
-    local_prefix_org: str | None
-    verification_status: EmailDomainVerificationStatus
-    dns_records: list[DnsRecordSchema]
-    mail_from_domain: str | None
-    mail_from_status: str | None = None
-    provider: str
-    verified_at: datetime | None
-    inbound_enabled: bool = False
-    forward_to: list[str] | None = None
-    forward_rate_per_hour: int | None = None
-    created_at: datetime
-    updated_at: datetime
+    id: UUID = Field(description="Unique identifier for this email domain.")
+    organization_id: UUID = Field(description="Organization that owns this domain.")
+    kind: EmailDomainKind = Field(
+        description="'hail_mail' (Hail-hosted address) or 'custom' (your own domain)."
+    )
+    domain: str = Field(description="The DNS domain mail is sent from.")
+    local_prefix_user: str | None = Field(
+        description="User local-part prefix for a hail_mail address. Null for kind='custom'."
+    )
+    local_prefix_org: str | None = Field(
+        description="Org local-part prefix for a hail_mail address. Null for kind='custom'."
+    )
+    verification_status: EmailDomainVerificationStatus = Field(
+        description="'pending' (not yet verified), 'verified' (ready to send), or 'failed'."
+    )
+    dns_records: list[DnsRecordSchema] = Field(
+        description="DNS records (DKIM, MAIL FROM MX, SPF) the tenant must publish to verify this domain."
+    )
+    mail_from_domain: str | None = Field(
+        description="Custom MAIL FROM domain, if configured. Null when using the provider default."
+    )
+    mail_from_status: str | None = Field(
+        default=None,
+        description="Verification status of the custom MAIL FROM domain, if one is configured. Secondary to verification_status.",
+    )
+    provider: str = Field(
+        description="Email sending provider for this domain (currently always 'ses')."
+    )
+    verified_at: datetime | None = Field(
+        description="When the domain became verified, ISO 8601 timestamp. Null until it is."
+    )
+    inbound_enabled: bool = Field(
+        default=False,
+        description="Whether this domain accepts and forwards inbound mail.",
+    )
+    forward_to: list[str] | None = Field(
+        default=None,
+        description="Email addresses inbound mail is forwarded to, if inbound is enabled.",
+    )
+    forward_rate_per_hour: int | None = Field(
+        default=None,
+        description="Configured cap on forwarded messages per hour, if set.",
+    )
+    created_at: datetime = Field(
+        description="When this domain was added, ISO 8601 timestamp."
+    )
+    updated_at: datetime = Field(
+        description="When this domain was last modified, ISO 8601 timestamp."
+    )
     # Populated by POST /{id}/verify on custom domains only; None everywhere else.
     # True when the domain's published MX points at the SES inbound host.
-    receive_ready: bool | None = None
+    receive_ready: bool | None = Field(
+        default=None,
+        description=(
+            "True when the domain's published MX points at Hail's inbound "
+            "host. Only populated by POST /{id}/verify on custom domains; "
+            "null everywhere else."
+        ),
+    )
 
 
 class EmailDomainListResponse(BaseModel):
-    items: list[EmailDomainResponse]
-    next_cursor: str | None = None
+    items: list[EmailDomainResponse] = Field(description="Email domains in this page.")
+    next_cursor: str | None = Field(
+        default=None,
+        description="Opaque cursor for the next page. Null when there are no more results.",
+    )
     # The address a send with no ``from`` goes out as. ``None`` when such a
     # send would be rejected: several verified identities (name one), or
     # none that can send yet. Computed across the whole org, not the page.
-    default_from: str | None = None
+    default_from: str | None = Field(
+        default=None,
+        description=(
+            "The From address used when a send omits 'from'. Null when no "
+            "such default can be resolved (e.g. multiple verified "
+            "identities, or none that can send yet). Computed across the "
+            "whole organization, not just this page."
+        ),
+    )
 
 
 class EmailCreate(ConsentAttestationMixin):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     # ``from`` is reserved; ``from_`` mirrors how CallCreate handles it.
-    from_: str | None = Field(default=None, alias="from")
+    from_: str | None = Field(
+        default=None,
+        alias="from",
+        description=(
+            "Sender email address. Must be a verified identity on the "
+            "organization's email domains. Omitted: the org's resolved "
+            "default sending address, if one exists."
+        ),
+    )
     # Friendly display name for the From: header ("Acme Billing
     # <billing@acme.com>"). Rendered by the email provider at send time
     # (see providers/email/ses.py); ``from_`` stays a bare address
     # everywhere else (sender resolution, compliance, events).
-    from_name: str | None = Field(default=None, max_length=256)
-    to: list[str] = Field(min_length=1)
-    cc: list[str] | None = None
-    bcc: list[str] | None = None
-    reply_to: str | None = None
-    subject: str = Field(min_length=1, max_length=998)
-    body_text: str | None = None
-    body_html: str | None = None
-    conversation_id: UUID | None = None
-    metadata: dict = Field(default_factory=dict)
-    attachment_ids: list[UUID] | None = None
+    from_name: str | None = Field(
+        default=None,
+        max_length=256,
+        description="Display name for the From: header (e.g. 'Acme Billing'). Omitted: no display name.",
+    )
+    to: list[str] = Field(
+        min_length=1, description="Recipient email addresses. At least one required."
+    )
+    cc: list[str] | None = Field(
+        default=None, description="CC recipient email addresses."
+    )
+    bcc: list[str] | None = Field(
+        default=None, description="BCC recipient email addresses."
+    )
+    reply_to: str | None = Field(
+        default=None,
+        description="Reply-To email address. Omitted: replies go to the From address.",
+    )
+    subject: str = Field(
+        min_length=1, max_length=998, description="Email subject line."
+    )
+    body_text: str | None = Field(
+        default=None,
+        description="Plain-text body. Either body_text or body_html (or both) is required.",
+    )
+    body_html: str | None = Field(
+        default=None,
+        description="HTML body. Either body_text or body_html (or both) is required.",
+    )
+    conversation_id: UUID | None = Field(
+        default=None,
+        description=(
+            "Groups this email with other calls/emails/SMS into one "
+            "conversation thread. Omitted: the email is not linked to a "
+            "conversation."
+        ),
+    )
+    metadata: dict = Field(
+        default_factory=dict,
+        description="Free-form JSON object attached to the email and echoed back on reads. Not interpreted by Hail.",
+    )
+    attachment_ids: list[UUID] | None = Field(
+        default=None,
+        description="Ids returned by POST /email-attachments to attach to this send. Omitted: no attachments.",
+    )
 
     @field_validator("from_name", mode="before")
     @classmethod
@@ -751,8 +1078,13 @@ class EmailEventResponse(BaseModel):
 
 
 class EmailEventListResponse(BaseModel):
-    items: list[EmailEventResponse]
-    next_cursor: str | None = None
+    items: list[EmailEventResponse] = Field(
+        description="Events for this email, oldest first."
+    )
+    next_cursor: str | None = Field(
+        default=None,
+        description="Opaque cursor for the next page. Null when there are no more results.",
+    )
 
 
 class EmailStatsCounts(BaseModel):
@@ -789,15 +1121,25 @@ class EmailStatsResponse(BaseModel):
     from_ts: datetime = Field(
         serialization_alias="from",
         validation_alias=AliasChoices("from_ts", "from"),
+        description="Start of the queried window, ISO 8601 timestamp (inclusive).",
     )
     to_ts: datetime = Field(
         serialization_alias="to",
         validation_alias=AliasChoices("to_ts", "to"),
+        description="End of the queried window, ISO 8601 timestamp (exclusive).",
     )
-    bucket: Literal["hour", "day"]
-    totals: EmailStatsCounts
-    rates: EmailStatsRates
-    series: list[EmailStatsBucket]
+    bucket: Literal["hour", "day"] = Field(
+        description="Time-bucket size used for the series."
+    )
+    totals: EmailStatsCounts = Field(
+        description="Event counts summed across the whole window."
+    )
+    rates: EmailStatsRates = Field(
+        description="Derived rates (delivery, bounce, complaint, open, click) for the whole window. Null when sent == 0."
+    )
+    series: list[EmailStatsBucket] = Field(
+        description="Per-bucket event counts across the window, in chronological order."
+    )
 
 
 class EmailSummary(BaseModel):
@@ -810,31 +1152,75 @@ class EmailSummary(BaseModel):
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
-    id: UUID
-    organization_id: UUID
-    conversation_id: UUID | None
-    email_domain_id: UUID | None
-    direction: Literal["outbound", "inbound"] = "outbound"
-    from_address: str
+    id: UUID = Field(description="Unique identifier for this email.")
+    organization_id: UUID = Field(
+        description="Organization that sent or received this email."
+    )
+    conversation_id: UUID | None = Field(
+        description=(
+            "Conversation thread this email is grouped into, if any. Null "
+            "when it was not linked to a conversation."
+        )
+    )
+    email_domain_id: UUID | None = Field(
+        description="The sending domain used, if from_address belongs to one of the org's configured domains."
+    )
+    direction: Literal["outbound", "inbound"] = Field(
+        default="outbound",
+        description="'outbound' for emails Hail sent, 'inbound' for emails received.",
+    )
+    from_address: str = Field(description="Sender email address.")
     # Display name used on the From: header, when the sender supplied one.
     # Always None on inbound rows and pre-existing outbound rows.
-    from_name: str | None = None
-    to_addresses: list[str]
-    cc_addresses: list[str] | None
-    bcc_addresses: list[str] | None
-    reply_to: str | None
-    subject: str
-    status: EmailStatus
-    end_reason: str | None
-    provider_message_id: str | None
-    requested_at: datetime
-    sent_at: datetime | None
-    failed_at: datetime | None
+    from_name: str | None = Field(
+        default=None,
+        description=(
+            "Display name used on the From: header, when the sender "
+            "supplied one. Always null on inbound rows."
+        ),
+    )
+    to_addresses: list[str] = Field(description="Recipient email addresses.")
+    cc_addresses: list[str] | None = Field(
+        description="CC recipient email addresses, if any."
+    )
+    bcc_addresses: list[str] | None = Field(
+        description="BCC recipient email addresses, if any."
+    )
+    reply_to: str | None = Field(description="Reply-To email address, if set.")
+    subject: str = Field(description="Email subject line.")
+    status: EmailStatus = Field(
+        description=(
+            "Delivery status: 'queued', 'sent', 'delivered', 'failed', "
+            "'bounced', 'complained', or 'received' (inbound emails)."
+        )
+    )
+    end_reason: str | None = Field(
+        description="Reason delivery failed or bounced, if applicable. Null on success or while pending."
+    )
+    provider_message_id: str | None = Field(
+        description="The email provider's identifier for this message, if assigned."
+    )
+    requested_at: datetime = Field(
+        description="When the send was requested, ISO 8601 timestamp."
+    )
+    sent_at: datetime | None = Field(
+        description="When the message was handed to the provider, ISO 8601 timestamp. Null until sent."
+    )
+    failed_at: datetime | None = Field(
+        description="When the send failed, ISO 8601 timestamp. Null unless it failed."
+    )
     # ``Email.metadata_`` is the SQLAlchemy attribute (``metadata`` is
     # reserved by Declarative). The validation_alias bridges that name so
     # ``from_attributes=True`` reads the right column; the field on the
     # response is still called ``metadata`` on the wire.
-    metadata: dict[str, Any] = Field(default_factory=dict, validation_alias="metadata_")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        validation_alias="metadata_",
+        description=(
+            "Free-form JSON object attached to the email, as sent on "
+            "create. Not interpreted by Hail."
+        ),
+    )
 
 
 class EmailAttachmentResponse(BaseModel):
@@ -862,42 +1248,83 @@ class EmailAttachmentUploadResponse(BaseModel):
     if never referenced by a send).
     """
 
-    id: UUID
-    filename: str
-    content_type: str
-    size_bytes: int
+    id: UUID = Field(
+        description="Reusable attachment id — pass it in EmailCreate.attachment_ids to attach it to a send."
+    )
+    filename: str = Field(description="Original filename of the uploaded file.")
+    content_type: str = Field(description="MIME type of the uploaded file.")
+    size_bytes: int = Field(description="Size of the uploaded file in bytes.")
 
     model_config = ConfigDict(from_attributes=True)
 
 
 class EmailResponse(EmailSummary):
-    body_text: str | None
-    body_html: str | None
+    body_text: str | None = Field(description="Plain-text body, if any.")
+    body_html: str | None = Field(description="HTML body, if any.")
     # Inbound-only metadata. Outbound rows leave these all null/empty —
     # we surface them on the full-row endpoint (GET /emails/{id}) rather
     # than the list summary because most inbound consumers will fetch the
     # row anyway to read the body. Defaults match the outbound shape so
     # existing serializations keep working.
-    message_id: str | None = None
-    in_reply_to: str | None = None
-    references_ids: list[str] | None = None
-    spam_verdict: str | None = None
-    virus_verdict: str | None = None
-    dkim_verdict: str | None = None
-    spf_verdict: str | None = None
-    dmarc_verdict: str | None = None
-    provider_received_at: datetime | None = None
+    message_id: str | None = Field(
+        default=None,
+        description="RFC 5322 Message-ID header. Inbound emails only; null on outbound rows.",
+    )
+    in_reply_to: str | None = Field(
+        default=None,
+        description="RFC 5322 In-Reply-To header. Inbound emails only; null on outbound rows.",
+    )
+    references_ids: list[str] | None = Field(
+        default=None,
+        description="RFC 5322 References header, split into ids. Inbound emails only; null on outbound rows.",
+    )
+    spam_verdict: str | None = Field(
+        default=None,
+        description="Provider spam-scan verdict (e.g. 'PASS'/'FAIL'). Inbound emails only; null on outbound rows.",
+    )
+    virus_verdict: str | None = Field(
+        default=None,
+        description="Provider virus-scan verdict (e.g. 'PASS'/'FAIL'). Inbound emails only; null on outbound rows.",
+    )
+    dkim_verdict: str | None = Field(
+        default=None,
+        description="Provider DKIM-authentication verdict (e.g. 'PASS'/'FAIL'). Inbound emails only; null on outbound rows.",
+    )
+    spf_verdict: str | None = Field(
+        default=None,
+        description="Provider SPF-authentication verdict (e.g. 'PASS'/'FAIL'). Inbound emails only; null on outbound rows.",
+    )
+    dmarc_verdict: str | None = Field(
+        default=None,
+        description="Provider DMARC-authentication verdict (e.g. 'PASS'/'FAIL'). Inbound emails only; null on outbound rows.",
+    )
+    provider_received_at: datetime | None = Field(
+        default=None,
+        description="When the provider received this email, ISO 8601 timestamp. Inbound emails only.",
+    )
     # ``raw_url`` is the API endpoint that 302-redirects to a presigned
     # S3 URL for the original MIME blob; ``raw_s3_key`` is the column on
     # the row but we don't expose internal storage paths on the wire.
-    raw_url: str | None = None
-    attachments: list[EmailAttachmentResponse] = []
-    last_event_at: datetime | None = None
+    raw_url: str | None = Field(
+        default=None,
+        description="API endpoint that redirects to the original MIME blob. Inbound emails only; null on outbound rows.",
+    )
+    attachments: list[EmailAttachmentResponse] = Field(
+        default=[],
+        description="Inbound MIME attachments on this email. Empty on outbound rows.",
+    )
+    last_event_at: datetime | None = Field(
+        default=None,
+        description="When the most recent delivery event for this email occurred, ISO 8601 timestamp.",
+    )
 
 
 class EmailListResponse(BaseModel):
-    items: list[EmailSummary]
-    next_cursor: str | None = None
+    items: list[EmailSummary] = Field(description="Emails in this page, newest first.")
+    next_cursor: str | None = Field(
+        default=None,
+        description="Opaque cursor for the next page. Null when there are no more results.",
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -934,14 +1361,27 @@ WebhookDeliveryStatus = Literal["pending", "succeeded", "failed", "dead"]
 
 
 class WebhookSubscriptionCreate(BaseModel):
-    target_url: str = Field(min_length=1)
-    event_types: list[WebhookEventType] = Field(min_length=1)
+    target_url: str = Field(
+        min_length=1, description="HTTPS URL Hail POSTs event payloads to."
+    )
+    event_types: list[WebhookEventType] = Field(
+        min_length=1,
+        description="Event types to subscribe to (e.g. 'call.completed', 'email.bounced'). At least one required.",
+    )
 
 
 class WebhookSubscriptionPatch(BaseModel):
-    target_url: str | None = None
-    event_types: list[WebhookEventType] | None = None
-    status: WebhookSubscriptionStatus | None = None
+    target_url: str | None = Field(
+        default=None, description="New delivery URL. Omit to leave unchanged."
+    )
+    event_types: list[WebhookEventType] | None = Field(
+        default=None,
+        description="New set of subscribed event types. Omit to leave unchanged.",
+    )
+    status: WebhookSubscriptionStatus | None = Field(
+        default=None,
+        description="Set to 'disabled' to pause deliveries, or 'active' to resume. Omit to leave unchanged.",
+    )
 
 
 class WebhookSubscriptionResponse(BaseModel):
@@ -951,46 +1391,113 @@ class WebhookSubscriptionResponse(BaseModel):
     later GETs return ``None`` so the plaintext never round-trips.
     """
 
-    id: UUID
-    organization_id: UUID
-    target_url: str
-    event_types: list[str]
-    status: WebhookSubscriptionStatus
-    consecutive_failures: int
-    last_success_at: datetime | None = None
-    last_failure_at: datetime | None = None
-    created_at: datetime
-    updated_at: datetime
-    secret: str | None = None
+    id: UUID = Field(description="Unique identifier for this subscription.")
+    organization_id: UUID = Field(
+        description="Organization that owns this subscription."
+    )
+    target_url: str = Field(description="HTTPS URL event payloads are POSTed to.")
+    event_types: list[str] = Field(
+        description="Event types this subscription receives."
+    )
+    status: WebhookSubscriptionStatus = Field(
+        description="'active' (delivering) or 'disabled' (paused)."
+    )
+    consecutive_failures: int = Field(
+        description="Consecutive failed delivery attempts since the last success. Resets to 0 on success."
+    )
+    last_success_at: datetime | None = Field(
+        default=None,
+        description="When a delivery last succeeded, ISO 8601 timestamp. Null if never.",
+    )
+    last_failure_at: datetime | None = Field(
+        default=None,
+        description="When a delivery last failed, ISO 8601 timestamp. Null if never.",
+    )
+    created_at: datetime = Field(
+        description="When this subscription was created, ISO 8601 timestamp."
+    )
+    updated_at: datetime = Field(
+        description="When this subscription was last modified, ISO 8601 timestamp."
+    )
+    secret: str | None = Field(
+        default=None,
+        description=(
+            "Plaintext signing secret for verifying delivery payloads. "
+            "Only present in the create and rotate-secret responses; "
+            "every later read returns null."
+        ),
+    )
 
     model_config = ConfigDict(from_attributes=True)
 
 
 class WebhookSubscriptionListResponse(BaseModel):
-    items: list[WebhookSubscriptionResponse]
-    next_cursor: str | None = None
+    items: list[WebhookSubscriptionResponse] = Field(
+        description="Subscriptions in this page."
+    )
+    next_cursor: str | None = Field(
+        default=None,
+        description="Opaque cursor for the next page. Null when there are no more results.",
+    )
 
 
 class WebhookDeliveryResponse(BaseModel):
-    id: UUID
-    subscription_id: UUID | None
-    email_domain_id: UUID | None
-    event_type: str
-    event_id: UUID
-    attempt: int
-    status: WebhookDeliveryStatus
-    response_status: int | None = None
-    response_body: str | None = None
-    next_attempt_at: datetime
-    succeeded_at: datetime | None = None
-    created_at: datetime
+    id: UUID = Field(description="Unique identifier for this delivery attempt.")
+    subscription_id: UUID | None = Field(
+        description="Subscription this delivery belongs to."
+    )
+    email_domain_id: UUID | None = Field(
+        description=(
+            "Email domain the triggering event relates to, if any. "
+            "Informational only (surfaced as the X-Hail-Email-Domain "
+            "header) — not a routing target."
+        )
+    )
+    event_type: str = Field(
+        description="The event type being delivered (e.g. 'call.completed')."
+    )
+    event_id: UUID = Field(
+        description="Identifier of the underlying event that triggered this delivery."
+    )
+    attempt: int = Field(
+        description="Number of delivery attempts made so far for this event, starting at 0."
+    )
+    status: WebhookDeliveryStatus = Field(
+        description=(
+            "'pending' (queued/retrying), 'succeeded', 'failed' (will "
+            "retry), or 'dead' (retries exhausted)."
+        )
+    )
+    response_status: int | None = Field(
+        default=None,
+        description="HTTP status code returned by the target URL on the last attempt. Null before any attempt.",
+    )
+    response_body: str | None = Field(
+        default=None,
+        description="Response body returned by the target URL on the last attempt, if any. Null before any attempt.",
+    )
+    next_attempt_at: datetime = Field(
+        description="When the next delivery attempt is scheduled, ISO 8601 timestamp."
+    )
+    succeeded_at: datetime | None = Field(
+        default=None,
+        description="When this delivery succeeded, ISO 8601 timestamp. Null until it does.",
+    )
+    created_at: datetime = Field(
+        description="When this delivery was queued, ISO 8601 timestamp."
+    )
 
     model_config = ConfigDict(from_attributes=True)
 
 
 class WebhookDeliveryListResponse(BaseModel):
-    items: list[WebhookDeliveryResponse]
-    next_cursor: str | None = None
+    items: list[WebhookDeliveryResponse] = Field(
+        description="Delivery attempts in this page."
+    )
+    next_cursor: str | None = Field(
+        default=None,
+        description="Opaque cursor for the next page. Null when there are no more results.",
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -1025,20 +1532,41 @@ class ContactEntry(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    id: str
-    kind: Literal["member", "manual"]
-    name: str
-    phone_e164: str | None = None
-    email: str | None = None
-    role: str | None = None
+    id: str = Field(
+        description="'member:<user_id>' for an org member, or the contact row's UUID (as a string) for a manual contact."
+    )
+    kind: Literal["member", "manual"] = Field(
+        description="'member' if this row is a member of the organization, 'manual' if it was added as a contact."
+    )
+    name: str = Field(description="Display name.")
+    phone_e164: str | None = Field(
+        default=None, description="Phone number, E.164 format. Null if none on file."
+    )
+    email: str | None = Field(
+        default=None, description="Email address. Null if none on file."
+    )
+    role: str | None = Field(
+        default=None,
+        description="Organization role (e.g. 'owner', 'admin', 'member') for kind='member'. Always null for kind='manual'.",
+    )
 
 
 class ContactCreate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    name: str = Field(min_length=1, max_length=200)
-    phone_e164: str | None = None
-    email: str | None = None
+    name: str = Field(
+        min_length=1,
+        max_length=200,
+        description="Display name for the contact.",
+    )
+    phone_e164: str | None = Field(
+        default=None,
+        description="Phone number, E.164 format. At least one of phone_e164 or email is required.",
+    )
+    email: str | None = Field(
+        default=None,
+        description="Email address, stored lowercased. At least one of phone_e164 or email is required.",
+    )
 
     _validate_phone = field_validator("phone_e164")(_e164_or_error)
     _validate_email = field_validator("email")(_normalize_contact_email)
@@ -1053,9 +1581,28 @@ class ContactCreate(BaseModel):
 class ContactPatch(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    name: str | None = Field(default=None, min_length=1, max_length=200)
-    phone_e164: str | None = None
-    email: str | None = None
+    name: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=200,
+        description="New display name. Omit to leave unchanged; cannot be set to null.",
+    )
+    phone_e164: str | None = Field(
+        default=None,
+        description=(
+            "New phone number, E.164 format. Omit to leave unchanged; "
+            "explicit null clears it. The contact must keep at least one "
+            "of phone_e164 or email."
+        ),
+    )
+    email: str | None = Field(
+        default=None,
+        description=(
+            "New email address, stored lowercased. Omit to leave "
+            "unchanged; explicit null clears it. The contact must keep at "
+            "least one of phone_e164 or email."
+        ),
+    )
 
     _validate_phone = field_validator("phone_e164")(_e164_or_error)
     _validate_email = field_validator("email")(_normalize_contact_email)
@@ -1073,14 +1620,19 @@ class ContactPatch(BaseModel):
 
 
 class ContactListResponse(BaseModel):
-    items: list[ContactEntry]
-    next_cursor: str | None = None
+    items: list[ContactEntry] = Field(description="Contacts in this page.")
+    next_cursor: str | None = Field(
+        default=None,
+        description="Opaque cursor for the next page. Null when there are no more results.",
+    )
 
 
 class MemberPhonePut(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    phone_e164: str
+    phone_e164: str = Field(
+        description="Phone number to save for the caller, E.164 format."
+    )
 
     _validate_phone = field_validator("phone_e164")(_e164_or_error)
 
@@ -1094,11 +1646,26 @@ class WhoamiResponse(BaseModel):
     ``email`` and skips the header when it is ``None``.
     """
 
-    auth_kind: Literal["apikey", "jwt", "shared"]
-    organization_id: UUID
-    user_id: UUID | None = None
-    email: str | None = None
-    name: str | None = None
+    auth_kind: Literal["apikey", "jwt", "shared"] = Field(
+        description=(
+            "How the caller authenticated: 'apikey' (org API key), 'jwt' "
+            "(logged-in user session), or 'shared' (the shared HAIL_API_KEY, "
+            "which carries no human identity)."
+        )
+    )
+    organization_id: UUID = Field(description="Organization the caller belongs to.")
+    user_id: UUID | None = Field(
+        default=None,
+        description="The authenticated user's id. Null for 'shared' callers.",
+    )
+    email: str | None = Field(
+        default=None,
+        description="The authenticated user's email. Null for 'shared' callers.",
+    )
+    name: str | None = Field(
+        default=None,
+        description="The authenticated user's display name. Null for 'shared' callers.",
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -1139,10 +1706,25 @@ class ProviderConfigUpsert(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    provider: str
-    api_key: str | None = None
-    params: dict[str, Any] = Field(default_factory=dict)
-    fallback_enabled: bool | None = None
+    provider: str = Field(
+        description="Provider name to save/activate for this layer (e.g. 'openai', 'cartesia')."
+    )
+    api_key: str | None = Field(
+        default=None,
+        description="API key for this provider. Omit to edit params without resending the key. Write-only — never echoed back.",
+    )
+    params: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Provider-specific config, validated against the layer's "
+            "schema (LLMParams/TTSParams/STTParams). Only the keys you "
+            "send are changed; other saved keys are kept."
+        ),
+    )
+    fallback_enabled: bool | None = Field(
+        default=None,
+        description="Whether to fall back to Hail's default provider on failure. Omit to leave unchanged; defaults to false on a new row.",
+    )
 
 
 class ProviderActivateRequest(BaseModel):
@@ -1150,7 +1732,9 @@ class ProviderActivateRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    provider: str
+    provider: str = Field(
+        description="Previously saved provider to make active for this layer."
+    )
 
 
 class ProviderValidateRequest(BaseModel):
@@ -1163,9 +1747,18 @@ class ProviderValidateRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    api_key: str | None = None
-    provider: str | None = None
-    params: dict[str, Any] = Field(default_factory=dict)
+    api_key: str | None = Field(
+        default=None,
+        description="Key to test instead of the stored one. Not persisted.",
+    )
+    provider: str | None = Field(
+        default=None,
+        description="Provider to test. Omitted: the layer's currently active provider.",
+    )
+    params: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Provider-specific config to test alongside the key.",
+    )
 
 
 class ProviderConfigEntry(BaseModel):
@@ -1177,21 +1770,39 @@ class ProviderConfigEntry(BaseModel):
     generate plain values instead of pointers in the Go CLI's client.
     """
 
-    layer: Literal["llm", "tts", "stt"]
-    provider: str
-    key_last4: str | None
-    key_set_at: str | None
-    params: dict[str, Any]
-    fallback_enabled: bool
-    is_active: bool
+    layer: Literal["llm", "tts", "stt"] = Field(
+        description="Voice-pipeline layer this config applies to."
+    )
+    provider: str = Field(description="Provider name (e.g. 'openai', 'cartesia').")
+    key_last4: str | None = Field(
+        description="Last 4 characters of the saved API key, for display. Null if no key is saved."
+    )
+    key_set_at: str | None = Field(
+        description="When the API key was last set, ISO 8601 timestamp. Null if no key is saved."
+    )
+    params: dict[str, Any] = Field(
+        description="Saved provider-specific config for this row."
+    )
+    fallback_enabled: bool = Field(
+        description="Whether Hail's default provider is used as a fallback if this one fails."
+    )
+    is_active: bool = Field(
+        description="True if this is the row currently used by calls on this layer."
+    )
 
 
 class ProviderConfigListResponse(BaseModel):
-    providers: list[ProviderConfigEntry]
+    providers: list[ProviderConfigEntry] = Field(
+        description="Every saved provider row for the organization, across all layers."
+    )
 
 
 class ProviderValidateResult(BaseModel):
     """Outcome of a live provider-key probe."""
 
-    status: str
-    message: str | None
+    status: str = Field(
+        description="Probe outcome: 'valid', 'invalid', or 'indeterminate' (the provider could not be reached)."
+    )
+    message: str | None = Field(
+        description="Human-readable detail about the outcome. 'ok' on success, an error description otherwise."
+    )

--- a/core/hailhq/core/schemas.py
+++ b/core/hailhq/core/schemas.py
@@ -100,9 +100,17 @@ def parse_resource_id(value: str) -> tuple[str, UUID]:
 class LLMConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    base_url: str
-    api_key: str
-    model: str
+    base_url: str = Field(
+        description=(
+            "Public HTTPS base URL of the BYO LLM endpoint the call runs "
+            "on. Must resolve to a public address — private/internal "
+            "hosts are rejected."
+        )
+    )
+    api_key: str = Field(
+        description="API key sent to the BYO LLM endpoint. Write-only — never echoed back."
+    )
+    model: str = Field(description="Model name to request from the BYO LLM endpoint.")
 
     @field_validator("base_url")
     @classmethod
@@ -127,12 +135,28 @@ class LLMConfig(BaseModel):
 class VoiceConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    tts: Literal["cartesia"] = "cartesia"
-    vad: Literal["silero"] = "silero"
-    turn_detection: Literal["livekit"] = "livekit"
+    tts: Literal["cartesia"] = Field(
+        default="cartesia",
+        description="Text-to-speech provider. Currently only 'cartesia'.",
+    )
+    vad: Literal["silero"] = Field(
+        default="silero",
+        description="Voice-activity-detection engine. Currently only 'silero'.",
+    )
+    turn_detection: Literal["livekit"] = Field(
+        default="livekit",
+        description="Turn-detection engine. Currently only 'livekit'.",
+    )
     # Per-call TTS voice override. Applies to whichever TTS provider serves
     # the call (org BYO config or Hail default). None → org/env default.
-    voice_id: str | None = None
+    voice_id: str | None = Field(
+        default=None,
+        description=(
+            "Per-call TTS voice override, applied to whichever TTS "
+            "provider serves the call. Omitted: the organization's or "
+            "environment's default voice."
+        ),
+    )
     language: Language | None = Field(
         default=None,
         description=(
@@ -550,12 +574,22 @@ class PhoneNumberListResponse(BaseModel):
 class SuppressionResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-    id: UUID
-    recipient: str
-    channel: str
-    reason: str
-    source: str
-    created_at: datetime
+    id: UUID = Field(description="Unique identifier for this suppression entry.")
+    recipient: str = Field(
+        description="The suppressed recipient — E.164 phone number for voice/sms, lowercased email address for email."
+    )
+    channel: str = Field(
+        description="Channel this entry blocks sends on: 'voice', 'email', 'sms', or 'all' (every channel)."
+    )
+    reason: str = Field(
+        description="Why the recipient was suppressed (e.g. an unsubscribe or a bounce)."
+    )
+    source: str = Field(
+        description="How this entry was created: 'unsubscribe_link', 'manual' (an operator action), or 'bounce'."
+    )
+    created_at: datetime = Field(
+        description="When this entry was created, ISO 8601 timestamp."
+    )
 
 
 class SuppressionListResponse(BaseModel):
@@ -573,14 +607,31 @@ class EventResponse(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    id: UUID
-    source: Literal["call", "email", "sms"]
-    call_id: UUID | None = None
-    email_id: UUID | None = None
-    sms_id: UUID | None = None
-    kind: str
-    payload: dict[str, Any]
-    occurred_at: datetime
+    id: UUID = Field(description="Unique identifier for this event.")
+    source: Literal["call", "email", "sms"] = Field(
+        description="Which channel this event belongs to: 'call', 'email', or 'sms'."
+    )
+    call_id: UUID | None = Field(
+        default=None,
+        description="The call this event belongs to. Set only when source='call'.",
+    )
+    email_id: UUID | None = Field(
+        default=None,
+        description="The email this event belongs to. Set only when source='email'.",
+    )
+    sms_id: UUID | None = Field(
+        default=None,
+        description="The message this event belongs to. Set only when source='sms'.",
+    )
+    kind: str = Field(
+        description="Event kind within the source (e.g. 'queued', 'delivered', 'bounced'). Vocabulary differs per source."
+    )
+    payload: dict[str, Any] = Field(
+        description="Event-kind-specific detail, as a free-form JSON object."
+    )
+    occurred_at: datetime = Field(
+        description="When this event occurred, ISO 8601 timestamp."
+    )
 
 
 class EventStreamResponse(BaseModel):
@@ -646,10 +697,20 @@ class DnsRecordSchema(BaseModel):
 
     model_config = ConfigDict(from_attributes=True, extra="allow")
 
-    name: str
-    value: str
-    type: Literal["CNAME", "MX", "TXT"] = "CNAME"
-    priority: int | None = None
+    name: str = Field(
+        description="DNS record name/host to publish (e.g. a CNAME's subdomain)."
+    )
+    value: str = Field(
+        description="DNS record value to publish (e.g. a CNAME target or TXT content)."
+    )
+    type: Literal["CNAME", "MX", "TXT"] = Field(
+        default="CNAME",
+        description="DNS record type: 'CNAME' (DKIM), 'MX' (MAIL FROM), or 'TXT' (SPF).",
+    )
+    priority: int | None = Field(
+        default=None,
+        description="MX priority. Only present for type='MX'; null otherwise.",
+    )
 
 
 class DomainCheckResponse(BaseModel):
@@ -1070,11 +1131,20 @@ EmailEventKind = Literal[
 class EmailEventResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-    id: UUID
-    email_id: UUID
-    kind: EmailEventKind
-    payload: dict[str, Any]
-    occurred_at: datetime
+    id: UUID = Field(description="Unique identifier for this event.")
+    email_id: UUID = Field(description="The email this event belongs to.")
+    kind: EmailEventKind = Field(
+        description=(
+            "Event kind: 'sent', 'delivered', 'delivery_delayed', "
+            "'bounced', 'complained', 'rejected', 'opened', or 'clicked'."
+        )
+    )
+    payload: dict[str, Any] = Field(
+        description="Event-kind-specific detail, as a free-form JSON object."
+    )
+    occurred_at: datetime = Field(
+        description="When this event occurred, ISO 8601 timestamp."
+    )
 
 
 class EmailEventListResponse(BaseModel):
@@ -1088,31 +1158,71 @@ class EmailEventListResponse(BaseModel):
 
 
 class EmailStatsCounts(BaseModel):
-    sent: int = 0
-    delivered: int = 0
-    delivery_delayed: int = 0
-    bounced: int = 0
-    bounced_hard: int = 0
-    complained: int = 0
-    rejected: int = 0
-    opened: int = 0
-    clicked: int = 0
-    unique_opened: int = 0
-    unique_clicked: int = 0
+    sent: int = Field(default=0, description="Emails sent in the window.")
+    delivered: int = Field(
+        default=0, description="Emails confirmed delivered in the window."
+    )
+    delivery_delayed: int = Field(
+        default=0, description="Emails with a delivery-delayed event in the window."
+    )
+    bounced: int = Field(
+        default=0, description="Emails bounced (soft or hard) in the window."
+    )
+    bounced_hard: int = Field(
+        default=0, description="Emails hard-bounced in the window. Subset of bounced."
+    )
+    complained: int = Field(
+        default=0, description="Emails that received a spam complaint in the window."
+    )
+    rejected: int = Field(
+        default=0,
+        description="Emails rejected by the provider before sending, in the window.",
+    )
+    opened: int = Field(
+        default=0,
+        description="Total open events in the window, including repeat opens by the same recipient.",
+    )
+    clicked: int = Field(
+        default=0,
+        description="Total click events in the window, including repeat clicks by the same recipient.",
+    )
+    unique_opened: int = Field(
+        default=0, description="Distinct emails opened at least once in the window."
+    )
+    unique_clicked: int = Field(
+        default=0, description="Distinct emails clicked at least once in the window."
+    )
 
 
 class EmailStatsBucket(EmailStatsCounts):
-    bucket_start: datetime
+    bucket_start: datetime = Field(
+        description="Start of this bucket, ISO 8601 timestamp."
+    )
 
 
 class EmailStatsRates(BaseModel):
     """All None when sent == 0 in the window."""
 
-    delivery: float | None = None
-    bounce: float | None = None  # hard bounces / sent
-    complaint: float | None = None
-    open: float | None = None  # unique_opened / sent
-    click: float | None = None  # unique_clicked / sent
+    delivery: float | None = Field(
+        default=None,
+        description="delivered / sent for the window. Null when sent == 0.",
+    )
+    bounce: float | None = Field(
+        default=None,
+        description="bounced_hard / sent for the window. Null when sent == 0.",
+    )  # hard bounces / sent
+    complaint: float | None = Field(
+        default=None,
+        description="complained / sent for the window. Null when sent == 0.",
+    )
+    open: float | None = Field(
+        default=None,
+        description="unique_opened / sent for the window. Null when sent == 0.",
+    )  # unique_opened / sent
+    click: float | None = Field(
+        default=None,
+        description="unique_clicked / sent for the window. Null when sent == 0.",
+    )  # unique_clicked / sent
 
 
 class EmailStatsResponse(BaseModel):
@@ -1135,7 +1245,10 @@ class EmailStatsResponse(BaseModel):
         description="Event counts summed across the whole window."
     )
     rates: EmailStatsRates = Field(
-        description="Derived rates (delivery, bounce, complaint, open, click) for the whole window. Null when sent == 0."
+        description=(
+            "Derived rates (delivery, bounce, complaint, open, click) for "
+            "the whole window. Each individual rate is null when sent == 0."
+        )
     )
     series: list[EmailStatsBucket] = Field(
         description="Per-bucket event counts across the window, in chronological order."
@@ -1230,12 +1343,17 @@ class EmailAttachmentResponse(BaseModel):
     presigned S3 URL on access — see GET /emails/{id}/attachments/{aid}.
     """
 
-    id: UUID
-    filename: str
-    content_type: str
-    size_bytes: int
-    content_id: str | None = None
-    url: str
+    id: UUID = Field(description="Unique identifier for this attachment.")
+    filename: str = Field(description="Original filename of the attachment.")
+    content_type: str = Field(description="MIME type of the attachment.")
+    size_bytes: int = Field(description="Size of the attachment in bytes.")
+    content_id: str | None = Field(
+        default=None,
+        description="MIME Content-ID, present when this attachment is referenced inline (cid:) from the HTML body. Null otherwise.",
+    )
+    url: str = Field(
+        description="API endpoint that 302-redirects to a presigned download URL for this attachment."
+    )
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/docs-site/urls.json
+++ b/docs-site/urls.json
@@ -12,5 +12,6 @@
   "/docs/self-host/smtp-inbound",
   "/docs/self-host/twilio",
   "/docs/self-host/vm-deploy",
+  "/docs/versioning",
   "/docs/webhooks"
 ]

--- a/docs/public/byo-llm.md
+++ b/docs/public/byo-llm.md
@@ -252,7 +252,7 @@ Reads never return it.
 Every surface takes the same three fields.
 
 ```bash
-curl -X POST https://api.hail.so/calls \
+curl -X POST https://api.hail.so/v1/calls \
   -H "Authorization: Bearer $HAIL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/public/meta.json
+++ b/docs/public/meta.json
@@ -3,6 +3,7 @@
     "README",
     "mcp",
     "webhooks",
+    "versioning",
     "byo-llm",
     "cli",
     "architecture",

--- a/docs/public/versioning.md
+++ b/docs/public/versioning.md
@@ -14,8 +14,8 @@ Every response from a legacy path carries:
 
 - `Deprecation: true` — this path is deprecated (see the IETF Deprecation
   HTTP header field).
-- `Link: <https://api.hail.so/v1/...>; rel="successor-version"` — the
-  canonical `/v1` path that replaces it.
+- `Link: </v1/...>; rel="successor-version"` — the canonical `/v1` path
+  that replaces it, as a relative path (not an absolute URL).
 
 ## Sunset
 

--- a/docs/public/versioning.md
+++ b/docs/public/versioning.md
@@ -1,0 +1,25 @@
+# API versioning
+
+`/v1/<resource>` is the canonical, documented form of every customer-facing
+Hail API route. It appears in the OpenAPI spec (`openapi/openapi.yaml`) and
+is what the CLI and generated clients target.
+
+## Legacy unprefixed paths
+
+Routes without the `/v1` prefix (e.g. `/whoami` instead of `/v1/whoami`)
+still work, for existing integrations built before versioning shipped. They
+are not in the OpenAPI spec and should not be used for new integrations.
+
+Every response from a legacy path carries:
+
+- `Deprecation: true` — this path is deprecated (see the IETF Deprecation
+  HTTP header field).
+- `Link: <https://api.hail.so/v1/...>; rel="successor-version"` — the
+  canonical `/v1` path that replaces it.
+
+## Sunset
+
+No sunset date is set for the legacy paths yet. If one is scheduled, it
+will be announced here and via a `Sunset` response header (RFC 8594) added
+ahead of the change, giving integrators advance notice before the
+unprefixed paths stop working.

--- a/docs/public/webhooks.md
+++ b/docs/public/webhooks.md
@@ -133,7 +133,7 @@ shape comes from the event type. Inbound events use [`build_event_data`](https:/
     "spf_verdict": "PASS",
     "dkim_verdict": "PASS",
     "dmarc_verdict": "PASS",
-    "raw_url": "https://api.hail.so/emails/em-uuid/raw",
+    "raw_url": "https://api.hail.so/v1/emails/em-uuid/raw",
     "attachments": [
       {
         "id": "att-uuid",
@@ -214,7 +214,7 @@ re-enable it, set its status back to `active`. Replay a single delivery from the
 console or through the API:
 
 ```bash
-curl -X POST "$HAIL_API_URL/webhooks/<subscription-id>/deliveries/<delivery-id>/redeliver" \
+curl -X POST "$HAIL_API_URL/v1/webhooks/<subscription-id>/deliveries/<delivery-id>/redeliver" \
   -H "Authorization: Bearer $HAIL_API_KEY"
 ```
 

--- a/docs/superpowers/plans/2026-08-22-agent-readiness-api-mcp.md
+++ b/docs/superpowers/plans/2026-08-22-agent-readiness-api-mcp.md
@@ -1,0 +1,979 @@
+# API Versioning, Rate Limits, OpenAPI Descriptions, and MCP Public Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close four gaps an "Is Agentic" readiness audit found in the Hail API and MCP server: no URL versioning or deprecation signal, no general rate-limit headers, sparse OpenAPI operation/field descriptions, and an MCP server that requires OAuth even for `initialize`/`tools/list` (capability discovery), blocking agents from seeing what Hail offers before deciding to authenticate.
+
+**Architecture:** All four are additive, backward-compatible changes to `api/` and `mcp/` — no existing authenticated behavior changes. Versioning dual-mounts every customer-facing router at `/v1/<resource>` (canonical, the only mount included in the OpenAPI schema) while keeping the unprefixed path alive at the routing layer (`include_in_schema=False`, so it does not duplicate operationIds or paths in the spec) with a `Deprecation` response header (the widely-deployed `Deprecation: true` form; RFC 9745 is the current authority for this header — RFC 8594 defines `Sunset`, a different header, not used here), so no existing integration breaks and the spec keeps a unique operationId per operation. Rate limiting is in-memory (`slowapi`/`limits`), keyed off the raw bearer token — this deployment is single-VM (confirmed: `docker-compose.yml` on one host, no replica orchestration), so in-memory state is safe; Redis is not needed. OpenAPI descriptions are added directly on route decorators and Pydantic `Field()` declarations — the spec is generated from the app (`app.openapi()`), so no separate spec-editing step. MCP discovery adds one new Starlette middleware, inserted before FastMCP's own auth middleware, that recognizes exactly two JSON-RPC methods (`initialize`, `tools/list`) and supplies a synthetic bearer for them only — every other method (`tools/call`, `resources/*`, etc.) is completely untouched and still requires a real bearer.
+
+**Tech Stack:** Python 3, FastAPI (async), Pydantic v2, SQLAlchemy async, pytest + a real Postgres test container, ruff + black + mypy. MCP: `mcp` SDK (`FastMCP`), Starlette, `mcp.server.auth`.
+
+**Design basis:** Live investigation of this repo on 2026-08-22 (not a pre-existing spec) — `api/hailhq/api/main.py:275-292` (router registration), `api/hailhq/api/routes/*.py` (12 customer-facing routers, each `APIRouter(prefix="/<resource>", tags=[...])`), `api/hailhq/api/routes/internal/*.py` (6 internal routers, `include_in_schema=False`, out of scope), `api/hailhq/api/deps.py:69-96` (`Principal`) and `:344+` (`get_current_principal`), `core/hailhq/core/agent_caps.py` (existing DB-backed per-org velocity cap — a _different_ mechanism from this plan's general rate limiter; do not conflate them), `mcp/hailhq/mcp/server.py` (`_build_app`, middleware wiring) and `mcp/hailhq/mcp/auth.py` (`PassThroughVerifier` — accepts any non-empty bearer string as "valid," real validation happens downstream at the API), `openapi/openapi.yaml` (4,491 lines, 53 operations, generated — confirmed via `docs/public/contributing.md:44-57` and CI `.github/workflows/openapi-check.yml:29-42`, which re-imports the app and diffs, not a live-server call).
+
+## Global Constraints
+
+- Branch `feat/agent-readiness-api-mcp` off `main`, already created in the repo root at `/Users/r/playground/hail` (not a worktree — no other in-progress work on `main` to isolate from, per the repo's own precedent in `docs/superpowers/plans/2026-08-07-console-speechmatics-byo.md`).
+- Conventional Commits. **Never** a `Co-Authored-By` / AI-attribution trailer.
+- Test: `cd /Users/r/playground/hail/api && uv run pytest -q` (and `cd core && uv run pytest -q` for `core/` changes). Lint/format before every commit: `uv run ruff check --fix .` then `uvx black .` (run from the relevant package directory — `api/` or `core/` or `mcp/`).
+- **OpenAPI is source of truth for the CLI** (repo invariant, `CLAUDE.md`). After Tasks 1, 3, and 4 (anything that changes a route signature, description, or schema field), regenerate `openapi/openapi.yaml` in the same commit — see Task 6 for the exact regen command. Do not hand-edit the YAML.
+- Do not touch the 6 `internal/*` routers (`api/hailhq/api/routes/internal/*.py`) in any task — they are `include_in_schema=False`, not part of the public/customer API surface this plan targets, and are called by internal services, not customer API keys.
+- Do not touch `core/hailhq/core/agent_caps.py` or the agent self-signup velocity caps — that is a different, already-shipped mechanism (per-channel send-count ceiling for agent-origin orgs). This plan's rate limiter is a _general_ request-rate limiter across all customer-facing routes, unrelated to and additive with the existing caps.
+- Every task that changes route behavior must not break an existing, unauthenticated-vs-authenticated distinction: unprefixed paths keep working exactly as today (Task 1), rate limiting must not reject any request that would have succeeded before this plan except by exceeding the new limit (Task 2), and MCP's `tools/call` and every method except `initialize`/`tools/list` must 401 exactly as before when unauthenticated (Task 5).
+- No dependency additions without checking AGPLv3 license compatibility (repo invariant). `slowapi` (MIT) and its dependency `limits` (MIT) are both compatible — confirm this in Task 2 regardless, don't just trust this plan.
+
+---
+
+### Task 1: `/v1` URL versioning with backward-compatible dual-mount
+
+**Files:**
+
+- Modify: `api/hailhq/api/main.py` (router registration block, currently lines 275-292)
+- Create: `api/hailhq/api/deprecation.py` (small middleware: stamps `Deprecation: true` + `Link: <https://api.hail.so/v1/...>; rel="successor-version"` on responses to unprefixed paths)
+- Create: `docs/public/versioning.md` (documents what `/v1` means and how deprecation is signaled — the audit item asks this to be documented, not just header-only)
+- Test: `api/tests/test_versioning.py`
+
+**Interfaces:**
+
+- Produces: every one of the 12 customer-facing routers becomes reachable at both `/v1/<resource>/...` (canonical, the only mount in the OpenAPI schema — one operationId per operation, unchanged from before this task) and `/<resource>/...` (legacy, still works, routable but `include_in_schema=False` so it does not appear in the spec, and now carries a `Deprecation` response header). No route handler code changes — same `APIRouter` objects, mounted twice.
+- Consumes: the existing `router` objects exported by each of `calls.py`, `email_attachments.py`, `emails.py`, `events.py`, `email_domains.py`, `numbers.py`, `webhooks.py`, `unsubscribe.py`, `sms.py`, `contacts.py`, `whoami.py`, `providers.py` (all already imported in `main.py`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# api/tests/test_versioning.py
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+from hailhq.core.models import ApiKey
+
+
+async def test_v1_prefix_reaches_whoami(
+    client: httpx.AsyncClient, org_and_key: tuple[uuid.UUID, ApiKey, str]
+) -> None:
+    _, _, plain_key = org_and_key
+    resp = await client.get("/v1/whoami", headers={"Authorization": f"Bearer {plain_key}"})
+    assert resp.status_code == 200
+
+
+async def test_unprefixed_path_still_works_and_is_marked_deprecated(
+    client: httpx.AsyncClient, org_and_key: tuple[uuid.UUID, ApiKey, str]
+) -> None:
+    _, _, plain_key = org_and_key
+    resp = await client.get("/whoami", headers={"Authorization": f"Bearer {plain_key}"})
+    assert resp.status_code == 200
+    assert resp.headers["deprecation"] == "true"
+    assert 'rel="successor-version"' in resp.headers["link"]
+    assert "/v1/whoami" in resp.headers["link"]
+
+
+async def test_v1_path_is_not_marked_deprecated(
+    client: httpx.AsyncClient, org_and_key: tuple[uuid.UUID, ApiKey, str]
+) -> None:
+    _, _, plain_key = org_and_key
+    resp = await client.get("/v1/whoami", headers={"Authorization": f"Bearer {plain_key}"})
+    assert "deprecation" not in resp.headers
+
+
+def test_legacy_unprefixed_paths_are_not_in_the_openapi_schema() -> None:
+    from hailhq.api.main import app
+
+    schema = app.openapi()
+    paths = schema["paths"]
+    assert "/v1/whoami" in paths
+    assert "/whoami" not in paths
+
+
+async def test_internal_routes_are_not_dual_mounted(client: httpx.AsyncClient) -> None:
+    # /internal/... must not also exist at /v1/internal/... — internal routers
+    # were never versioned; a bare-string prefix match on "/v1" + internal's
+    # own "/internal" prefix would be a real path if this task's loop is too
+    # broad. Confirm it 404s. Adjust the exact sub-path to a real internal
+    # route if "ses-events/healthz" doesn't exist verbatim — check
+    # api/hailhq/api/routes/internal/ses_events.py for its real paths first.
+    resp = await client.get("/v1/internal/ses-events/healthz")
+    assert resp.status_code == 404
+```
+
+This uses the real `client` and `org_and_key` fixtures already defined in `api/tests/conftest.py:256-283` (a `httpx.AsyncClient` wired to the real `app` with common provider mocks overridden) and `:284-287` (returns `(organization_id, ApiKey, plain_key_string)`) — the same pattern `api/tests/test_auth_shared.py` and the rest of the suite already use for real-app integration tests against a live-shaped API key. No `@pytest.mark.asyncio`/`anyio` decorator is needed on async test functions in `api/` — confirmed `api/pyproject.toml:47` sets `asyncio_mode = "auto"`, so a bare `async def test_...` is enough (this differs from `mcp/`, which uses `@pytest.mark.asyncio` explicitly — see Task 5 — don't copy that convention into `api/` tests or vice versa).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd api && uv run pytest tests/test_versioning.py -v`
+Expected: FAIL — `/v1/whoami` 404s (no such route yet), and the unprefixed path has no `Deprecation` header.
+
+- [ ] **Step 3: Implement the dual-mount**
+
+In `api/hailhq/api/main.py`, replace the current block:
+
+```python
+app.include_router(calls_routes.router)
+app.include_router(email_attachments_routes.router)
+app.include_router(emails_routes.router)
+app.include_router(events_routes.router)
+app.include_router(email_domains_routes.router)
+app.include_router(numbers_routes.router)
+app.include_router(webhooks_routes.router)
+app.include_router(unsubscribe_routes.router)
+app.include_router(sms_routes.router)
+app.include_router(contacts_routes.router)
+app.include_router(whoami_routes.router)
+app.include_router(providers_routes.router)
+```
+
+with:
+
+```python
+# Customer-facing routers are dual-mounted: /v1/<resource> is canonical
+# and the only mount that appears in the OpenAPI schema. The unprefixed
+# path keeps working for existing integrations (routable, real handler)
+# but is excluded from the schema (include_in_schema=False) so it does
+# not create a second, colliding operationId per operation — FastAPI
+# derives operationId from the function name, and a route mounted twice
+# with schema inclusion on both would produce duplicate IDs and a spec
+# with two paths per operation. The unprefixed path is marked
+# Deprecation: true instead (see deprecation.py). No route handler is
+# duplicated, both mounts point at the same router object.
+_CUSTOMER_ROUTERS = [
+    calls_routes.router,
+    email_attachments_routes.router,
+    emails_routes.router,
+    events_routes.router,
+    email_domains_routes.router,
+    numbers_routes.router,
+    webhooks_routes.router,
+    unsubscribe_routes.router,
+    sms_routes.router,
+    contacts_routes.router,
+    whoami_routes.router,
+    providers_routes.router,
+]
+for _router in _CUSTOMER_ROUTERS:
+    app.include_router(_router, prefix="/v1")
+    app.include_router(_router, include_in_schema=False)
+```
+
+Then add the deprecation-stamping middleware. Create `api/hailhq/api/deprecation.py`:
+
+```python
+"""Marks legacy (unprefixed) customer-API responses as deprecated.
+
+/v1/<resource> is canonical (see main.py's router dual-mount). The
+unprefixed path keeps working — no existing integration breaks — but
+every response on it carries a Deprecation: true header (the widely
+deployed form; RFC 9745 is the current authority for this header) plus a
+Link pointing at the /v1 successor, so a client (or an agent reading the
+response) can tell the path is being phased out without guessing.
+
+Matches on path shape, not a route allowlist: any request whose path does
+NOT start with /v1/ and does NOT start with /internal/ is presumed to be
+hitting a legacy-mounted customer route. /healthz and unmatched 404s also
+pass through this middleware harmlessly (a Deprecation header on a 404 or
+a healthcheck is inert, not incorrect) — this stays simple rather than
+duplicating the router list here too.
+"""
+
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+_V1_PREFIX = "/v1/"
+_INTERNAL_PREFIX = "/internal/"
+
+
+class DeprecationHeaderMiddleware(BaseHTTPMiddleware):
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        response = await call_next(request)
+        path = request.url.path
+        if not path.startswith(_V1_PREFIX) and not path.startswith(_INTERNAL_PREFIX):
+            response.headers["Deprecation"] = "true"
+            versioned = "/v1" + path
+            response.headers["Link"] = f'<{versioned}>; rel="successor-version"'
+        return response
+```
+
+Register it in `main.py` right after `app = FastAPI(...)`:
+
+```python
+from hailhq.api.deprecation import DeprecationHeaderMiddleware
+# ...
+app.add_middleware(DeprecationHeaderMiddleware)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd api && uv run pytest tests/test_versioning.py -v`
+Expected: PASS (all 5 cases)
+
+- [ ] **Step 5: Run the full API test suite to confirm no regression**
+
+Run: `cd api && uv run pytest -q`
+Expected: all pass. Every existing test that calls an unprefixed path (the whole existing suite, since nothing used `/v1` before this task) must still pass unchanged — that's the point of the dual-mount.
+
+- [ ] **Step 6: Write a short versioning doc**
+
+The audit item behind this task asks for more than the header alone — it asks that how deprecation is signaled be documented somewhere an agent (or a human integrator) can read it, not just infer from response headers. Create `docs/public/versioning.md`:
+
+```markdown
+# API versioning
+
+`/v1/<resource>` is the canonical, documented form of every customer-facing
+Hail API route. It appears in the OpenAPI spec (`openapi/openapi.yaml`) and
+is what the CLI and generated clients target.
+
+## Legacy unprefixed paths
+
+Routes without the `/v1` prefix (e.g. `/whoami` instead of `/v1/whoami`)
+still work, for existing integrations built before versioning shipped. They
+are not in the OpenAPI spec and should not be used for new integrations.
+
+Every response from a legacy path carries:
+
+- `Deprecation: true` — this path is deprecated (see the IETF Deprecation
+  HTTP header field).
+- `Link: <https://api.hail.so/v1/...>; rel="successor-version"` — the
+  canonical `/v1` path that replaces it.
+
+## Sunset
+
+No sunset date is set for the legacy paths yet. If one is scheduled, it
+will be announced here and via a `Sunset` response header (RFC 8594) added
+ahead of the change, giving integrators advance notice before the
+unprefixed paths stop working.
+```
+
+- [ ] **Step 7: Lint and format**
+
+Run: `cd api && uv run ruff check --fix . && uvx black .`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add hailhq/api/main.py hailhq/api/deprecation.py tests/test_versioning.py ../docs/public/versioning.md
+git commit -m "feat(api): dual-mount every customer router at /v1, deprecate unprefixed paths"
+```
+
+(Regenerating `openapi/openapi.yaml` happens once, in Task 6, after Tasks 1/3/4 are all in — regenerating after every task would just produce three overlapping diffs of the same file.)
+
+---
+
+### Task 2: General rate-limit headers
+
+**Files:**
+
+- Modify: `api/pyproject.toml` (add `slowapi` dependency)
+- Create: `api/hailhq/api/ratelimit.py`
+- Modify: `api/hailhq/api/main.py` (wire the limiter)
+- Modify: `core/hailhq/core/config.py` (one new setting: default requests-per-minute ceiling)
+- Test: `api/tests/test_ratelimit.py`
+
+**Interfaces:**
+
+- Produces: every response from a customer-facing route (both `/v1/...` and legacy unprefixed, per Task 1's dual-mount — the limiter is keyed on the raw bearer, which is identical on both mounts of the same call) carries `RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset` (IETF `draft-ietf-httpapi-ratelimit-headers` conventions — the header names, not a specific RFC number, since that draft is not yet an RFC; if `slowapi`'s header names differ from these three, use `slowapi`'s actual header names and note the difference in your report rather than fighting the library). A 429 additionally carries `Retry-After`.
+- Consumes: nothing from Task 1 directly — independent of the versioning dual-mount, applies identically to both mounts since it's global middleware keyed on the request, not the matched route.
+
+- [ ] **Step 1: Confirm the dependency and its license**
+
+Run: `cd api && uv add slowapi` (this also pulls in `limits`, its underlying rate-tracking engine). Then confirm both `slowapi` and `limits` are MIT-licensed (check their PyPI project pages or `uv run pip show slowapi limits` for the `License` field) — do not proceed past this step if either turns out to be non-permissive; report back instead.
+
+- [ ] **Step 2: Add the setting**
+
+In `core/hailhq/core/config.py`, add alongside the existing `agent_*` cap settings (same file, same style — read the surrounding `Settings` class fields first to match the naming/env-var convention exactly):
+
+```python
+    api_rate_limit_per_minute: int = 300
+```
+
+(300/min = 5 req/sec sustained per caller — generous for legitimate agent/automation traffic, still bounds a runaway loop. This number is a starting point, not a researched-and-final threshold; flag it clearly as tunable in your commit message, and if `Settings` has an existing doc-comment convention for tunable values, follow it here too.)
+
+- [ ] **Step 3: Write the failing test**
+
+```python
+# api/tests/test_ratelimit.py
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+from hailhq.core.models import ApiKey
+from hailhq.core.config import settings
+
+
+async def test_response_carries_ratelimit_headers(
+    client: httpx.AsyncClient, org_and_key: tuple[uuid.UUID, ApiKey, str]
+) -> None:
+    _, _, plain_key = org_and_key
+    resp = await client.get("/v1/whoami", headers={"Authorization": f"Bearer {plain_key}"})
+    assert resp.status_code == 200
+    assert "ratelimit-limit" in resp.headers or "x-ratelimit-limit" in resp.headers
+
+
+async def test_exceeding_the_limit_returns_429_with_retry_after(
+    client: httpx.AsyncClient,
+    org_and_key: tuple[uuid.UUID, ApiKey, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, plain_key = org_and_key
+    # Drop the ceiling to something trivially exceedable within one test,
+    # rather than firing 300+ real requests.
+    monkeypatch.setattr(settings, "api_rate_limit_per_minute", 2)
+    headers = {"Authorization": f"Bearer {plain_key}"}
+    for _ in range(2):
+        resp = await client.get("/v1/whoami", headers=headers)
+        assert resp.status_code == 200
+    resp = await client.get("/v1/whoami", headers=headers)
+    assert resp.status_code == 429
+    assert "retry-after" in resp.headers
+
+
+async def test_internal_routes_are_not_rate_limited(client: httpx.AsyncClient) -> None:
+    # Internal routes are called by internal services on a trusted path,
+    # not customer API keys — confirm the limiter's key_func (bearer-based)
+    # doesn't apply to a route with no Authorization header at all, and that
+    # this doesn't crash the key function.
+    ...  # implement against whichever internal route is easiest to call
+         # unauthenticated in the existing internal test suite's style —
+         # check api/tests/ for how internal routes are already tested
+         # (search for "internal" in api/tests/*.py for the real pattern).
+```
+
+Note: `monkeypatch.setattr(settings, ...)` only works if `slowapi`'s limiter reads the ceiling dynamically per-request rather than capturing it once at app-startup/import time. If your Step 4 implementation captures the limit as a static decorator argument (the more common `slowapi` pattern, e.g. `@limiter.limit("300/minute")`), this specific test's monkeypatch approach won't work — adapt the test to either use a dependency-override pattern (check `api/tests/conftest.py` for how other settings-dependent tests already do this in this repo) or parametrize the limiter's key/limit per-test some other way. Get the real mechanism working before insisting on the monkeypatch approach as written here.
+
+- [ ] **Step 4: Implement the limiter**
+
+Create `api/hailhq/api/ratelimit.py`:
+
+```python
+"""General per-caller request-rate limiting.
+
+Distinct from core.agent_caps (a DB-backed, per-org, per-channel *send*
+velocity cap for agent-origin orgs only). This is a general HTTP
+request-rate limiter across every customer-facing route, for every
+caller. In-memory storage — safe because this API runs single-instance
+(one VM, docker-compose, no replica orchestration; see deploy.yml). If a
+second instance is ever added, swap slowapi's storage_uri to Redis; no
+call-site changes needed.
+
+Keyed on the raw Authorization header value (hashed) rather than the
+resolved Principal, so the limiter runs before any DB round-trip —
+distinct callers with distinct keys/tokens get distinct buckets even
+before auth resolves whether the token is valid.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from starlette.requests import Request
+
+from hailhq.core.config import settings
+
+
+def _rate_limit_key(request: Request) -> str:
+    auth = request.headers.get("authorization")
+    if not auth:
+        return get_remote_address(request)
+    return hashlib.sha256(auth.encode()).hexdigest()
+
+
+limiter = Limiter(key_func=_rate_limit_key)
+
+
+def rate_limit_string() -> str:
+    return f"{settings.api_rate_limit_per_minute}/minute"
+```
+
+Wire it in `main.py` (check `slowapi`'s current recommended FastAPI integration — the app-level `app.state.limiter = limiter` + `app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)` + `SlowAPIMiddleware` pattern is standard as of `slowapi` 0.1.x, but confirm against the version `uv add` actually installed rather than assuming). Apply the limit to the 12 customer routers only (skip `internal_*` and `/healthz`) — check whether `slowapi` supports a middleware-level default limit with a per-route exemption list, or whether it's cleaner to add the limiter as a dependency on each customer router's `APIRouter(...)` construction (`dependencies=[Depends(limiter.limit(...))]` or similar — the exact mechanism depends on the installed `slowapi` version's API, which you'll confirm in Step 1).
+
+- [ ] **Step 5: Document the new 429 in OpenAPI, following the codebase's existing convention exactly**
+
+This codebase already has a precedent for exactly this: `api/hailhq/api/agent_gate.py:22-33` defines `RATE_LIMITED_RESPONSES` (a `dict[int | str, dict[str, Any]]` documenting the agent-abuse-cap 429's shape, including a `Retry-After` header), and `calls.py`/`sms.py`/`emails.py`'s create-route decorators pass it as `responses=RATE_LIMITED_RESPONSES`. The file's own top comment says why: "FastAPI does not infer statuses from `raise HTTPException`... the create routes must declare this on their decorator... for the generated spec — and the CLI codegen from it — to reflect the rate limit." Your new general limiter's 429 needs the same treatment, or an agent reading the OpenAPI spec has no way to know a 429 is even possible on 51 of the 53 operations that don't already have it.
+
+Add a sibling constant in `api/hailhq/api/ratelimit.py` (same file as the limiter, since it documents that limiter's own error shape):
+
+```python
+from typing import Any
+
+GENERAL_RATE_LIMITED_RESPONSES: dict[int | str, dict[str, Any]] = {
+    429: {
+        "description": (
+            "Rate limited. This caller exceeded the general request-rate "
+            "ceiling. Retry after the Retry-After header (seconds)."
+        ),
+        "headers": {
+            "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {"type": "integer"},
+            },
+            "RateLimit-Limit": {
+                "description": "The request ceiling for the current window.",
+                "schema": {"type": "integer"},
+            },
+            "RateLimit-Remaining": {
+                "description": "Requests remaining in the current window.",
+                "schema": {"type": "integer"},
+            },
+            "RateLimit-Reset": {
+                "description": "Seconds until the current window resets.",
+                "schema": {"type": "integer"},
+            },
+        },
+    }
+}
+```
+
+(Adjust the header names inside this dict to match whatever `slowapi` actually emits, confirmed in Step 4 — don't document header names the implementation doesn't actually send.)
+
+Then add `responses=GENERAL_RATE_LIMITED_RESPONSES` to every one of the 53 route decorators across the 12 customer route files. On the 3 routes that already carry `responses=RATE_LIMITED_RESPONSES` (`calls.py`'s create route, `sms.py`'s create route, `emails.py`'s create route), **merge the two dicts' `429` keys** rather than passing one that clobbers the other — both 429 reasons are real and distinct on those specific routes (the general limiter can fire before the agent-abuse gate is ever reached, and vice versa isn't true, but both are genuinely possible responses a caller needs documented). A simple `{**RATE_LIMITED_RESPONSES, 429: {**RATE_LIMITED_RESPONSES[429], "description": RATE_LIMITED_RESPONSES[429]["description"] + " " + GENERAL_RATE_LIMITED_RESPONSES[429]["description"], "headers": {**RATE_LIMITED_RESPONSES[429]["headers"], **GENERAL_RATE_LIMITED_RESPONSES[429]["headers"]}}}` (or a small named helper, your call on the cleanest shape) captures both without losing either.
+
+This step touches the same 12 files Task 3 touches (route decorators). If Task 3 hasn't run yet when you do this, no conflict — you're each adding a different kwarg/docstring to the same decorators, not fighting over the same lines. If Task 3 already ran, just add `responses=` alongside the description that's already there.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd api && uv run pytest tests/test_ratelimit.py -v`
+Expected: PASS
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `cd api && uv run pytest -q`
+Expected: all pass — in particular, confirm no existing test fires 300+ requests against the same route in one test run and now trips the new limiter (grep the existing test suite for any loop calling a customer route many times before assuming this is clean).
+
+- [ ] **Step 8: Lint and format**
+
+Run: `cd api && uv run ruff check --fix . && uvx black .`
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add hailhq/api/ratelimit.py hailhq/api/main.py hailhq/api/routes/ pyproject.toml uv.lock ../core/hailhq/core/config.py tests/test_ratelimit.py
+git commit -m "feat(api): general in-memory rate limiting with RateLimit-*/Retry-After headers"
+```
+
+---
+
+### Task 3: OpenAPI operation descriptions
+
+**Files:**
+
+- Modify: all 12 files under `api/hailhq/api/routes/` that register a customer-facing route (`calls.py`, `email_attachments.py`, `emails.py`, `events.py`, `email_domains.py`, `numbers.py`, `webhooks.py`, `unsubscribe.py`, `sms.py`, `contacts.py`, `whoami.py`, `providers.py`)
+- Test: `api/tests/test_openapi_descriptions.py`
+
+**Interfaces:**
+
+- Produces: every one of the 53 operations gets a real `description` (via the route decorator's `description=` kwarg, or a docstring on the handler function — FastAPI uses the function docstring as the description when no explicit `description=` is given, so either mechanism satisfies this task; pick whichever a given file already leans toward, or default to a docstring since it doubles as in-code documentation for a future reader).
+- Consumes: nothing from Tasks 1/2.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# api/tests/test_openapi_descriptions.py
+from hailhq.api.main import app
+
+
+def test_every_public_operation_has_a_real_description() -> None:
+    schema = app.openapi()
+    missing = []
+    for path, methods in schema["paths"].items():
+        if path.startswith("/internal") or path.startswith("/v1/internal"):
+            continue
+        for method, op in methods.items():
+            if method not in ("get", "post", "put", "patch", "delete"):
+                continue
+            desc = (op.get("description") or "").strip()
+            if len(desc) < 20:
+                missing.append(f"{method.upper()} {path}")
+    assert not missing, f"{len(missing)} operations still lack a real description: {missing}"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd api && uv run pytest tests/test_openapi_descriptions.py -v`
+Expected: FAIL, listing most of the 53 operations. Task 1's legacy mount is `include_in_schema=False`, so the schema has exactly one entry per operation (at `/v1/...`), not two — the failure count is 53, not 106.
+
+- [ ] **Step 3: Write descriptions**
+
+For each route handler in the 12 files, add a docstring (or `description=` kwarg) that states: what the operation does, in plain language a caller (human or agent) can act on without reading the handler body; any non-obvious side effect (e.g. "triggers an outbound call within seconds," "queues async delivery — use the webhook or GET this resource to confirm final status," "irreversible — the number is permanently released"); and any consent/compliance precondition the caller must already have satisfied (several routes require `recipient_consent` on the request body per `core/hailhq/core/schemas.py` — check for that field's presence in the operation's request model and mention the requirement when it's there, e.g. calls/sms/emails).
+
+Example — `api/hailhq/api/routes/calls.py`'s `create_call` (currently no docstring, currently the empty `description: ""` this task exists to fix):
+
+```python
+@router.post("", response_model=CallResponse, status_code=201)
+async def create_call(...):
+    """Place an outbound AI voice call.
+
+    The call is placed asynchronously — this returns as soon as the call is
+    queued, not when it completes. Poll GET /calls/{call_id} or configure a
+    webhook to get the final status and transcript. Requires
+    recipient_consent=true on the request body; Hail does not verify lawful
+    basis to contact the recipient, the caller warrants it.
+    """
+```
+
+Do this for all 53 operations across the 12 files. Where a file already has some docstrings and some blank ones (check each file individually — don't assume uniform blankness), only touch the blank ones; don't rewrite an existing adequate description just to match this example's exact voice.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd api && uv run pytest tests/test_openapi_descriptions.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `cd api && uv run pytest -q`
+Expected: all pass (docstring-only changes, but confirm nothing else broke).
+
+- [ ] **Step 6: Lint and format**
+
+Run: `cd api && uv run ruff check --fix . && uvx black .`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add hailhq/api/routes/
+git commit -m "docs(api): add real descriptions to all 53 public operations"
+```
+
+---
+
+### Task 4: OpenAPI schema field descriptions
+
+**Files:**
+
+- Modify: `core/hailhq/core/schemas.py`
+- Test: `api/tests/test_openapi_descriptions.py` (extend the file from Task 3 with a field-level check)
+
+**Interfaces:**
+
+- Produces: every field on a request or response Pydantic model reachable from a public operation gets a `Field(description=...)`.
+- Consumes: nothing from Tasks 1-3, but naturally sequenced after Task 3 since both feed the same regeneration step in Task 6.
+
+- [ ] **Step 1: Extend the failing test**
+
+Add to `api/tests/test_openapi_descriptions.py`. This is real, confirmed-working code — verified against a live `app.openapi()` dump on 2026-08-22 (`POST /calls`'s `requestBody.content["application/json"].schema.$ref == "#/components/schemas/CallCreate"`; `CallListResponse.properties.items == {"items": {"$ref": "..."}, "type": "array", ...}`; nullable fields use `anyOf: [{...}, {"type": "null"}]`, confirmed on `CallListResponse.properties.next_cursor`):
+
+```python
+def _collect_schema_refs(node: object, found: set[str]) -> None:
+    """Recursively collect every #/components/schemas/<Name> reference
+    reachable from `node` — handles direct $ref, array `items`, and the
+    `anyOf` shape Pydantic v2 uses for `X | None` fields."""
+    if isinstance(node, dict):
+        ref = node.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/components/schemas/"):
+            found.add(ref.removeprefix("#/components/schemas/"))
+        for key in ("items", "requestBody", "schema"):
+            if key in node:
+                _collect_schema_refs(node[key], found)
+        for key in ("anyOf", "oneOf", "allOf"):
+            for sub in node.get(key, []):
+                _collect_schema_refs(sub, found)
+        content = node.get("content")
+        if isinstance(content, dict):
+            for media in content.values():
+                _collect_schema_refs(media, found)
+    elif isinstance(node, list):
+        for item in node:
+            _collect_schema_refs(item, found)
+
+
+def test_every_public_schema_field_has_a_description() -> None:
+    schema = app.openapi()
+    referenced_schemas: set[str] = set()
+    for path, methods in schema["paths"].items():
+        if path.startswith("/internal") or path.startswith("/v1/internal"):
+            continue
+        for method, op in methods.items():
+            if method not in ("get", "post", "put", "patch", "delete"):
+                continue
+            if "requestBody" in op:
+                _collect_schema_refs(op["requestBody"], referenced_schemas)
+            for resp in op.get("responses", {}).values():
+                _collect_schema_refs(resp, referenced_schemas)
+
+    # Referenced schemas can themselves reference further schemas (e.g. a
+    # response wraps a list of another model) — expand transitively until
+    # the set stops growing.
+    frontier = set(referenced_schemas)
+    while frontier:
+        new_refs: set[str] = set()
+        for name in frontier:
+            model = schema["components"]["schemas"].get(name, {})
+            _collect_schema_refs(model, new_refs)
+        frontier = new_refs - referenced_schemas
+        referenced_schemas |= new_refs
+
+    missing = []
+    for name in sorted(referenced_schemas):
+        model = schema["components"]["schemas"].get(name, {})
+        for field_name, field_schema in model.get("properties", {}).items():
+            if not field_schema.get("description"):
+                missing.append(f"{name}.{field_name}")
+    assert not missing, f"{len(missing)} public schema fields still lack a description: {missing}"
+```
+
+Run this against the real repo before treating it as final — the shapes above were confirmed on 2026-08-22 against this exact codebase, but re-verify with a fresh `app.openapi()` dump if anything about the schema generation has changed since (a FastAPI/Pydantic version bump, for instance, could shift the `anyOf`-for-nullable convention).
+
+- [ ] **Step 2: Run to see it fail**
+
+Run: `cd api && uv run pytest tests/test_openapi_descriptions.py::test_every_public_schema_field_has_a_description -v`
+Expected: FAIL. Confirmed count against the live repo on 2026-08-22: 229 fields across 44 referenced schemas (e.g. `CallCreate.to`, `CallCreate.system_prompt`, `CallListResponse.items`, `Body_upload_email_attachment.file`) — re-confirm the exact count and list at implementation time in case the schema has changed since.
+
+- [ ] **Step 3: Add field descriptions**
+
+In `core/hailhq/core/schemas.py`, add `description=` to every `Field(...)` (or convert a bare type annotation to `Field(description=...)` where none exists yet) on every model reachable from a public operation's request or response. Prioritize by what an agent integrating blind actually needs to know: enum-valued fields (state which values mean what), fields with format constraints (E.164 phone numbers, ISO 8601 timestamps — say so), fields whose name alone is ambiguous (`state` on a Call could mean call-progress or US-state — many are like this, check), and any field whose absence vs. `null` vs. empty-string carries different meaning. For fields that are genuinely self-explanatory from their name and type alone (e.g. `id: UUID`), a short description is still expected (`"Unique identifier for this call."`) — brevity is fine, absence is not.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd api && uv run pytest tests/test_openapi_descriptions.py -v`
+Expected: PASS (both tests from Task 3 and this task)
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `cd core && uv run pytest -q && cd ../api && uv run pytest -q`
+Expected: all pass.
+
+- [ ] **Step 6: Lint and format**
+
+Run: `cd core && uv run ruff check --fix . && uvx black .`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add hailhq/core/schemas.py ../api/tests/test_openapi_descriptions.py
+git commit -m "docs(core): add descriptions to every public API schema field"
+```
+
+---
+
+### Task 5: MCP unauthenticated capability discovery (`initialize` + `tools/list`)
+
+**Files:**
+
+- Create: `mcp/hailhq/mcp/discovery_auth.py`
+- Modify: `mcp/hailhq/mcp/server.py` (insert the new middleware first in the stack)
+- Test: `mcp/tests/test_discovery_auth.py`
+
+**Interfaces:**
+
+- Produces: an unauthenticated `initialize` or `tools/list` JSON-RPC request to `mcp.hail.so` (oauth-rs mode) succeeds instead of 401ing. Every other method — `tools/call`, `resources/*`, `notifications/*`, `ping` — is completely unaffected: still 401s without a bearer, exactly as `test_oauth_rs_unauth_returns_401_with_resource_metadata` (`mcp/tests/test_server_transport.py:38-47`, pre-existing, must still pass unmodified) already asserts for `ping`.
+- Consumes: `mcp.hailhq.mcp.auth.PassThroughVerifier` (unmodified) — the new middleware works by injecting a synthetic non-empty bearer for the two safelisted methods, which the _existing_ verifier already accepts (it accepts any non-empty token string as "valid," per its own docstring — deliberately, since real validation happens downstream at the API and these two methods never reach a downstream API call anyway).
+
+- [ ] **Step 1: Write the failing tests**
+
+Read `mcp/tests/test_server_transport.py` in full first — this task adds to the same file, reusing its `_boot(monkeypatch, oauth=True)` helper (reloads `hailhq.mcp.server` under oauth-rs env, returns the reloaded module — `srv.app` is the real Starlette app) and its `httpx.ASGITransport(app=srv.app)` + `httpx.AsyncClient(transport=transport, base_url="http://t")` pattern, exactly as `test_oauth_rs_unauth_returns_401_with_resource_metadata` (lines 38-47) already does. Use `@pytest.mark.asyncio` on each test — confirmed via that existing test, this package's convention (unlike `api/`, which has `asyncio_mode = "auto"` and needs no decorator — see Task 1's note).
+
+**Session-handshake caveat, resolve before writing the real test:** MCP's Streamable HTTP transport is session-oriented — a real client normally calls `initialize` first, the server returns an `Mcp-Session-Id` response header, and subsequent calls (`tools/list`, `tools/call`, ...) include that header. The pre-existing `ping` test sends a bare `{"method": "ping"}` with no prior `initialize` and no session header and gets 401 — which only proves the _auth_ check runs before any session-state check, not that `tools/list` would work session-less once auth passes. Before asserting `tools/list` returns 200 with no session header, run it against a locally booted oauth-rs server (Step 6 gives you the exact `curl` commands) and see what actually comes back. If FastMCP requires a session, the test (and the manual curl in Step 6) needs two calls: `initialize` first (still with the synthetic-bearer path from this task, so it also succeeds unauthenticated), capture the `Mcp-Session-Id` response header, then send `tools/list` with that header attached. Write the test to match whatever the real protocol requires — don't assert a bare-`tools/list`-succeeds shape if the real server needs the session handshake first.
+
+**Two more transport details to resolve against the real server, not guess:**
+
+1. **`Accept` header.** The `mcp` SDK's Streamable HTTP transport requires the client to send `Accept: application/json, text/event-stream` on POST requests — a request without it (or with only one of the two) gets rejected with 406 before your new middleware's method-check even matters once auth passes. `httpx`'s `json=` kwarg sets `Accept: */*`, which will not satisfy a literal-substring check if the SDK does one. Send the header explicitly on every POST in the new tests: `headers={"Accept": "application/json, text/event-stream"}` (merge with the existing `Content-Type: application/json` header httpx sets automatically for `json=`).
+2. **Response framing.** With FastMCP's default `json_response=False`, a successful POST response comes back as `Content-Type: text/event-stream`, body framed as SSE (`data: {...}` lines), not a bare JSON body — `resp.json()` will raise on a real success response. Before asserting on `body["result"]["tools"]`, check `resp.headers["content-type"]`: if it's `application/json`, `resp.json()` works as written below; if it's `text/event-stream`, parse the JSON out of the `data:` line(s) instead (e.g. `json.loads(next(l[len("data:"):].strip() for l in resp.text.splitlines() if l.startswith("data:")))`). Write the test to match whichever framing the real server actually returns — don't assume `resp.json()` works untested.
+
+```python
+# Add to mcp/tests/test_server_transport.py, near the existing
+# test_oauth_rs_unauth_returns_401_with_resource_metadata test.
+# This is the no-session-required shape; adapt per the caveat above if the
+# real server needs an initialize -> Mcp-Session-Id -> tools/list handshake.
+
+_MCP_ACCEPT = "application/json, text/event-stream"
+
+
+def _parse_mcp_body(resp: httpx.Response) -> dict:
+    """A success response may be framed as bare JSON or as SSE, depending
+    on FastMCP's json_response setting — confirmed by inspecting the real
+    server's response (see Step 6); this helper handles either."""
+    content_type = resp.headers.get("content-type", "")
+    if content_type.startswith("application/json"):
+        return resp.json()
+    data_line = next(
+        line for line in resp.text.splitlines() if line.startswith("data:")
+    )
+    return json.loads(data_line[len("data:") :].strip())
+
+
+@pytest.mark.asyncio
+async def test_oauth_rs_unauth_initialize_succeeds(monkeypatch):
+    """Capability discovery must not require a bearer."""
+    srv = _boot(monkeypatch, oauth=True)
+    transport = httpx.ASGITransport(app=srv.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        resp = await c.post(
+            "/",
+            headers={"Accept": _MCP_ACCEPT},
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "0.0.0"},
+                },
+            },
+        )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_oauth_rs_unauth_tools_list_succeeds(monkeypatch):
+    srv = _boot(monkeypatch, oauth=True)
+    transport = httpx.ASGITransport(app=srv.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        resp = await c.post(
+            "/",
+            headers={"Accept": _MCP_ACCEPT},
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+        )
+    assert resp.status_code == 200
+    body = _parse_mcp_body(resp)
+    tool_names = {t["name"] for t in body["result"]["tools"]}
+    assert "place_call" in tool_names
+    assert "whoami" in tool_names
+
+
+@pytest.mark.asyncio
+async def test_oauth_rs_unauth_tools_call_still_401s(monkeypatch):
+    """The safelist is exactly two methods — tools/call must still require auth."""
+    srv = _boot(monkeypatch, oauth=True)
+    transport = httpx.ASGITransport(app=srv.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        resp = await c.post(
+            "/",
+            headers={"Accept": _MCP_ACCEPT},
+            json={
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "whoami", "arguments": {}},
+            },
+        )
+    assert resp.status_code == 401
+    assert "WWW-Authenticate" in resp.headers
+```
+
+Add `import json` to the test file's imports if not already present (check `mcp/tests/test_server_transport.py`'s existing imports first — don't duplicate).
+
+The pre-existing `test_oauth_rs_unauth_returns_401_with_resource_metadata` already covers `ping` staying 401 unauthenticated — do not duplicate it, just confirm it still passes unmodified in Step 4.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd mcp && uv run pytest tests/test_server_transport.py -k discovery_auth -v` (or however the new tests are named/selected)
+Expected: FAIL — `initialize` and `tools/list` currently 401 same as everything else.
+
+- [ ] **Step 3: Implement the middleware**
+
+Create `mcp/hailhq/mcp/discovery_auth.py`:
+
+```python
+"""Lets an unauthenticated MCP client discover Hail's capabilities.
+
+FastMCP's AuthenticationMiddleware gates the entire Streamable HTTP
+endpoint — every JSON-RPC method, not just tool calls. That's correct for
+tools/call (a real action against a real account) but means an agent
+evaluating whether to bother authenticating at all can't even see what
+tools exist, matching the "properly scoped, upgrade to public tool
+listing" gap an external audit flagged.
+
+This middleware runs BEFORE FastMCP's own auth middleware (see server.py's
+middleware ordering) and, for exactly two JSON-RPC methods —
+"initialize" and "tools/list" — injects a synthetic, non-functional
+bearer token if the request has none. auth.PassThroughVerifier accepts
+any non-empty token string as "valid" (real validation is the downstream
+API's job, and these two methods never call the downstream API), so
+FastMCP's auth layer then lets the request through.
+
+Every other method (tools/call, resources/*, notifications/*, ping, ...)
+is untouched: no header is injected, so a request with no real bearer
+401s exactly as it did before this file existed. This is a safelist, not
+a bypass — widening it later needs the same scrutiny as the original
+two entries, not a one-line addition.
+"""
+
+from __future__ import annotations
+
+import json
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+_DISCOVERY_METHODS = frozenset({"initialize", "tools/list"})
+_SYNTHETIC_BEARER = b"authorization: bearer anonymous-discovery"
+
+
+class DiscoveryAuthMiddleware:
+    """Pure ASGI middleware (not BaseHTTPMiddleware) so it can inspect and
+    replay the request body without interfering with FastMCP's own
+    body-consuming logic downstream — BaseHTTPMiddleware's buffering has
+    known interactions with streaming bodies that this avoids."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or scope["method"] != "POST":
+            await self.app(scope, receive, send)
+            return
+
+        has_auth = any(k.lower() == b"authorization" for k, _ in scope.get("headers", []))
+        if has_auth:
+            await self.app(scope, receive, send)
+            return
+
+        body = b""
+        more_body = True
+        messages = []
+        while more_body:
+            message = await receive()
+            messages.append(message)
+            body += message.get("body", b"")
+            more_body = message.get("more_body", False)
+
+        async def replay_receive() -> dict:
+            if messages:
+                return messages.pop(0)
+            return {"type": "http.disconnect"}
+
+        try:
+            payload = json.loads(body) if body else {}
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            payload = {}
+
+        method = payload.get("method") if isinstance(payload, dict) else None
+        if method in _DISCOVERY_METHODS:
+            new_headers = list(scope.get("headers", []))
+            new_headers.append((b"authorization", b"Bearer anonymous-discovery"))
+            scope = {**scope, "headers": new_headers}
+
+        await self.app(scope, replay_receive, send)
+```
+
+Wire it into `mcp/hailhq/mcp/server.py`'s `_build_app`, wrapping the final `app`. Starlette's `Starlette(middleware=[A, B, ...])` runs `A` outermost (first-listed = outermost = runs first on the way in) — so `DiscoveryAuthMiddleware` must be first in the list, ahead of FastMCP's own middleware, so it can inject the synthetic bearer before FastMCP's `AuthenticationMiddleware` reads the headers:
+
+```python
+from hailhq.mcp.discovery_auth import DiscoveryAuthMiddleware
+from starlette.middleware import Middleware
+# ...
+middleware=[Middleware(DiscoveryAuthMiddleware), *http_app.user_middleware]
+```
+
+Confirm with a quick read of `server.py`'s existing `middleware=[...]` construction site (the comment there already documents that the FastMCP auth middleware must fire "before any route resolution" — this new entry goes before that one in the list, per the ordering above) rather than guessing the variable name.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd mcp && uv run pytest tests/test_server_transport.py -v`
+Expected: PASS — including the pre-existing `test_oauth_rs_unauth_returns_401_with_resource_metadata`, unmodified and still green.
+
+- [ ] **Step 5: Run the full MCP test suite**
+
+Run: `cd mcp && uv run pytest -q`
+Expected: all pass.
+
+- [ ] **Step 6: Manual verification against a locally running server**
+
+Run: `cd mcp && uv run uvicorn hailhq.mcp.server:app --reload --port 8081` (requires `HAIL_AUTH_URL` set per the dev-commands section of `CLAUDE.md` — check `.env.example` for what oauth-rs mode needs locally, or use whatever this repo's existing local-dev docs say for standing up oauth-rs mode specifically, since static-key mode wouldn't exercise this code path at all).
+
+```bash
+curl -s -i -X POST http://localhost:8081/ \
+  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
+# expect: 200, no WWW-Authenticate challenge. -i prints response headers —
+# check Content-Type here: application/json means the body is bare JSON,
+# text/event-stream means it's framed as `data: {...}` lines. Note which
+# one it is and use that to finalize _parse_mcp_body in Step 1's tests.
+# If the response also carries Mcp-Session-Id, capture it and pass it as
+# -H "Mcp-Session-Id: <value>" on the tools/list call below.
+
+curl -s -i -X POST http://localhost:8081/ \
+  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+# expect: 200, a tools array including place_call, send_sms, send_email, whoami, etc.
+# (in the JSON body directly, or inside a `data:` line — see above)
+
+curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:8081/ \
+  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"whoami","arguments":{}}}'
+# expect: 401 — unchanged from before this task
+```
+
+Record the literal output in your report — this is real evidence a unit test alone doesn't fully provide (confirms the ASGI-level header injection actually works against a running server, not just the test client).
+
+- [ ] **Step 7: Lint and format**
+
+Run: `cd mcp && uv run ruff check --fix . && uvx black .`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add hailhq/mcp/discovery_auth.py hailhq/mcp/server.py tests/test_server_transport.py
+git commit -m "feat(mcp): allow unauthenticated initialize + tools/list for capability discovery"
+```
+
+---
+
+### Task 6: Regenerate `openapi/openapi.yaml` and verify CI's diff check
+
+**Files:**
+
+- Modify: `openapi/openapi.yaml` (regenerated, not hand-edited)
+
+**Interfaces:**
+
+- Consumes: the combined effect of Tasks 1, 2, 3, and 4 (new `/v1/...` paths, the new general-limiter 429 response shape, new operation descriptions, new field descriptions — confirmed via `api/hailhq/api/agent_gate.py:22-33`'s existing `RATE_LIMITED_RESPONSES` precedent that this codebase does model response headers in the spec, which is why Task 2 gained its own `GENERAL_RATE_LIMITED_RESPONSES` step). Task 5 (MCP) does not change the OpenAPI surface — the MCP service has no OpenAPI spec at all, it's a separate protocol.
+
+- [ ] **Step 1: Regenerate**
+
+Follow the exact regeneration steps in `docs/public/contributing.md:44-57` (read them first — this plan's summary of "import the app and call app.openapi()" is not necessarily the literal command; use the documented one).
+
+- [ ] **Step 2: Run the CI diff check locally**
+
+Run whatever `.github/workflows/openapi-check.yml:29-42` runs, locally, to confirm the committed file now matches `app.openapi()` with zero diff — read that workflow file for the exact command rather than guessing.
+
+- [ ] **Step 3: Sanity-check the diff**
+
+Run: `git diff openapi/openapi.yaml | head -100` and confirm the diff is plausible. Because Task 1's legacy mount is `include_in_schema=False`, expect every existing path to be _renamed_ to its `/v1/...` form (each old path removed, its `/v1/` counterpart added) rather than doubled — the diff will look large (53 paths renamed) but each operationId should still appear exactly once. Also confirm descriptions are filled in, and that there's no accidental unrelated reformatting of the whole file from a tool-version mismatch. If the diff shows an operationId appearing twice, or touches far more than Tasks 1/3/4's actual changes (e.g. every single line re-indented), stop and report — that's a sign of a generator-version mismatch or a Task 1 regression, not something to paper over by committing anyway.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add openapi/openapi.yaml
+git commit -m "chore(openapi): regenerate spec for /v1 versioning + new descriptions"
+```
+
+- [ ] **Step 5: Note the CLI follow-up**
+
+`CLAUDE.md` states the CLI codegens its client from this file. Regenerating and releasing the Go CLI (`cli/`) is a separate, manual release step per the repo's own docs (`cli/` ships via GitHub Releases, not this PR's CI) — do not attempt to regenerate or release the CLI as part of this plan. Note in your final report that the CLI's generated client will still target the old unprefixed paths until someone runs its own codegen+release cycle, and that this is expected, not a bug in this task.
+
+---
+
+## Final verification pass (after all tasks)
+
+- [ ] **Step 1: Full test suite across all three packages**
+
+Run: `cd api && uv run pytest -q && cd ../core && uv run pytest -q && cd ../mcp && uv run pytest -q`
+Expected: all pass.
+
+- [ ] **Step 2: Lint + format across all three**
+
+Run: `cd api && uv run ruff check . && cd ../core && uv run ruff check . && cd ../mcp && uv run ruff check .` (should be clean already from each task's own Step; this is the final gate) plus `uvx black --check .` in each.
+
+- [ ] **Step 3: mypy**
+
+Run: `cd api && uv run mypy .` (and `core`, `mcp` if they're separately type-checked in CI — check `.github/workflows/ci.yml` for the exact invocation per package).
+
+- [ ] **Step 4: Manual end-to-end smoke test against a locally running API**
+
+Run: `cd api && uv run uvicorn hailhq.api.main:app --reload --port 8080` (needs local Postgres — see `CLAUDE.md`'s dev-commands section), then:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/v1/whoami -H "Authorization: Bearer $HAIL_API_KEY"
+curl -s -D - http://localhost:8080/whoami -H "Authorization: Bearer $HAIL_API_KEY" -o /dev/null | grep -i "deprecation\|link"
+curl -s -D - http://localhost:8080/v1/whoami -H "Authorization: Bearer $HAIL_API_KEY" -o /dev/null | grep -i "ratelimit"
+```
+
+- [ ] **Step 5: Note in the final summary** that everything here is verified locally; a production re-check (does the deployed api.hail.so and mcp.hail.so actually reflect this) only makes sense after these PRs merge and `deploy.yml` rolls the `api` and `mcp` service images — same caveat as the hail-website branch's own final verification.

--- a/mcp/hailhq/mcp/discovery_auth.py
+++ b/mcp/hailhq/mcp/discovery_auth.py
@@ -30,6 +30,17 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 _DISCOVERY_METHODS = frozenset({"initialize", "tools/list"})
 
+# 64 KiB — comfortably above any real initialize/tools/list payload (both are
+# small JSON-RPC envelopes; neither carries bulk data), and small enough to
+# bound worst-case memory for this pre-auth body peek. Before this middleware
+# existed, FastMCP's auth layer 401'd before ever reading the body, so an
+# unbounded buffer here would be a new, unauthenticated DoS surface. Once a
+# request's body exceeds this, it cannot be a legitimate discovery request —
+# stop buffering and fall through with no header injected, so it hits
+# FastMCP's real auth middleware unmodified and 401s like any other
+# non-safelisted request today.
+_MAX_PEEK_BYTES = 64 * 1024
+
 
 class DiscoveryAuthMiddleware:
     """Pure ASGI middleware (not BaseHTTPMiddleware) so it can inspect and
@@ -55,11 +66,21 @@ class DiscoveryAuthMiddleware:
         body = b""
         more_body = True
         messages = []
+        oversized = False
         while more_body:
             message = await receive()
             messages.append(message)
             body += message.get("body", b"")
             more_body = message.get("more_body", False)
+            if len(body) > _MAX_PEEK_BYTES:
+                # Stop reading now — do not keep draining the client's
+                # body into memory just to discover it can never match
+                # the safelist. Whatever's left unread stays unread here;
+                # replay_receive()'s fallback to the real receive() below
+                # still hands it to the downstream app in order, so the
+                # ASGI message stream stays coherent.
+                oversized = True
+                break
 
         async def replay_receive() -> dict:
             # Replay the buffered body messages first; once exhausted,
@@ -77,12 +98,14 @@ class DiscoveryAuthMiddleware:
                 return messages.pop(0)
             return await receive()
 
-        try:
-            payload = json.loads(body) if body else {}
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            payload = {}
+        method = None
+        if not oversized:
+            try:
+                payload = json.loads(body) if body else {}
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                payload = {}
+            method = payload.get("method") if isinstance(payload, dict) else None
 
-        method = payload.get("method") if isinstance(payload, dict) else None
         if method in _DISCOVERY_METHODS:
             new_headers = list(scope.get("headers", []))
             new_headers.append((b"authorization", b"Bearer anonymous-discovery"))

--- a/mcp/hailhq/mcp/discovery_auth.py
+++ b/mcp/hailhq/mcp/discovery_auth.py
@@ -20,11 +20,17 @@ is untouched: no header is injected, so a request with no real bearer
 401s exactly as it did before this file existed. This is a safelist, not
 a bypass — widening it later needs the same scrutiny as the original
 two entries, not a one-line addition.
+
+"initialize" additionally carries a per-remote-IP rate cap (see
+_ANON_INIT_MAX_PER_WINDOW below) — unlike tools/list, a real initialize
+call creates a permanent, stateful MCP session, so unrestricted anonymous
+initialize is a resource-exhaustion vector, not just an information leak.
 """
 
 from __future__ import annotations
 
 import json
+import time
 
 from starlette.types import ASGIApp, Receive, Scope, Send
 
@@ -40,6 +46,49 @@ _DISCOVERY_METHODS = frozenset({"initialize", "tools/list"})
 # FastMCP's real auth middleware unmodified and 401s like any other
 # non-safelisted request today.
 _MAX_PEEK_BYTES = 64 * 1024
+
+# Anonymous "initialize" rate cap. FastMCP's session manager (this SDK
+# version) has no idle timeout — session_idle_timeout defaults to None and
+# is never passed — so sessions are reaped only on explicit DELETE, crash,
+# or restart. A real "initialize" call through this safelist creates a
+# real, permanent, stateful session. Without a cap, an unauthenticated
+# caller can loop "initialize" and accumulate unbounded sessions/tasks — a
+# resource-exhaustion vector distinct from _MAX_PEEK_BYTES above (that
+# bounds per-request memory, not session count). Deliberately NOT applied
+# to "tools/list" — that method doesn't create a session, it only reads
+# one that already exists.
+#
+# Self-contained in-memory fixed-window counter keyed by remote IP —
+# approximate is fine, this only needs to bound the worst case, not be
+# perfectly precise (same reasoning as the body-peek cap; this package has
+# no rate-limiting dependency the way api/'s ratelimit.py does, so a bare
+# dict is simpler than adding one for a single counter).
+_ANON_INIT_WINDOW_SECONDS = 60.0
+_ANON_INIT_MAX_PER_WINDOW = 20
+
+_anon_init_counts: dict[str, tuple[int, float]] = {}
+
+
+def _remote_ip(scope: Scope) -> str:
+    client = scope.get("client")
+    return client[0] if client else "unknown"
+
+
+def _anon_init_cap_exceeded(remote_ip: str) -> bool:
+    now = time.monotonic()
+    count, window_start = _anon_init_counts.get(remote_ip, (0, now))
+    if now - window_start >= _ANON_INIT_WINDOW_SECONDS:
+        count, window_start = 0, now
+    count += 1
+    _anon_init_counts[remote_ip] = (count, window_start)
+    return count > _ANON_INIT_MAX_PER_WINDOW
+
+
+def _reset_anon_init_rate_state_for_tests() -> None:
+    """Test-only: clear accumulated per-IP counters between test cases so
+    one test's anonymous initialize calls can't trip the cap for another
+    (see tests/conftest.py's autouse fixture)."""
+    _anon_init_counts.clear()
 
 
 class DiscoveryAuthMiddleware:
@@ -106,9 +155,16 @@ class DiscoveryAuthMiddleware:
                 payload = {}
             method = payload.get("method") if isinstance(payload, dict) else None
 
-        if method in _DISCOVERY_METHODS:
+        cap_exceeded = method == "initialize" and _anon_init_cap_exceeded(
+            _remote_ip(scope)
+        )
+        if method in _DISCOVERY_METHODS and not cap_exceeded:
             new_headers = list(scope.get("headers", []))
             new_headers.append((b"authorization", b"Bearer anonymous-discovery"))
             scope = {**scope, "headers": new_headers}
+        # cap_exceeded (or method not in the safelist): no header injected,
+        # falls through to FastMCP's real auth middleware unmodified — same
+        # established pattern as the oversized-body case above (no bespoke
+        # response shape invented here).
 
         await self.app(scope, replay_receive, send)

--- a/mcp/hailhq/mcp/discovery_auth.py
+++ b/mcp/hailhq/mcp/discovery_auth.py
@@ -29,6 +29,7 @@ initialize is a resource-exhaustion vector, not just an information leak.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 
@@ -46,6 +47,14 @@ _DISCOVERY_METHODS = frozenset({"initialize", "tools/list"})
 # FastMCP's real auth middleware unmodified and 401s like any other
 # non-safelisted request today.
 _MAX_PEEK_BYTES = 64 * 1024
+
+# Bounds wall-clock time, not just memory: without this, a client that
+# trickles the body in small chunks under _MAX_PEEK_BYTES and never sets
+# more_body=False keeps this coroutine (and its connection) blocked on
+# receive() indefinitely — a Slowloris-style hang the byte cap alone does
+# not catch. 5s is generous for a same-request body that's supposed to be a
+# small JSON-RPC envelope arriving in one or two chunks.
+_MAX_PEEK_SECONDS = 5.0
 
 # Anonymous "initialize" rate cap. FastMCP's session manager (this SDK
 # version) has no idle timeout — session_idle_timeout defaults to None and
@@ -116,8 +125,20 @@ class DiscoveryAuthMiddleware:
         more_body = True
         messages = []
         oversized = False
+        deadline = time.monotonic() + _MAX_PEEK_SECONDS
         while more_body:
-            message = await receive()
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                # Same fallthrough as the oversized case: stop waiting on
+                # this client's body and let the real auth middleware 401
+                # the request unmodified.
+                oversized = True
+                break
+            try:
+                message = await asyncio.wait_for(receive(), timeout=remaining)
+            except asyncio.TimeoutError:
+                oversized = True
+                break
             messages.append(message)
             body += message.get("body", b"")
             more_body = message.get("more_body", False)

--- a/mcp/hailhq/mcp/discovery_auth.py
+++ b/mcp/hailhq/mcp/discovery_auth.py
@@ -1,0 +1,91 @@
+"""Lets an unauthenticated MCP client discover Hail's capabilities.
+
+FastMCP's AuthenticationMiddleware gates the entire Streamable HTTP
+endpoint — every JSON-RPC method, not just tool calls. That's correct for
+tools/call (a real action against a real account) but means an agent
+evaluating whether to bother authenticating at all can't even see what
+tools exist, matching the "properly scoped, upgrade to public tool
+listing" gap an external audit flagged.
+
+This middleware runs BEFORE FastMCP's own auth middleware (see server.py's
+middleware ordering) and, for exactly two JSON-RPC methods —
+"initialize" and "tools/list" — injects a synthetic, non-functional
+bearer token if the request has none. auth.PassThroughVerifier accepts
+any non-empty token string as "valid" (real validation is the downstream
+API's job, and these two methods never call the downstream API), so
+FastMCP's auth layer then lets the request through.
+
+Every other method (tools/call, resources/*, notifications/*, ping, ...)
+is untouched: no header is injected, so a request with no real bearer
+401s exactly as it did before this file existed. This is a safelist, not
+a bypass — widening it later needs the same scrutiny as the original
+two entries, not a one-line addition.
+"""
+
+from __future__ import annotations
+
+import json
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+_DISCOVERY_METHODS = frozenset({"initialize", "tools/list"})
+
+
+class DiscoveryAuthMiddleware:
+    """Pure ASGI middleware (not BaseHTTPMiddleware) so it can inspect and
+    replay the request body without interfering with FastMCP's own
+    body-consuming logic downstream — BaseHTTPMiddleware's buffering has
+    known interactions with streaming bodies that this avoids."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or scope["method"] != "POST":
+            await self.app(scope, receive, send)
+            return
+
+        has_auth = any(
+            k.lower() == b"authorization" for k, _ in scope.get("headers", [])
+        )
+        if has_auth:
+            await self.app(scope, receive, send)
+            return
+
+        body = b""
+        more_body = True
+        messages = []
+        while more_body:
+            message = await receive()
+            messages.append(message)
+            body += message.get("body", b"")
+            more_body = message.get("more_body", False)
+
+        async def replay_receive() -> dict:
+            # Replay the buffered body messages first; once exhausted,
+            # delegate to the REAL upstream receive() rather than
+            # fabricating {"type": "http.disconnect"}. Downstream (e.g.
+            # sse_starlette's EventSourceResponse, used by FastMCP's
+            # streamable HTTP transport) has its own disconnect-watcher
+            # task that calls receive() past body-consumption expecting
+            # it to reflect real connection state. A fabricated disconnect
+            # here makes that watcher fire immediately, which cancels the
+            # whole SSE response's task group before the actual JSON-RPC
+            # payload is ever streamed back — confirmed empirically: the
+            # client saw 200 + SSE headers but a truncated/empty body.
+            if messages:
+                return messages.pop(0)
+            return await receive()
+
+        try:
+            payload = json.loads(body) if body else {}
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            payload = {}
+
+        method = payload.get("method") if isinstance(payload, dict) else None
+        if method in _DISCOVERY_METHODS:
+            new_headers = list(scope.get("headers", []))
+            new_headers.append((b"authorization", b"Bearer anonymous-discovery"))
+            scope = {**scope, "headers": new_headers}
+
+        await self.app(scope, replay_receive, send)

--- a/mcp/hailhq/mcp/server.py
+++ b/mcp/hailhq/mcp/server.py
@@ -29,9 +29,11 @@ from collections.abc import AsyncIterator
 
 from hailhq.core.config import settings
 from hailhq.mcp.auth import AuthMode, PassThroughVerifier, select_auth_mode
+from hailhq.mcp.discovery_auth import DiscoveryAuthMiddleware
 from hailhq.mcp.hail_client import HailClient
 from hailhq.mcp.tools import register_tools
 from starlette.applications import Starlette
+from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
@@ -94,13 +96,18 @@ def _build_app() -> tuple[FastMCP, HailClient | None, Starlette]:
     # http_app.user_middleware, NOT on its routes. Fold them into the
     # parent app's middleware stack so 401-with-WWW-Authenticate fires
     # before any route resolution.
+    #
+    # DiscoveryAuthMiddleware goes first in the list (= outermost = runs
+    # first on the way in), ahead of FastMCP's own auth middleware, so it
+    # can inject a synthetic bearer for the two capability-discovery
+    # methods before AuthenticationMiddleware reads the headers.
     app = Starlette(
         routes=[
             Route("/healthz", healthz, methods=["GET"]),
             Route("/.well-known/glama.json", glama_connector_claim, methods=["GET"]),
             *http_app.routes,
         ],
-        middleware=list(http_app.user_middleware),
+        middleware=[Middleware(DiscoveryAuthMiddleware), *http_app.user_middleware],
         lifespan=lifespan,
     )
     return mcp_app, singleton, app

--- a/mcp/tests/conftest.py
+++ b/mcp/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared test fixtures for the mcp package's test suite."""
+
+from __future__ import annotations
+
+import pytest
+from hailhq.mcp.discovery_auth import _reset_anon_init_rate_state_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _reset_discovery_auth_rate_state():
+    """DiscoveryAuthMiddleware's anonymous-initialize rate cap is a
+    module-level, process-wide counter keyed by remote IP. httpx's
+    ASGITransport defaults every test to the same synthetic client address
+    (127.0.0.1:123 — see httpx.ASGITransport.__init__), so without this
+    reset, one test's initialize calls would count against every other
+    test's budget and could spuriously trip the cap. Resets before AND
+    after each test so ordering never matters.
+    """
+    _reset_anon_init_rate_state_for_tests()
+    yield
+    _reset_anon_init_rate_state_for_tests()

--- a/mcp/tests/test_server_transport.py
+++ b/mcp/tests/test_server_transport.py
@@ -13,6 +13,7 @@ import json
 
 import httpx
 import pytest
+from hailhq.mcp import discovery_auth
 
 
 def _boot(
@@ -189,6 +190,54 @@ async def test_oauth_rs_oversized_body_not_buffered_unbounded(monkeypatch):
                 "params": {"padding": oversized_padding},
             },
         )
+    assert resp.status_code == 401
+    www = resp.headers.get("www-authenticate", "")
+    assert "Bearer" in www
+    assert "resource_metadata=" in www
+
+
+@pytest.mark.asyncio
+async def test_oauth_rs_anon_initialize_capped_per_ip(monkeypatch):
+    """Fix: an unauthenticated caller looping "initialize" must not
+    accumulate unbounded MCP sessions (this SDK version's session manager
+    has no idle timeout, so each successful anonymous initialize is a
+    permanent session). Once the per-IP cap
+    (discovery_auth._ANON_INIT_MAX_PER_WINDOW) is exceeded, further
+    anonymous initialize calls fall through to FastMCP's real auth
+    middleware unmodified (no synthetic bearer injected) — same
+    established pattern as test_oauth_rs_oversized_body_not_buffered_unbounded
+    above: a plain 401, not a bespoke response shape.
+    """
+    monkeypatch.setattr(discovery_auth, "_ANON_INIT_MAX_PER_WINDOW", 2)
+
+    def _init_payload(i: int) -> dict:
+        return {
+            "jsonrpc": "2.0",
+            "id": i,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "0.0.0"},
+            },
+        }
+
+    srv = _boot(monkeypatch, oauth=True)
+    async with srv.app.router.lifespan_context(srv.app):
+        transport = httpx.ASGITransport(app=srv.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+            for i in range(2):
+                resp = await c.post(
+                    "/", headers={"Accept": _MCP_ACCEPT}, json=_init_payload(i)
+                )
+                assert resp.status_code == 200
+
+            # Cap now exceeded (httpx's ASGITransport uses the same
+            # synthetic client address, 127.0.0.1:123, for every request in
+            # this client — see httpx.ASGITransport.__init__).
+            resp = await c.post(
+                "/", headers={"Accept": _MCP_ACCEPT}, json=_init_payload(99)
+            )
     assert resp.status_code == 401
     www = resp.headers.get("www-authenticate", "")
     assert "Bearer" in www

--- a/mcp/tests/test_server_transport.py
+++ b/mcp/tests/test_server_transport.py
@@ -9,6 +9,7 @@ in both modes.
 from __future__ import annotations
 
 import importlib
+import json
 
 import httpx
 import pytest
@@ -46,6 +47,123 @@ async def test_oauth_rs_unauth_returns_401_with_resource_metadata(monkeypatch):
     assert "Bearer" in www
     assert "resource_metadata=" in www
     assert "https://mcp.hail.so/.well-known/oauth-protected-resource" in www
+
+
+_MCP_ACCEPT = "application/json, text/event-stream"
+
+
+def _parse_mcp_body(resp: httpx.Response) -> dict:
+    """A success response may be framed as bare JSON or as SSE, depending
+    on FastMCP's json_response setting. Empirically confirmed against a
+    locally booted oauth-rs server (see task-5-report.md): with the
+    default json_response=False, a 200 comes back as
+    Content-Type: text/event-stream with the JSON-RPC payload on a
+    ``data:`` line — this helper handles either framing."""
+    content_type = resp.headers.get("content-type", "")
+    if content_type.startswith("application/json"):
+        return resp.json()
+    data_line = next(
+        line for line in resp.text.splitlines() if line.startswith("data:")
+    )
+    return json.loads(data_line[len("data:") :].strip())
+
+
+@pytest.mark.asyncio
+async def test_oauth_rs_unauth_initialize_succeeds(monkeypatch):
+    """Capability discovery must not require a bearer.
+
+    Reaching FastMCP's streamable handler needs the parent app's lifespan
+    running (it starts mcp_app.session_manager) — same requirement as
+    test_static_key_no_auth_no_protected_resource_route above. httpx's
+    ASGITransport does not run lifespan on its own, so drive it explicitly.
+    """
+    srv = _boot(monkeypatch, oauth=True)
+    async with srv.app.router.lifespan_context(srv.app):
+        transport = httpx.ASGITransport(app=srv.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+            resp = await c.post(
+                "/",
+                headers={"Accept": _MCP_ACCEPT},
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-06-18",
+                        "capabilities": {},
+                        "clientInfo": {"name": "test", "version": "0.0.0"},
+                    },
+                },
+            )
+    assert resp.status_code == 200
+    body = _parse_mcp_body(resp)
+    assert body["result"]["protocolVersion"] == "2025-06-18"
+
+
+@pytest.mark.asyncio
+async def test_oauth_rs_unauth_tools_list_succeeds(monkeypatch):
+    """tools/list is session-oriented: empirically (see task-5-report.md),
+    a bare tools/list with no prior initialize gets 400 "Missing session
+    ID". So this test does the real handshake — initialize (also
+    unauthenticated, via the same safelist) first, captures the returned
+    Mcp-Session-Id, then sends tools/list with that header.
+    """
+    srv = _boot(monkeypatch, oauth=True)
+    async with srv.app.router.lifespan_context(srv.app):
+        transport = httpx.ASGITransport(app=srv.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+            init_resp = await c.post(
+                "/",
+                headers={"Accept": _MCP_ACCEPT},
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-06-18",
+                        "capabilities": {},
+                        "clientInfo": {"name": "test", "version": "0.0.0"},
+                    },
+                },
+            )
+            assert init_resp.status_code == 200
+            session_id = init_resp.headers["mcp-session-id"]
+
+            resp = await c.post(
+                "/",
+                headers={"Accept": _MCP_ACCEPT, "Mcp-Session-Id": session_id},
+                json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+            )
+    assert resp.status_code == 200
+    body = _parse_mcp_body(resp)
+    tool_names = {t["name"] for t in body["result"]["tools"]}
+    assert "place_call" in tool_names
+    assert "whoami" in tool_names
+
+
+@pytest.mark.asyncio
+async def test_oauth_rs_unauth_tools_call_still_401s(monkeypatch):
+    """The safelist is exactly two methods — tools/call must still require
+    auth. No lifespan needed here: like the pre-existing ping/401 test,
+    auth is rejected before the request ever reaches FastMCP's
+    session-manager-dependent streamable handler."""
+    srv = _boot(monkeypatch, oauth=True)
+    transport = httpx.ASGITransport(app=srv.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        resp = await c.post(
+            "/",
+            headers={"Accept": _MCP_ACCEPT},
+            json={
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "whoami", "arguments": {}},
+            },
+        )
+    assert resp.status_code == 401
+    www = resp.headers.get("www-authenticate", "")
+    assert "Bearer" in www
+    assert "resource_metadata=" in www
 
 
 @pytest.mark.asyncio

--- a/mcp/tests/test_server_transport.py
+++ b/mcp/tests/test_server_transport.py
@@ -167,6 +167,35 @@ async def test_oauth_rs_unauth_tools_call_still_401s(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_oauth_rs_oversized_body_not_buffered_unbounded(monkeypatch):
+    """DiscoveryAuthMiddleware's pre-auth body peek is capped
+    (_MAX_PEEK_BYTES). A body past the cap must not get the synthetic
+    bearer injected, even if its (unparsed, because unread past the cap)
+    method name is "initialize" — it falls through to FastMCP's real auth
+    middleware unmodified and 401s exactly like any other unauthenticated,
+    non-safelisted request. This exercises the cap without sending a truly
+    huge body: 200 KiB is comfortably past the 64 KiB ceiling."""
+    srv = _boot(monkeypatch, oauth=True)
+    transport = httpx.ASGITransport(app=srv.app)
+    oversized_padding = "x" * (200 * 1024)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        resp = await c.post(
+            "/",
+            headers={"Accept": _MCP_ACCEPT},
+            json={
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "initialize",
+                "params": {"padding": oversized_padding},
+            },
+        )
+    assert resp.status_code == 401
+    www = resp.headers.get("www-authenticate", "")
+    assert "Bearer" in www
+    assert "resource_metadata=" in www
+
+
+@pytest.mark.asyncio
 async def test_oauth_rs_publishes_protected_resource_metadata(monkeypatch):
     srv = _boot(monkeypatch, oauth=True)
     transport = httpx.ASGITransport(app=srv.app)

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -18,7 +18,7 @@ paths:
       description:
         "Place an outbound AI voice call.\n\nThe call is placed asynchronously\
         \ \u2014 this returns as soon as the call is\nqueued, not when it completes.\
-        \ Poll GET /calls/{call_id} or configure a\nwebhook to get the final status\
+        \ Poll GET /v1/calls/{call_id} or configure a\nwebhook to get the final status\
         \ and transcript. Requires\nrecipient_consent=true on the request body; Hail\
         \ does not verify lawful\nbasis to contact the recipient, the caller warrants\
         \ it."
@@ -194,7 +194,7 @@ paths:
 
         (not 403, to avoid confirming the id exists). Use this to poll for the
 
-        final outcome of a call placed with POST /calls."
+        final outcome of a call placed with POST /v1/calls."
       operationId: get_call_v1_calls__call_id__get
       parameters:
         - name: call_id
@@ -256,7 +256,7 @@ paths:
 
         The returned id can be referenced from attachment_ids on many later
 
-        POST /emails calls until it is garbage-collected for being unused; it is
+        POST /v1/emails calls until it is garbage-collected for being unused; it is
 
         not deleted immediately after first use. Uploads are size-limited and
 
@@ -320,9 +320,9 @@ paths:
         "Send an outbound email through SES.\n\nSends synchronously \u2014\
         \ the response reports the final status (sent or\nfailed), not a queued placeholder;\
         \ no separate poll is needed for the\nhappy path, though a bounce or complaint\
-        \ can still arrive later as a\nwebhook or GET /emails/{email_id}/events entry.\
-        \ Requires\nrecipient_consent=true on the request body; Hail does not verify\
-        \ lawful\nbasis to contact the recipient, the caller warrants it."
+        \ can still arrive later as a\nwebhook or GET /v1/emails/{email_id}/events\
+        \ entry. Requires\nrecipient_consent=true on the request body; Hail does not\
+        \ verify lawful\nbasis to contact the recipient, the caller warrants it."
       operationId: create_email_v1_emails_post
       parameters:
         - name: authorization
@@ -391,7 +391,7 @@ paths:
         "List emails for the caller's organization, newest first.\n\nCursor-paginated:\
         \ pass the returned next_cursor to fetch the next page;\na null next_cursor\
         \ means there are no more results. Filter by status or\ndirection (outbound/inbound).\
-        \ List entries omit body_text/body_html \u2014\nfetch GET /emails/{email_id}\
+        \ List entries omit body_text/body_html \u2014\nfetch GET /v1/emails/{email_id}\
         \ for the full body."
       operationId: list_emails_v1_emails_get
       parameters:
@@ -574,7 +574,8 @@ paths:
 
         an 8-day range; any bucket size is limited to a 92-day range. Registered
 
-        above GET /{email_id} so "stats" is not swallowed by the id path param.'
+        above GET /v1/emails/{email_id} so "stats" is not swallowed by the id path
+        param.'
       operationId: get_email_stats_v1_emails_stats_get
       parameters:
         - name: from
@@ -660,7 +661,7 @@ paths:
 
         organization. For an inbound email with a stored raw MIME, raw_url
 
-        points at GET /emails/{email_id}/raw."
+        points at GET /v1/emails/{email_id}/raw."
       operationId: get_email_v1_emails__email_id__get
       parameters:
         - name: email_id
@@ -931,8 +932,8 @@ paths:
         kind=\"hail_mail\" mints an address on the shared hail-mail domain and is\n\
         immediately verified \u2014 no DNS work needed. kind=\"custom\" registers\
         \ your\nown domain with SES and returns DKIM records; the domain stays\nunverified\
-        \ (POST /email-domains/{domain_id}/verify) until you publish\nthose DNS records\
-        \ and Hail confirms them."
+        \ (POST /v1/email-domains/{domain_id}/verify) until you publish\nthose DNS\
+        \ records and Hail confirms them."
       operationId: create_email_domain_v1_email_domains_post
       parameters:
         - name: authorization
@@ -990,8 +991,8 @@ paths:
       description:
         "List sender domains/identities for the caller's organization.\n\
         \nCursor-paginated, newest first. The response also includes\ndefault_from\
-        \ \u2014 the address a from-less POST /emails would use right\nnow given the\
-        \ org's current verified senders."
+        \ \u2014 the address a from-less POST /v1/emails would use right\nnow given\
+        \ the org's current verified senders."
       operationId: list_email_domains_v1_email_domains_get
       parameters:
         - name: cursor
@@ -1691,8 +1692,8 @@ paths:
         "Create a webhook subscription for one or more event types.\n\n\
         The response includes the plaintext signing secret \u2014 this is the only\n\
         time it is ever returned; store it now. Every later GET omits it. Use\nPOST\
-        \ /webhooks/{sub_id}/rotate-secret to get a new plaintext secret if\nit is\
-        \ lost or compromised."
+        \ /v1/webhooks/{sub_id}/rotate-secret to get a new plaintext secret if\nit\
+        \ is lost or compromised."
       operationId: create_subscription_v1_webhooks_post
       parameters:
         - name: authorization
@@ -1750,7 +1751,8 @@ paths:
       description:
         "List webhook subscriptions for the caller's organization.\n\n\
         Cursor-paginated, newest first. The signing secret is never included \u2014\
-        \nonly POST /webhooks and POST /webhooks/{sub_id}/rotate-secret return it."
+        \nonly POST /v1/webhooks and POST /v1/webhooks/{sub_id}/rotate-secret return\
+        \ it."
       operationId: list_subscriptions_v1_webhooks_get
       parameters:
         - name: cursor
@@ -2066,7 +2068,7 @@ paths:
       description:
         "List delivery attempts for one webhook subscription, newest first.\n\
         \nCursor-paginated. Each entry shows the attempt count, response status,\n\
-        and response body Hail recorded \u2014 use POST /webhooks/{sub_id}/\ndeliveries/{delivery_id}/redeliver\
+        and response body Hail recorded \u2014 use POST /v1/webhooks/{sub_id}/\ndeliveries/{delivery_id}/redeliver\
         \ to retry a failed one."
       operationId: list_deliveries_v1_webhooks__sub_id__deliveries_get
       parameters:
@@ -2267,7 +2269,7 @@ paths:
         "Send an outbound SMS.\n\nSends synchronously \u2014 the response\
         \ reports the final status (sent or\nfailed), not a queued placeholder, though\
         \ delivery confirmation from\nthe carrier can still arrive later as a webhook\
-        \ or GET /sms/{sms_id}\nupdate. An explicit from resolves a dedicated number;\
+        \ or GET /v1/sms/{sms_id}\nupdate. An explicit from resolves a dedicated number;\
         \ otherwise Hail\npicks an alphanumeric sender ID where the destination corridor\
         \ allows\nit, or requires a dedicated SMS-capable number otherwise. Requires\n\
         recipient_consent=true on the request body; Hail does not verify\nlawful basis\
@@ -2438,9 +2440,9 @@ paths:
         "List SMS numbers suppressed from receiving messages, newest first.
 
 
-        Cursor-paginated. A suppressed number blocks POST /sms sends to it
+        Cursor-paginated. A suppressed number blocks POST /v1/sms sends to it
 
-        with a 403 until removed via DELETE /sms/suppressions/{number}."
+        with a 403 until removed via DELETE /v1/sms/suppressions/{number}."
       operationId: list_sms_suppressions_v1_sms_suppressions_get
       parameters:
         - name: cursor

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2233,27 +2233,6 @@ paths:
             text/html:
               schema:
                 type: string
-        "429":
-          description:
-            Rate limited. This caller exceeded the general request-rate
-            ceiling. Retry after the Retry-After header (seconds).
-          headers:
-            Retry-After:
-              description: Seconds to wait before retrying.
-              schema:
-                type: integer
-            RateLimit-Limit:
-              description: The request ceiling for the current window.
-              schema:
-                type: integer
-            RateLimit-Remaining:
-              description: Requests remaining in the current window.
-              schema:
-                type: integer
-            RateLimit-Reset:
-              description: Seconds until the current window resets.
-              schema:
-                type: integer
         "422":
           description: Validation Error
           content:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -10,12 +10,19 @@ servers:
   - url: https://api.hail.so
     description: Hail Cloud
 paths:
-  /calls:
+  /v1/calls:
     post:
       tags:
         - calls
       summary: Create Call
-      operationId: create_call_calls_post
+      description:
+        "Place an outbound AI voice call.\n\nThe call is placed asynchronously\
+        \ \u2014 this returns as soon as the call is\nqueued, not when it completes.\
+        \ Poll GET /calls/{call_id} or configure a\nwebhook to get the final status\
+        \ and transcript. Requires\nrecipient_consent=true on the request body; Hail\
+        \ does not verify lawful\nbasis to contact the recipient, the caller warrants\
+        \ it."
+      operationId: create_call_v1_calls_post
       parameters:
         - name: authorization
           in: header
@@ -50,10 +57,23 @@ paths:
           description:
             Rate limited. The agent-origin workspace exceeded a per-channel
             velocity cap, or the platform kill switch is on. Retry after the Retry-After
-            header (seconds).
+            header (seconds). Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
           headers:
             Retry-After:
               description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
               schema:
                 type: integer
         "422":
@@ -66,7 +86,15 @@ paths:
       tags:
         - calls
       summary: List Calls
-      operationId: list_calls_calls_get
+      description: "List calls for the caller's organization, newest first.
+
+
+        Cursor-paginated: pass the returned next_cursor to fetch the next page;
+
+        a null next_cursor means there are no more results. Filter by status or
+
+        destination number (to) to narrow the list."
+      operationId: list_calls_v1_calls_get
       parameters:
         - name: cursor
           in: query
@@ -126,18 +154,48 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CallListResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /calls/{call_id}:
+  /v1/calls/{call_id}:
     get:
       tags:
         - calls
       summary: Get Call
-      operationId: get_call_calls__call_id__get
+      description:
+        "Fetch one call by id, including its current status and end reason.
+
+
+        Org-scoped: returns 404 for a call belonging to a different organization
+
+        (not 403, to avoid confirming the id exists). Use this to poll for the
+
+        final outcome of a call placed with POST /calls."
+      operationId: get_call_v1_calls__call_id__get
       parameters:
         - name: call_id
           in: path
@@ -161,17 +219,48 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CallResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /email-attachments:
+  /v1/email-attachments:
     post:
       tags:
         - email-attachments
       summary: Create Email Attachment
+      description: "Upload a file and get back a reusable attachment id.
+
+
+        The returned id can be referenced from attachment_ids on many later
+
+        POST /emails calls until it is garbage-collected for being unused; it is
+
+        not deleted immediately after first use. Uploads are size-limited and
+
+        scoped to the caller's organization."
       operationId: upload_email_attachment
       parameters:
         - name: authorization
@@ -195,18 +284,46 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EmailAttachmentUploadResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /emails:
+  /v1/emails:
     post:
       tags:
         - emails
       summary: Create Email
-      operationId: create_email_emails_post
+      description:
+        "Send an outbound email through SES.\n\nSends synchronously \u2014\
+        \ the response reports the final status (sent or\nfailed), not a queued placeholder;\
+        \ no separate poll is needed for the\nhappy path, though a bounce or complaint\
+        \ can still arrive later as a\nwebhook or GET /emails/{email_id}/events entry.\
+        \ Requires\nrecipient_consent=true on the request body; Hail does not verify\
+        \ lawful\nbasis to contact the recipient, the caller warrants it."
+      operationId: create_email_v1_emails_post
       parameters:
         - name: authorization
           in: header
@@ -241,10 +358,23 @@ paths:
           description:
             Rate limited. The agent-origin workspace exceeded a per-channel
             velocity cap, or the platform kill switch is on. Retry after the Retry-After
-            header (seconds).
+            header (seconds). Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
           headers:
             Retry-After:
               description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
               schema:
                 type: integer
         "422":
@@ -257,7 +387,13 @@ paths:
       tags:
         - emails
       summary: List Emails
-      operationId: list_emails_emails_get
+      description:
+        "List emails for the caller's organization, newest first.\n\nCursor-paginated:\
+        \ pass the returned next_cursor to fetch the next page;\na null next_cursor\
+        \ means there are no more results. Filter by status or\ndirection (outbound/inbound).\
+        \ List entries omit body_text/body_html \u2014\nfetch GET /emails/{email_id}\
+        \ for the full body."
+      operationId: list_emails_v1_emails_get
       parameters:
         - name: cursor
           in: query
@@ -318,13 +454,34 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EmailListResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /emails/{email_id}/events:
+  /v1/emails/{email_id}/events:
     get:
       tags:
         - emails
@@ -335,7 +492,7 @@ paths:
         Cursor-paginated with the same forward-walk shape as ``GET /events``:
 
         strictly-greater on ``(occurred_at, id)``, ascending."
-      operationId: list_email_events_emails__email_id__events_get
+      operationId: list_email_events_v1_emails__email_id__events_get
       parameters:
         - name: email_id
           in: path
@@ -376,18 +533,49 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EmailEventListResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /emails/stats:
+  /v1/emails/stats:
     get:
       tags:
         - emails
       summary: Get Email Stats
-      operationId: get_email_stats_emails_stats_get
+      description:
+        'Aggregate send/delivery/open/click/bounce counts and rates over
+        a range.
+
+
+        Defaults to the last 7 days, bucketed by day. bucket=hour is limited to
+
+        an 8-day range; any bucket size is limited to a 92-day range. Registered
+
+        above GET /{email_id} so "stats" is not swallowed by the id path param.'
+      operationId: get_email_stats_v1_emails_stats_get
       parameters:
         - name: from
           in: query
@@ -432,18 +620,48 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EmailStatsResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /emails/{email_id}:
+  /v1/emails/{email_id}:
     get:
       tags:
         - emails
       summary: Get Email
-      operationId: get_email_emails__email_id__get
+      description:
+        "Fetch one email by id, including attachments and last event time.
+
+
+        Org-scoped: returns 404 for an email belonging to a different
+
+        organization. For an inbound email with a stored raw MIME, raw_url
+
+        points at GET /emails/{email_id}/raw."
+      operationId: get_email_v1_emails__email_id__get
       parameters:
         - name: email_id
           in: path
@@ -467,13 +685,34 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EmailResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /emails/{email_id}/raw:
+  /v1/emails/{email_id}/raw:
     get:
       tags:
         - emails
@@ -481,7 +720,7 @@ paths:
       description:
         "302 \u2192 presigned S3 URL for the raw inbound MIME (404 for\
         \ outbound)."
-      operationId: get_email_raw_emails__email_id__raw_get
+      operationId: get_email_raw_v1_emails__email_id__raw_get
       parameters:
         - name: email_id
           in: path
@@ -504,19 +743,40 @@ paths:
           content:
             application/json:
               schema: {}
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /emails/{email_id}/attachments/{attachment_id}:
+  /v1/emails/{email_id}/attachments/{attachment_id}:
     get:
       tags:
         - emails
       summary: Get Email Attachment
       description: "302 \u2192 presigned S3 URL for one attachment."
-      operationId: get_email_attachment_emails__email_id__attachments__attachment_id__get
+      operationId: get_email_attachment_v1_emails__email_id__attachments__attachment_id__get
       parameters:
         - name: email_id
           in: path
@@ -546,18 +806,45 @@ paths:
           content:
             application/json:
               schema: {}
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /events:
+  /v1/events:
     get:
       tags:
         - events
       summary: List Events
-      operationId: list_events_events_get
+      description:
+        "Cursor-paginated forward stream of call, email, and SMS events.\n\
+        \nScoped to the caller's organization. Pass id (typed \"<type>:<uuid>\",\n\
+        e.g. \"call:<uuid>\") to narrow to one resource's events, or kind to\nnarrow\
+        \ to one event kind. Walks forward in time \u2014 pass the returned\nnext_cursor\
+        \ to continue tailing where you left off."
+      operationId: list_events_v1_events_get
       parameters:
         - name: cursor
           in: query
@@ -607,18 +894,46 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EventStreamResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /email-domains:
+  /v1/email-domains:
     post:
       tags:
         - email-domains
       summary: Create Email Domain
-      operationId: create_email_domain_email_domains_post
+      description:
+        "Register a sender identity to send outbound email through.\n\n\
+        kind=\"hail_mail\" mints an address on the shared hail-mail domain and is\n\
+        immediately verified \u2014 no DNS work needed. kind=\"custom\" registers\
+        \ your\nown domain with SES and returns DKIM records; the domain stays\nunverified\
+        \ (POST /email-domains/{domain_id}/verify) until you publish\nthose DNS records\
+        \ and Hail confirms them."
+      operationId: create_email_domain_v1_email_domains_post
       parameters:
         - name: authorization
           in: header
@@ -641,6 +956,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EmailDomainResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
@@ -651,7 +987,12 @@ paths:
       tags:
         - email-domains
       summary: List Email Domains
-      operationId: list_email_domains_email_domains_get
+      description:
+        "List sender domains/identities for the caller's organization.\n\
+        \nCursor-paginated, newest first. The response also includes\ndefault_from\
+        \ \u2014 the address a from-less POST /emails would use right\nnow given the\
+        \ org's current verified senders."
+      operationId: list_email_domains_v1_email_domains_get
       parameters:
         - name: cursor
           in: query
@@ -685,19 +1026,40 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EmailDomainListResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /email-domains/check-domain:
+  /v1/email-domains/check-domain:
     get:
       tags:
         - email-domains
       summary: Check Domain
       description: Does this domain already receive mail? Drives apex-vs-prefix onboarding.
-      operationId: check_domain_email_domains_check_domain_get
+      operationId: check_domain_v1_email_domains_check_domain_get
       parameters:
         - name: domain
           in: query
@@ -720,18 +1082,48 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DomainCheckResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /email-domains/{domain_id}:
+  /v1/email-domains/{domain_id}:
     get:
       tags:
         - email-domains
       summary: Get Email Domain
-      operationId: get_email_domain_email_domains__domain_id__get
+      description:
+        "Fetch one sender domain/identity by id, including its DNS records.
+
+
+        Org-scoped: returns 404 for a domain belonging to a different
+
+        organization. For a pending custom domain, dns_records lists the DKIM
+
+        records still to publish."
+      operationId: get_email_domain_v1_email_domains__domain_id__get
       parameters:
         - name: domain_id
           in: path
@@ -755,6 +1147,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EmailDomainResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
@@ -772,7 +1185,7 @@ paths:
         \ writes here when\n  an org admin changes the visible hail-mail address.\n\
         * **Inbound action edit** (``inbound_enabled`` / ``forward_to`` /\n  ``forward_rate_per_hour``):\
         \ any row kind."
-      operationId: patch_email_domain_email_domains__domain_id__patch
+      operationId: patch_email_domain_v1_email_domains__domain_id__patch
       parameters:
         - name: domain_id
           in: path
@@ -802,6 +1215,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EmailDomainResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
@@ -812,7 +1246,13 @@ paths:
       tags:
         - email-domains
       summary: Delete Email Domain
-      operationId: delete_email_domain_email_domains__domain_id__delete
+      description:
+        "Permanently remove a sender domain/identity.\n\nIrreversible \u2014\
+        \ for a custom domain, also deletes the SES identity, so\nthe domain can no\
+        \ longer send until re-registered and re-verified.\nFails with 409 if any\
+        \ Email rows still reference this domain; delete\nor wait for those to age\
+        \ out first."
+      operationId: delete_email_domain_v1_email_domains__domain_id__delete
       parameters:
         - name: domain_id
           in: path
@@ -832,13 +1272,34 @@ paths:
       responses:
         "204":
           description: Successful Response
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /email-domains/{domain_id}/verify:
+  /v1/email-domains/{domain_id}/verify:
     post:
       tags:
         - email-domains
@@ -848,7 +1309,7 @@ paths:
         \nOn-demand only \u2014 there is no background poller in v1. Operators /\n\
         tenants hit this after publishing DNS to flip the row to ``verified``.\nHail-mail\
         \ rows are no-ops (they're already verified by construction)."
-      operationId: verify_email_domain_email_domains__domain_id__verify_post
+      operationId: verify_email_domain_v1_email_domains__domain_id__verify_post
       parameters:
         - name: domain_id
           in: path
@@ -872,18 +1333,45 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EmailDomainResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /numbers:
+  /v1/numbers:
     post:
       tags:
         - numbers
       summary: Acquire Number
-      operationId: acquire_number_numbers_post
+      description:
+        "Buy a dedicated phone number for the caller's organization.\n\n\
+        This purchases a real number at the carrier and starts a recurring\nmonthly\
+        \ fee immediately \u2014 it is not a reservation. The number is usable\nfor\
+        \ voice, SMS, or both depending on the requested capabilities and\nwhat the\
+        \ carrier offers for the given country_code/number_type."
+      operationId: acquire_number_v1_numbers_post
       parameters:
         - name: authorization
           in: header
@@ -914,6 +1402,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PhoneNumberResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
@@ -924,7 +1433,11 @@ paths:
       tags:
         - numbers
       summary: List Numbers
-      operationId: list_numbers_numbers_get
+      description:
+        "List dedicated numbers owned by the caller's organization.\n\n\
+        Cursor-paginated, newest first. Only org-owned numbers are listed \u2014\n\
+        shared pool numbers used for outbound calls never appear here."
+      operationId: list_numbers_v1_numbers_get
       parameters:
         - name: cursor
           in: query
@@ -958,13 +1471,34 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PhoneNumberListResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /numbers/{number_id}:
+  /v1/numbers/{number_id}:
     delete:
       tags:
         - numbers
@@ -976,7 +1510,7 @@ paths:
         release month; months already accrued stay owed (the rater bills late,
 
         never forgives)."
-      operationId: release_number_numbers__number_id__delete
+      operationId: release_number_v1_numbers__number_id__delete
       parameters:
         - name: number_id
           in: path
@@ -996,6 +1530,27 @@ paths:
       responses:
         "204":
           description: Successful Response
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
@@ -1006,7 +1561,15 @@ paths:
       tags:
         - numbers
       summary: Get Number
-      operationId: get_number_numbers__number_id__get
+      description:
+        "Fetch one dedicated number by id, including its capabilities and
+        state.
+
+
+        Org-scoped: returns 404 for a number belonging to a different
+
+        organization."
+      operationId: get_number_v1_numbers__number_id__get
       parameters:
         - name: number_id
           in: path
@@ -1030,18 +1593,45 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PhoneNumberResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /numbers/{number_id}/enable-sms:
+  /v1/numbers/{number_id}/enable-sms:
     post:
       tags:
         - numbers
       summary: Enable Sms
-      operationId: enable_sms_numbers__number_id__enable_sms_post
+      description:
+        "Attach a dedicated number to the org's shared SMS Messaging Service.\n\
+        \nRequired once per number before it can send/receive SMS; the number\nmust\
+        \ already have been acquired with sms capability. Idempotent \u2014\ncalling\
+        \ this again on an already-enabled number just returns its\ncurrent state.\
+        \ Fails with 422 for a released number or one that lacks\nsms capability."
+      operationId: enable_sms_v1_numbers__number_id__enable_sms_post
       parameters:
         - name: number_id
           in: path
@@ -1065,18 +1655,45 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PhoneNumberResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /webhooks:
+  /v1/webhooks:
     post:
       tags:
         - webhooks
       summary: Create Subscription
-      operationId: create_subscription_webhooks_post
+      description:
+        "Create a webhook subscription for one or more event types.\n\n\
+        The response includes the plaintext signing secret \u2014 this is the only\n\
+        time it is ever returned; store it now. Every later GET omits it. Use\nPOST\
+        \ /webhooks/{sub_id}/rotate-secret to get a new plaintext secret if\nit is\
+        \ lost or compromised."
+      operationId: create_subscription_v1_webhooks_post
       parameters:
         - name: authorization
           in: header
@@ -1099,6 +1716,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WebhookSubscriptionResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
@@ -1109,7 +1747,11 @@ paths:
       tags:
         - webhooks
       summary: List Subscriptions
-      operationId: list_subscriptions_webhooks_get
+      description:
+        "List webhook subscriptions for the caller's organization.\n\n\
+        Cursor-paginated, newest first. The signing secret is never included \u2014\
+        \nonly POST /webhooks and POST /webhooks/{sub_id}/rotate-secret return it."
+      operationId: list_subscriptions_v1_webhooks_get
       parameters:
         - name: cursor
           in: query
@@ -1143,18 +1785,40 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WebhookSubscriptionListResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /webhooks/{sub_id}:
+  /v1/webhooks/{sub_id}:
     get:
       tags:
         - webhooks
       summary: Get Subscription
-      operationId: get_subscription_webhooks__sub_id__get
+      description: Fetch one webhook subscription by id. The signing secret is omitted.
+      operationId: get_subscription_v1_webhooks__sub_id__get
       parameters:
         - name: sub_id
           in: path
@@ -1178,6 +1842,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WebhookSubscriptionResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
@@ -1188,7 +1873,19 @@ paths:
       tags:
         - webhooks
       summary: Patch Subscription
-      operationId: patch_subscription_webhooks__sub_id__patch
+      description:
+        'Update a webhook subscription''s target_url, event_types, and/or
+        status.
+
+
+        Only fields present in the request body are changed. Setting
+
+        status="active" resets the consecutive-failure counter, so a
+
+        subscription that was auto-disabled after 50 straight delivery
+
+        failures does not immediately re-disable itself.'
+      operationId: patch_subscription_v1_webhooks__sub_id__patch
       parameters:
         - name: sub_id
           in: path
@@ -1218,6 +1915,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WebhookSubscriptionResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
@@ -1228,7 +1946,11 @@ paths:
       tags:
         - webhooks
       summary: Delete Subscription
-      operationId: delete_subscription_webhooks__sub_id__delete
+      description:
+        "Permanently remove a webhook subscription.\n\nIrreversible \u2014\
+        \ no further events are delivered to it, and its\ndelivery history is deleted\
+        \ with it."
+      operationId: delete_subscription_v1_webhooks__sub_id__delete
       parameters:
         - name: sub_id
           in: path
@@ -1248,18 +1970,44 @@ paths:
       responses:
         "204":
           description: Successful Response
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /webhooks/{sub_id}/rotate-secret:
+  /v1/webhooks/{sub_id}/rotate-secret:
     post:
       tags:
         - webhooks
       summary: Rotate Secret
-      operationId: rotate_secret_webhooks__sub_id__rotate_secret_post
+      description:
+        "Generate a new signing secret and immediately invalidate the old\
+        \ one.\n\nThe response includes the new plaintext secret \u2014 this is the\
+        \ only\ntime it is returned; update your verification code with it right away,\n\
+        since the old secret stops validating new deliveries immediately."
+      operationId: rotate_secret_v1_webhooks__sub_id__rotate_secret_post
       parameters:
         - name: sub_id
           in: path
@@ -1283,18 +2031,44 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WebhookSubscriptionResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /webhooks/{sub_id}/deliveries:
+  /v1/webhooks/{sub_id}/deliveries:
     get:
       tags:
         - webhooks
       summary: List Deliveries
-      operationId: list_deliveries_webhooks__sub_id__deliveries_get
+      description:
+        "List delivery attempts for one webhook subscription, newest first.\n\
+        \nCursor-paginated. Each entry shows the attempt count, response status,\n\
+        and response body Hail recorded \u2014 use POST /webhooks/{sub_id}/\ndeliveries/{delivery_id}/redeliver\
+        \ to retry a failed one."
+      operationId: list_deliveries_v1_webhooks__sub_id__deliveries_get
       parameters:
         - name: sub_id
           in: path
@@ -1335,18 +2109,44 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WebhookDeliveryListResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /webhooks/{sub_id}/deliveries/{delivery_id}/redeliver:
+  /v1/webhooks/{sub_id}/deliveries/{delivery_id}/redeliver:
     post:
       tags:
         - webhooks
       summary: Redeliver
-      operationId: redeliver_webhooks__sub_id__deliveries__delivery_id__redeliver_post
+      description:
+        "Retry one webhook delivery attempt.\n\nResets it to pending with\
+        \ a fresh attempt counter \u2014 the delivery\nworker picks it up and re-sends\
+        \ the same event payload to target_url\nshortly after. Useful after fixing\
+        \ an endpoint that was returning\nerrors."
+      operationId: redeliver_v1_webhooks__sub_id__deliveries__delivery_id__redeliver_post
       parameters:
         - name: sub_id
           in: path
@@ -1377,18 +2177,46 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WebhookDeliveryResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /unsubscribe:
+  /v1/unsubscribe:
     get:
       tags:
         - unsubscribe
       summary: Unsubscribe
-      operationId: unsubscribe_unsubscribe_get
+      description:
+        "One-click email opt-out (RFC 8058), reached by clicking a link\
+        \ in a sent email.\n\nPublic and unauthenticated \u2014 the signed token query\
+        \ param is the sole\ncredential, proving the caller holds a link Hail sent\
+        \ to that address.\nOn success, the address is added to the org's suppression\
+        \ list and all\nfuture outbound email to it is blocked. Returns an HTML page,\
+        \ not JSON."
+      operationId: unsubscribe_v1_unsubscribe_get
       parameters:
         - name: token
           in: query
@@ -1403,18 +2231,48 @@ paths:
             text/html:
               schema:
                 type: string
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /sms:
+  /v1/sms:
     post:
       tags:
         - sms
       summary: Create Sms
-      operationId: create_sms_sms_post
+      description:
+        "Send an outbound SMS.\n\nSends synchronously \u2014 the response\
+        \ reports the final status (sent or\nfailed), not a queued placeholder, though\
+        \ delivery confirmation from\nthe carrier can still arrive later as a webhook\
+        \ or GET /sms/{sms_id}\nupdate. An explicit from resolves a dedicated number;\
+        \ otherwise Hail\npicks an alphanumeric sender ID where the destination corridor\
+        \ allows\nit, or requires a dedicated SMS-capable number otherwise. Requires\n\
+        recipient_consent=true on the request body; Hail does not verify\nlawful basis\
+        \ to contact the recipient, the caller warrants it."
+      operationId: create_sms_v1_sms_post
       parameters:
         - name: authorization
           in: header
@@ -1449,10 +2307,23 @@ paths:
           description:
             Rate limited. The agent-origin workspace exceeded a per-channel
             velocity cap, or the platform kill switch is on. Retry after the Retry-After
-            header (seconds).
+            header (seconds). Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
           headers:
             Retry-After:
               description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
               schema:
                 type: integer
         "422":
@@ -1465,7 +2336,16 @@ paths:
       tags:
         - sms
       summary: List Sms
-      operationId: list_sms_sms_get
+      description:
+        "List SMS messages for the caller's organization, newest first.
+
+
+        Cursor-paginated: pass the returned next_cursor to fetch the next page;
+
+        a null next_cursor means there are no more results. Filter by status or
+
+        destination number (to) to narrow the list."
+      operationId: list_sms_v1_sms_get
       parameters:
         - name: cursor
           in: query
@@ -1522,18 +2402,46 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SmsListResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /sms/suppressions:
+  /v1/sms/suppressions:
     get:
       tags:
         - sms
       summary: List Sms Suppressions
-      operationId: list_sms_suppressions_sms_suppressions_get
+      description:
+        "List SMS numbers suppressed from receiving messages, newest first.
+
+
+        Cursor-paginated. A suppressed number blocks POST /sms sends to it
+
+        with a 403 until removed via DELETE /sms/suppressions/{number}."
+      operationId: list_sms_suppressions_v1_sms_suppressions_get
       parameters:
         - name: cursor
           in: query
@@ -1567,18 +2475,44 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SuppressionListResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /sms/suppressions/{number}:
+  /v1/sms/suppressions/{number}:
     delete:
       tags:
         - sms
       summary: Delete Sms Suppression
-      operationId: delete_sms_suppression_sms_suppressions__number__delete
+      description:
+        "Remove one number from the SMS suppression list, re-allowing sends\
+        \ to it.\n\nDoes not itself constitute renewed consent \u2014 the caller is\
+        \ responsible\nfor having a lawful basis (e.g. a fresh opt-in) before sending\
+        \ again.\nReturns 404 if the number was not suppressed."
+      operationId: delete_sms_suppression_v1_sms_suppressions__number__delete
       parameters:
         - name: number
           in: path
@@ -1597,18 +2531,46 @@ paths:
       responses:
         "204":
           description: Successful Response
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /sms/sender-id:
+  /v1/sms/sender-id:
     get:
       tags:
         - sms
       summary: Get Sender Id
-      operationId: get_sender_id_sms_sender_id_get
+      description:
+        "Get the org's custom alphanumeric SMS sender ID, if any is set.
+
+
+        effective_default is the platform sender id used for
+
+        alphanumeric-eligible corridors when custom_sender_id is null."
+      operationId: get_sender_id_v1_sms_sender_id_get
       parameters:
         - name: authorization
           in: header
@@ -1625,6 +2587,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SenderIdResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
@@ -1635,7 +2618,12 @@ paths:
       tags:
         - sms
       summary: Patch Sender Id
-      operationId: patch_sender_id_sms_sender_id_patch
+      description:
+        "Set or clear the org's custom alphanumeric SMS sender ID.\n\n\
+        Pass custom_sender_id=null to clear it and fall back to the platform\ndefault\
+        \ sender id. Only affects alphanumeric-eligible corridors \u2014 a\ncorridor\
+        \ requiring a dedicated number is unaffected."
+      operationId: patch_sender_id_v1_sms_sender_id_patch
       parameters:
         - name: authorization
           in: header
@@ -1658,18 +2646,45 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SenderIdResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /sms/{sms_id}:
+  /v1/sms/{sms_id}:
     get:
       tags:
         - sms
       summary: Get Sms
-      operationId: get_sms_sms__sms_id__get
+      description: "Fetch one SMS by id, including its current status.
+
+
+        Org-scoped: returns 404 for an SMS belonging to a different
+
+        organization."
+      operationId: get_sms_v1_sms__sms_id__get
       parameters:
         - name: sms_id
           in: path
@@ -1693,18 +2708,45 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SmsResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /contacts:
+  /v1/contacts:
     get:
       tags:
         - contacts
       summary: List Contacts
-      operationId: list_contacts_contacts_get
+      description:
+        "List contacts for the caller's organization, newest first.\n\n\
+        Merges two sources into one list: org members (kind=\"member\", ids\nprefixed\
+        \ \"member:\", managed via membership \u2014 not editable here) and\nmanually-created\
+        \ contacts (kind=\"manual\", editable via PATCH/DELETE\n/contacts/{contact_id}).\
+        \ Cursor-paginated; q does a substring search\nover name/phone/email."
+      operationId: list_contacts_v1_contacts_get
       parameters:
         - name: q
           in: query
@@ -1746,6 +2788,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ContactListResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
@@ -1756,7 +2819,15 @@ paths:
       tags:
         - contacts
       summary: Create Contact
-      operationId: create_contact_contacts_post
+      description: "Create a manual contact with a phone and/or an email.
+
+
+        Requires at least one of phone_e164 or email. Fails with 409 if a
+
+        contact with the same phone or email already exists in this
+
+        organization."
+      operationId: create_contact_v1_contacts_post
       parameters:
         - name: authorization
           in: header
@@ -1779,18 +2850,45 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ContactEntry"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /contacts/{contact_id}:
+  /v1/contacts/{contact_id}:
     patch:
       tags:
         - contacts
       summary: Patch Contact
-      operationId: patch_contact_contacts__contact_id__patch
+      description:
+        "Update a manual contact's fields. Only fields present in the body\
+        \ change.\n\nManual contacts only \u2014 a member: id (org members synced\
+        \ from\nmembership) returns 422; edit those via the membership APIs instead.\n\
+        The contact must still have at least one of phone_e164 or email after\nthe\
+        \ update. Fails with 409 on a duplicate phone/email."
+      operationId: patch_contact_v1_contacts__contact_id__patch
       parameters:
         - name: contact_id
           in: path
@@ -1819,6 +2917,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ContactEntry"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
@@ -1829,7 +2948,11 @@ paths:
       tags:
         - contacts
       summary: Delete Contact
-      operationId: delete_contact_contacts__contact_id__delete
+      description:
+        "Permanently remove a manual contact.\n\nManual contacts only \u2014\
+        \ a member: id returns 422; org members are\nremoved via the membership APIs,\
+        \ not this route. Irreversible."
+      operationId: delete_contact_v1_contacts__contact_id__delete
       parameters:
         - name: contact_id
           in: path
@@ -1848,18 +2971,44 @@ paths:
       responses:
         "204":
           description: Successful Response
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /members/{user_id}/phone:
+  /v1/members/{user_id}/phone:
     put:
       tags:
         - contacts
       summary: Put Member Phone
-      operationId: put_member_phone_members__user_id__phone_put
+      description:
+        "Set an org member's phone number.\n\nPass user_id=\"me\" to set\
+        \ your own, or a member's user id \u2014 setting\nanother member's phone requires\
+        \ the caller to be an org owner or\nadmin. Returns 404 if the target is not\
+        \ a member of this organization."
+      operationId: put_member_phone_v1_members__user_id__phone_put
       parameters:
         - name: user_id
           in: path
@@ -1890,7 +3039,28 @@ paths:
                 type: object
                 additionalProperties:
                   type: string
-                title: Response Put Member Phone Members  User Id  Phone Put
+                title: Response Put Member Phone V1 Members  User Id  Phone Put
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
@@ -1901,7 +3071,12 @@ paths:
       tags:
         - contacts
       summary: Delete Member Phone
-      operationId: delete_member_phone_members__user_id__phone_delete
+      description:
+        "Clear an org member's phone number.\n\nPass user_id=\"me\" to\
+        \ clear your own, or a member's user id \u2014 clearing\nanother member's\
+        \ phone requires the caller to be an org owner or\nadmin. Returns 404 if the\
+        \ target is not a member of this organization."
+      operationId: delete_member_phone_v1_members__user_id__phone_delete
       parameters:
         - name: user_id
           in: path
@@ -1920,18 +3095,51 @@ paths:
       responses:
         "204":
           description: Successful Response
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /whoami:
+  /v1/whoami:
     get:
       tags:
         - whoami
       summary: Get Whoami
-      operationId: get_whoami_whoami_get
+      description:
+        "Identify the caller: auth kind, organization, and (if resolvable)
+        user.
+
+
+        Useful for an agent that needs the human's address to put in
+
+        Reply-To, since the bearer token itself only carries an organization.
+
+        user_id/email/name come back null for a shared-key
+
+        (HAIL_API_KEY) call, which has no individual user behind it."
+      operationId: get_whoami_v1_whoami_get
       parameters:
         - name: authorization
           in: header
@@ -1948,13 +3156,34 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WhoamiResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /providers:
+  /v1/providers:
     get:
       tags:
         - providers
@@ -1977,13 +3206,34 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ProviderConfigListResponse"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /providers/{layer}:
+  /v1/providers/{layer}:
     put:
       tags:
         - providers
@@ -2024,13 +3274,34 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ProviderConfigEntry"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /providers/{layer}/{provider}:
+  /v1/providers/{layer}/{provider}:
     delete:
       tags:
         - providers
@@ -2066,13 +3337,34 @@ paths:
       responses:
         "204":
           description: Successful Response
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /providers/{layer}/activate:
+  /v1/providers/{layer}/activate:
     post:
       tags:
         - providers
@@ -2111,13 +3403,34 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ProviderConfigEntry"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  /providers/{layer}/validate:
+  /v1/providers/{layer}/validate:
     post:
       tags:
         - providers
@@ -2159,6 +3472,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ProviderValidateResult"
+        "429":
+          description:
+            Rate limited. This caller exceeded the general request-rate
+            ceiling. Retry after the Retry-After header (seconds).
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+            RateLimit-Limit:
+              description: The request ceiling for the current window.
+              schema:
+                type: integer
+            RateLimit-Remaining:
+              description: Requests remaining in the current window.
+              schema:
+                type: integer
+            RateLimit-Reset:
+              description: Seconds until the current window resets.
+              schema:
+                type: integer
         "422":
           description: Validation Error
           content:
@@ -2168,6 +3502,7 @@ paths:
   /healthz:
     get:
       summary: Healthz
+      description: 'Liveness check. Returns {"status": "ok"} with no auth required.'
       operationId: healthz_healthz_get
       responses:
         "200":
@@ -2187,6 +3522,9 @@ components:
           type: string
           contentMediaType: application/octet-stream
           title: File
+          description:
+            The file to upload, as multipart/form-data. Size-limited; an
+            oversize upload is rejected with 422.
       type: object
       required:
         - file
@@ -2229,25 +3567,42 @@ components:
         to:
           type: string
           title: To
+          description: Recipient phone number, E.164 format (e.g. +14155551234).
         from:
           anyOf:
             - type: string
             - type: "null"
           title: From
+          description:
+            "Caller-id phone number, E.164 format. Must be a number owned
+            by the organization with the voice capability. Omitted: an active org-owned
+            number is used if one exists, else a number is claimed from the shared
+            pool."
         system_prompt:
           anyOf:
             - type: string
             - type: "null"
           title: System Prompt
+          description:
+            Task instructions for the agent, sent as its leading system
+            message. At least one of system_prompt or llm is required; both together
+            is also valid.
         llm:
           anyOf:
             - $ref: "#/components/schemas/LLMConfig"
             - type: "null"
+          description:
+            BYO LLM endpoint the call runs on instead of Hail's default
+            model. At least one of system_prompt or llm is required; both together
+            is also valid.
         first_message:
           anyOf:
             - type: string
             - type: "null"
           title: First Message
+          description:
+            "Opening line the agent speaks first. Omitted: the agent waits
+            for the callee to speak first."
         ai_disclosure:
           type: boolean
           title: Ai Disclosure
@@ -2262,16 +3617,25 @@ components:
           default: true
         voice_config:
           $ref: "#/components/schemas/VoiceConfig"
+          description:
+            TTS voice, VAD, turn-detection, and spoken-language settings
+            for this call.
         conversation_id:
           anyOf:
             - type: string
               format: uuid
             - type: "null"
           title: Conversation Id
+          description:
+            "Groups this call with other calls/emails/SMS into one conversation
+            thread. Omitted: the call is not linked to a conversation."
         metadata:
           additionalProperties: true
           type: object
           title: Metadata
+          description:
+            Free-form JSON object attached to the call and echoed back
+            on reads. Not interpreted by Hail.
         tools:
           anyOf:
             - items:
@@ -2296,11 +3660,15 @@ components:
             $ref: "#/components/schemas/CallResponse"
           type: array
           title: Items
+          description: Calls in this page, newest first.
         next_cursor:
           anyOf:
             - type: string
             - type: "null"
           title: Next Cursor
+          description:
+            Opaque cursor for the next page. Null when there are no more
+            results.
       type: object
       required:
         - items
@@ -2311,28 +3679,37 @@ components:
           type: string
           format: uuid
           title: Id
+          description: Unique identifier for this call.
         organization_id:
           type: string
           format: uuid
           title: Organization Id
+          description: Organization that placed or received this call.
         conversation_id:
           anyOf:
             - type: string
               format: uuid
             - type: "null"
           title: Conversation Id
+          description:
+            Conversation thread this call is grouped into, if any. Null
+            when the call was not linked to a conversation.
         from_e164:
           type: string
           title: From E164
+          description: Caller-id phone number used, E.164 format.
         to_e164:
           type: string
           title: To E164
+          description: Recipient phone number, E.164 format.
         direction:
           type: string
           enum:
             - outbound
             - inbound
           title: Direction
+          description: "'outbound' for calls Hail placed, 'inbound' for calls
+            received."
         status:
           type: string
           enum:
@@ -2346,53 +3723,79 @@ components:
             - no_answer
             - canceled
           title: Status
+          description:
+            "Current call-progress state: 'queued', 'dialing', 'ringing',
+            'in_progress', or one of the terminal states 'completed', 'failed',
+            'busy', 'no_answer', 'canceled'."
         end_reason:
           anyOf:
             - type: string
             - type: "null"
           title: End Reason
+          description:
+            Machine-readable reason the call reached a terminal status
+            (e.g. 'normal_hangup', 'user_rejected', 'sip_trunk_failure'). Null while
+            the call is still in progress.
         provider_call_sid:
           anyOf:
             - type: string
             - type: "null"
           title: Provider Call Sid
+          description: The telephony provider's identifier for this call leg, if assigned.
         livekit_room:
           anyOf:
             - type: string
             - type: "null"
           title: Livekit Room
+          description:
+            Name of the LiveKit room hosting this call's media session,
+            if one was created.
         initial_prompt:
           anyOf:
             - type: string
             - type: "null"
           title: Initial Prompt
+          description: The system_prompt this call was created with, if any.
         recording_s3_key:
           anyOf:
             - type: string
             - type: "null"
           title: Recording S3 Key
+          description:
+            Internal storage key for the call recording. Not a directly
+            fetchable URL.
         requested_at:
           type: string
           format: date-time
           title: Requested At
+          description: When the call was requested, ISO 8601 timestamp.
         started_at:
           anyOf:
             - type: string
               format: date-time
             - type: "null"
           title: Started At
+          description:
+            When dialing began, ISO 8601 timestamp. Null until the call
+            starts.
         answered_at:
           anyOf:
             - type: string
               format: date-time
             - type: "null"
           title: Answered At
+          description:
+            When the callee answered, ISO 8601 timestamp. Null if never
+            answered.
         ended_at:
           anyOf:
             - type: string
               format: date-time
             - type: "null"
           title: Ended At
+          description:
+            When the call ended, ISO 8601 timestamp. Null while still in
+            progress.
       type: object
       required:
         - id
@@ -2419,16 +3822,23 @@ components:
           maxLength: 200
           minLength: 1
           title: Name
+          description: Display name for the contact.
         phone_e164:
           anyOf:
             - type: string
             - type: "null"
           title: Phone E164
+          description:
+            Phone number, E.164 format. At least one of phone_e164 or email
+            is required.
         email:
           anyOf:
             - type: string
             - type: "null"
           title: Email
+          description:
+            Email address, stored lowercased. At least one of phone_e164
+            or email is required.
       additionalProperties: false
       type: object
       required:
@@ -2439,30 +3849,42 @@ components:
         id:
           type: string
           title: Id
+          description:
+            "'member:<user_id>' for an org member, or the contact row's
+            UUID (as a string) for a manual contact."
         kind:
           type: string
           enum:
             - member
             - manual
           title: Kind
+          description:
+            "'member' if this row is a member of the organization, 'manual'
+            if it was added as a contact."
         name:
           type: string
           title: Name
+          description: Display name.
         phone_e164:
           anyOf:
             - type: string
             - type: "null"
           title: Phone E164
+          description: Phone number, E.164 format. Null if none on file.
         email:
           anyOf:
             - type: string
             - type: "null"
           title: Email
+          description: Email address. Null if none on file.
         role:
           anyOf:
             - type: string
             - type: "null"
           title: Role
+          description:
+            Organization role (e.g. 'owner', 'admin', 'member') for kind='member'.
+            Always null for kind='manual'.
       type: object
       required:
         - id
@@ -2480,11 +3902,15 @@ components:
             $ref: "#/components/schemas/ContactEntry"
           type: array
           title: Items
+          description: Contacts in this page.
         next_cursor:
           anyOf:
             - type: string
             - type: "null"
           title: Next Cursor
+          description:
+            Opaque cursor for the next page. Null when there are no more
+            results.
       type: object
       required:
         - items
@@ -2498,16 +3924,26 @@ components:
               minLength: 1
             - type: "null"
           title: Name
+          description:
+            New display name. Omit to leave unchanged; cannot be set to
+            null.
         phone_e164:
           anyOf:
             - type: string
             - type: "null"
           title: Phone E164
+          description:
+            New phone number, E.164 format. Omit to leave unchanged; explicit
+            null clears it. The contact must keep at least one of phone_e164 or email.
         email:
           anyOf:
             - type: string
             - type: "null"
           title: Email
+          description:
+            New email address, stored lowercased. Omit to leave unchanged;
+            explicit null clears it. The contact must keep at least one of phone_e164
+            or email.
       additionalProperties: false
       type: object
       title: ContactPatch
@@ -2516,9 +3952,11 @@ components:
         name:
           type: string
           title: Name
+          description: DNS record name/host to publish (e.g. a CNAME's subdomain).
         value:
           type: string
           title: Value
+          description: DNS record value to publish (e.g. a CNAME target or TXT content).
         type:
           type: string
           enum:
@@ -2526,12 +3964,15 @@ components:
             - MX
             - TXT
           title: Type
+          description: "DNS record type: 'CNAME' (DKIM), 'MX' (MAIL FROM), or
+            'TXT' (SPF)."
           default: CNAME
         priority:
           anyOf:
             - type: integer
             - type: "null"
           title: Priority
+          description: MX priority. Only present for type='MX'; null otherwise.
       additionalProperties: true
       type: object
       required:
@@ -2547,17 +3988,28 @@ components:
         domain:
           type: string
           title: Domain
+          description: The apex domain that was checked, lowercased.
         in_use:
           type: boolean
           title: In Use
+          description:
+            "True if the domain already has MX records \u2014 it receives\
+            \ mail elsewhere."
         existing_mx:
           items:
             type: string
           type: array
           title: Existing Mx
+          description:
+            MX hostnames currently published for the domain. Empty when
+            in_use is false.
         suggested_domain:
           type: string
           title: Suggested Domain
+          description:
+            "Domain to use for a custom sending identity: the apex domain
+            if it is not already receiving mail, or an 'inbox.' subdomain if it
+            is (so setup doesn't collide with existing mail)."
       type: object
       required:
         - domain
@@ -2571,23 +4023,33 @@ components:
           type: string
           format: uuid
           title: Id
+          description: Unique identifier for this attachment.
         filename:
           type: string
           title: Filename
+          description: Original filename of the attachment.
         content_type:
           type: string
           title: Content Type
+          description: MIME type of the attachment.
         size_bytes:
           type: integer
           title: Size Bytes
+          description: Size of the attachment in bytes.
         content_id:
           anyOf:
             - type: string
             - type: "null"
           title: Content Id
+          description:
+            MIME Content-ID, present when this attachment is referenced
+            inline (cid:) from the HTML body. Null otherwise.
         url:
           type: string
           title: Url
+          description:
+            API endpoint that 302-redirects to a presigned download URL
+            for this attachment.
       type: object
       required:
         - id
@@ -2606,15 +4068,21 @@ components:
           type: string
           format: uuid
           title: Id
+          description:
+            "Reusable attachment id \u2014 pass it in EmailCreate.attachment_ids\
+            \ to attach it to a send."
         filename:
           type: string
           title: Filename
+          description: Original filename of the uploaded file.
         content_type:
           type: string
           title: Content Type
+          description: MIME type of the uploaded file.
         size_bytes:
           type: integer
           title: Size Bytes
+          description: Size of the uploaded file in bytes.
       type: object
       required:
         - id
@@ -2670,18 +4138,25 @@ components:
             - type: string
             - type: "null"
           title: From
+          description:
+            "Sender email address. Must be a verified identity on the organization's
+            email domains. Omitted: the org's resolved default sending address, if
+            one exists."
         from_name:
           anyOf:
             - type: string
               maxLength: 256
             - type: "null"
           title: From Name
+          description: "Display name for the From: header (e.g. 'Acme Billing').
+            Omitted: no display name."
         to:
           items:
             type: string
           type: array
           minItems: 1
           title: To
+          description: Recipient email addresses. At least one required.
         cc:
           anyOf:
             - items:
@@ -2689,6 +4164,7 @@ components:
               type: array
             - type: "null"
           title: Cc
+          description: CC recipient email addresses.
         bcc:
           anyOf:
             - items:
@@ -2696,36 +4172,49 @@ components:
               type: array
             - type: "null"
           title: Bcc
+          description: BCC recipient email addresses.
         reply_to:
           anyOf:
             - type: string
             - type: "null"
           title: Reply To
+          description: "Reply-To email address. Omitted: replies go to the From address."
         subject:
           type: string
           maxLength: 998
           minLength: 1
           title: Subject
+          description: Email subject line.
         body_text:
           anyOf:
             - type: string
             - type: "null"
           title: Body Text
+          description:
+            Plain-text body. Either body_text or body_html (or both) is
+            required.
         body_html:
           anyOf:
             - type: string
             - type: "null"
           title: Body Html
+          description: HTML body. Either body_text or body_html (or both) is required.
         conversation_id:
           anyOf:
             - type: string
               format: uuid
             - type: "null"
           title: Conversation Id
+          description:
+            "Groups this email with other calls/emails/SMS into one conversation
+            thread. Omitted: the email is not linked to a conversation."
         metadata:
           additionalProperties: true
           type: object
           title: Metadata
+          description:
+            Free-form JSON object attached to the email and echoed back
+            on reads. Not interpreted by Hail.
         attachment_ids:
           anyOf:
             - items:
@@ -2734,6 +4223,9 @@ components:
               type: array
             - type: "null"
           title: Attachment Ids
+          description:
+            "Ids returned by POST /email-attachments to attach to this
+            send. Omitted: no attachments."
       additionalProperties: false
       type: object
       required:
@@ -2749,21 +4241,36 @@ components:
             - hail_mail
             - custom
           title: Kind
+          description:
+            "'hail_mail' for a Hail-hosted address (domain omitted, composed
+            from the prefix fields), or 'custom' to send from your own domain (domain
+            required, prefix fields omitted)."
         domain:
           anyOf:
             - type: string
             - type: "null"
           title: Domain
+          description:
+            DNS domain to send from (e.g. 'acme.com'). Required for kind='custom';
+            must be omitted for kind='hail_mail'.
         local_prefix_user:
           anyOf:
             - type: string
             - type: "null"
           title: Local Prefix User
+          description:
+            User-chosen local-part prefix for a hail_mail address. Only
+            valid for kind='hail_mail'. Falls back to HAIL_MAIL_DEFAULT_USER_PREFIX
+            if omitted.
         local_prefix_org:
           anyOf:
             - type: string
             - type: "null"
           title: Local Prefix Org
+          description:
+            Org-chosen local-part prefix for a hail_mail address. Only
+            valid for kind='hail_mail'. Falls back to HAIL_MAIL_DEFAULT_ORG_PREFIX
+            if omitted.
       additionalProperties: false
       type: object
       required:
@@ -2790,16 +4297,25 @@ components:
             $ref: "#/components/schemas/EmailDomainResponse"
           type: array
           title: Items
+          description: Email domains in this page.
         next_cursor:
           anyOf:
             - type: string
             - type: "null"
           title: Next Cursor
+          description:
+            Opaque cursor for the next page. Null when there are no more
+            results.
         default_from:
           anyOf:
             - type: string
             - type: "null"
           title: Default From
+          description:
+            The From address used when a send omits 'from'. Null when no
+            such default can be resolved (e.g. multiple verified identities, or none
+            that can send yet). Computed across the whole organization, not just this
+            page.
       type: object
       required:
         - items
@@ -2811,16 +4327,25 @@ components:
             - type: string
             - type: "null"
           title: Local Prefix User
+          description:
+            New user local-part prefix. Only valid on kind='hail_mail'
+            rows. Omit to leave unchanged.
         local_prefix_org:
           anyOf:
             - type: string
             - type: "null"
           title: Local Prefix Org
+          description:
+            New org local-part prefix. Only valid on kind='hail_mail' rows.
+            Omit to leave unchanged.
         inbound_enabled:
           anyOf:
             - type: boolean
             - type: "null"
           title: Inbound Enabled
+          description:
+            Whether to accept inbound mail on this domain. Requires forward_to
+            (or an existing one) when true. Omit to leave unchanged.
         forward_to:
           anyOf:
             - items:
@@ -2828,11 +4353,13 @@ components:
               type: array
             - type: "null"
           title: Forward To
+          description: Email addresses to forward inbound mail to. Omit to leave unchanged.
         forward_rate_per_hour:
           anyOf:
             - type: integer
             - type: "null"
           title: Forward Rate Per Hour
+          description: Cap on forwarded messages per hour. Omit to leave unchanged.
       additionalProperties: false
       type: object
       title: EmailDomainPatch
@@ -2855,29 +4382,36 @@ components:
           type: string
           format: uuid
           title: Id
+          description: Unique identifier for this email domain.
         organization_id:
           type: string
           format: uuid
           title: Organization Id
+          description: Organization that owns this domain.
         kind:
           type: string
           enum:
             - hail_mail
             - custom
           title: Kind
+          description: "'hail_mail' (Hail-hosted address) or 'custom' (your own
+            domain)."
         domain:
           type: string
           title: Domain
+          description: The DNS domain mail is sent from.
         local_prefix_user:
           anyOf:
             - type: string
             - type: "null"
           title: Local Prefix User
+          description: User local-part prefix for a hail_mail address. Null for kind='custom'.
         local_prefix_org:
           anyOf:
             - type: string
             - type: "null"
           title: Local Prefix Org
+          description: Org local-part prefix for a hail_mail address. Null for kind='custom'.
         verification_status:
           type: string
           enum:
@@ -2885,33 +4419,50 @@ components:
             - verified
             - failed
           title: Verification Status
+          description:
+            "'pending' (not yet verified), 'verified' (ready to send),
+            or 'failed'."
         dns_records:
           items:
             $ref: "#/components/schemas/DnsRecordSchema"
           type: array
           title: Dns Records
+          description:
+            DNS records (DKIM, MAIL FROM MX, SPF) the tenant must publish
+            to verify this domain.
         mail_from_domain:
           anyOf:
             - type: string
             - type: "null"
           title: Mail From Domain
+          description:
+            Custom MAIL FROM domain, if configured. Null when using the
+            provider default.
         mail_from_status:
           anyOf:
             - type: string
             - type: "null"
           title: Mail From Status
+          description:
+            Verification status of the custom MAIL FROM domain, if one
+            is configured. Secondary to verification_status.
         provider:
           type: string
           title: Provider
+          description: Email sending provider for this domain (currently always 'ses').
         verified_at:
           anyOf:
             - type: string
               format: date-time
             - type: "null"
           title: Verified At
+          description:
+            When the domain became verified, ISO 8601 timestamp. Null until
+            it is.
         inbound_enabled:
           type: boolean
           title: Inbound Enabled
+          description: Whether this domain accepts and forwards inbound mail.
           default: false
         forward_to:
           anyOf:
@@ -2920,24 +4471,34 @@ components:
               type: array
             - type: "null"
           title: Forward To
+          description:
+            Email addresses inbound mail is forwarded to, if inbound is
+            enabled.
         forward_rate_per_hour:
           anyOf:
             - type: integer
             - type: "null"
           title: Forward Rate Per Hour
+          description: Configured cap on forwarded messages per hour, if set.
         created_at:
           type: string
           format: date-time
           title: Created At
+          description: When this domain was added, ISO 8601 timestamp.
         updated_at:
           type: string
           format: date-time
           title: Updated At
+          description: When this domain was last modified, ISO 8601 timestamp.
         receive_ready:
           anyOf:
             - type: boolean
             - type: "null"
           title: Receive Ready
+          description:
+            True when the domain's published MX points at Hail's inbound
+            host. Only populated by POST /{id}/verify on custom domains; null everywhere
+            else.
       type: object
       required:
         - id
@@ -2969,11 +4530,15 @@ components:
             $ref: "#/components/schemas/EmailEventResponse"
           type: array
           title: Items
+          description: Events for this email, oldest first.
         next_cursor:
           anyOf:
             - type: string
             - type: "null"
           title: Next Cursor
+          description:
+            Opaque cursor for the next page. Null when there are no more
+            results.
       type: object
       required:
         - items
@@ -2984,10 +4549,12 @@ components:
           type: string
           format: uuid
           title: Id
+          description: Unique identifier for this event.
         email_id:
           type: string
           format: uuid
           title: Email Id
+          description: The email this event belongs to.
         kind:
           type: string
           enum:
@@ -3000,14 +4567,18 @@ components:
             - opened
             - clicked
           title: Kind
+          description: "Event kind: 'sent', 'delivered', 'delivery_delayed',
+            'bounced', 'complained', 'rejected', 'opened', or 'clicked'."
         payload:
           additionalProperties: true
           type: object
           title: Payload
+          description: Event-kind-specific detail, as a free-form JSON object.
         occurred_at:
           type: string
           format: date-time
           title: Occurred At
+          description: When this event occurred, ISO 8601 timestamp.
       type: object
       required:
         - id
@@ -3023,11 +4594,15 @@ components:
             $ref: "#/components/schemas/EmailSummary"
           type: array
           title: Items
+          description: Emails in this page, newest first.
         next_cursor:
           anyOf:
             - type: string
             - type: "null"
           title: Next Cursor
+          description:
+            Opaque cursor for the next page. Null when there are no more
+            results.
       type: object
       required:
         - items
@@ -3038,42 +4613,57 @@ components:
           type: string
           format: uuid
           title: Id
+          description: Unique identifier for this email.
         organization_id:
           type: string
           format: uuid
           title: Organization Id
+          description: Organization that sent or received this email.
         conversation_id:
           anyOf:
             - type: string
               format: uuid
             - type: "null"
           title: Conversation Id
+          description:
+            Conversation thread this email is grouped into, if any. Null
+            when it was not linked to a conversation.
         email_domain_id:
           anyOf:
             - type: string
               format: uuid
             - type: "null"
           title: Email Domain Id
+          description:
+            The sending domain used, if from_address belongs to one of
+            the org's configured domains.
         direction:
           type: string
           enum:
             - outbound
             - inbound
           title: Direction
+          description: "'outbound' for emails Hail sent, 'inbound' for emails
+            received."
           default: outbound
         from_address:
           type: string
           title: From Address
+          description: Sender email address.
         from_name:
           anyOf:
             - type: string
             - type: "null"
           title: From Name
+          description:
+            "Display name used on the From: header, when the sender supplied
+            one. Always null on inbound rows."
         to_addresses:
           items:
             type: string
           type: array
           title: To Addresses
+          description: Recipient email addresses.
         cc_addresses:
           anyOf:
             - items:
@@ -3081,6 +4671,7 @@ components:
               type: array
             - type: "null"
           title: Cc Addresses
+          description: CC recipient email addresses, if any.
         bcc_addresses:
           anyOf:
             - items:
@@ -3088,14 +4679,17 @@ components:
               type: array
             - type: "null"
           title: Bcc Addresses
+          description: BCC recipient email addresses, if any.
         reply_to:
           anyOf:
             - type: string
             - type: "null"
           title: Reply To
+          description: Reply-To email address, if set.
         subject:
           type: string
           title: Subject
+          description: Email subject line.
         status:
           type: string
           enum:
@@ -3107,56 +4701,79 @@ components:
             - complained
             - received
           title: Status
+          description:
+            "Delivery status: 'queued', 'sent', 'delivered', 'failed',
+            'bounced', 'complained', or 'received' (inbound emails)."
         end_reason:
           anyOf:
             - type: string
             - type: "null"
           title: End Reason
+          description:
+            Reason delivery failed or bounced, if applicable. Null on success
+            or while pending.
         provider_message_id:
           anyOf:
             - type: string
             - type: "null"
           title: Provider Message Id
+          description: The email provider's identifier for this message, if assigned.
         requested_at:
           type: string
           format: date-time
           title: Requested At
+          description: When the send was requested, ISO 8601 timestamp.
         sent_at:
           anyOf:
             - type: string
               format: date-time
             - type: "null"
           title: Sent At
+          description:
+            When the message was handed to the provider, ISO 8601 timestamp.
+            Null until sent.
         failed_at:
           anyOf:
             - type: string
               format: date-time
             - type: "null"
           title: Failed At
+          description: When the send failed, ISO 8601 timestamp. Null unless it failed.
         metadata:
           additionalProperties: true
           type: object
           title: Metadata
+          description:
+            Free-form JSON object attached to the email, as sent on create.
+            Not interpreted by Hail.
         body_text:
           anyOf:
             - type: string
             - type: "null"
           title: Body Text
+          description: Plain-text body, if any.
         body_html:
           anyOf:
             - type: string
             - type: "null"
           title: Body Html
+          description: HTML body, if any.
         message_id:
           anyOf:
             - type: string
             - type: "null"
           title: Message Id
+          description:
+            RFC 5322 Message-ID header. Inbound emails only; null on outbound
+            rows.
         in_reply_to:
           anyOf:
             - type: string
             - type: "null"
           title: In Reply To
+          description:
+            RFC 5322 In-Reply-To header. Inbound emails only; null on outbound
+            rows.
         references_ids:
           anyOf:
             - items:
@@ -3164,47 +4781,72 @@ components:
               type: array
             - type: "null"
           title: References Ids
+          description:
+            RFC 5322 References header, split into ids. Inbound emails
+            only; null on outbound rows.
         spam_verdict:
           anyOf:
             - type: string
             - type: "null"
           title: Spam Verdict
+          description:
+            Provider spam-scan verdict (e.g. 'PASS'/'FAIL'). Inbound emails
+            only; null on outbound rows.
         virus_verdict:
           anyOf:
             - type: string
             - type: "null"
           title: Virus Verdict
+          description:
+            Provider virus-scan verdict (e.g. 'PASS'/'FAIL'). Inbound emails
+            only; null on outbound rows.
         dkim_verdict:
           anyOf:
             - type: string
             - type: "null"
           title: Dkim Verdict
+          description:
+            Provider DKIM-authentication verdict (e.g. 'PASS'/'FAIL').
+            Inbound emails only; null on outbound rows.
         spf_verdict:
           anyOf:
             - type: string
             - type: "null"
           title: Spf Verdict
+          description:
+            Provider SPF-authentication verdict (e.g. 'PASS'/'FAIL'). Inbound
+            emails only; null on outbound rows.
         dmarc_verdict:
           anyOf:
             - type: string
             - type: "null"
           title: Dmarc Verdict
+          description:
+            Provider DMARC-authentication verdict (e.g. 'PASS'/'FAIL').
+            Inbound emails only; null on outbound rows.
         provider_received_at:
           anyOf:
             - type: string
               format: date-time
             - type: "null"
           title: Provider Received At
+          description:
+            When the provider received this email, ISO 8601 timestamp.
+            Inbound emails only.
         raw_url:
           anyOf:
             - type: string
             - type: "null"
           title: Raw Url
+          description:
+            API endpoint that redirects to the original MIME blob. Inbound
+            emails only; null on outbound rows.
         attachments:
           items:
             $ref: "#/components/schemas/EmailAttachmentResponse"
           type: array
           title: Attachments
+          description: Inbound MIME attachments on this email. Empty on outbound rows.
           default: []
         last_event_at:
           anyOf:
@@ -3212,6 +4854,9 @@ components:
               format: date-time
             - type: "null"
           title: Last Event At
+          description:
+            When the most recent delivery event for this email occurred,
+            ISO 8601 timestamp.
       type: object
       required:
         - id
@@ -3238,51 +4883,67 @@ components:
         sent:
           type: integer
           title: Sent
+          description: Emails sent in the window.
           default: 0
         delivered:
           type: integer
           title: Delivered
+          description: Emails confirmed delivered in the window.
           default: 0
         delivery_delayed:
           type: integer
           title: Delivery Delayed
+          description: Emails with a delivery-delayed event in the window.
           default: 0
         bounced:
           type: integer
           title: Bounced
+          description: Emails bounced (soft or hard) in the window.
           default: 0
         bounced_hard:
           type: integer
           title: Bounced Hard
+          description: Emails hard-bounced in the window. Subset of bounced.
           default: 0
         complained:
           type: integer
           title: Complained
+          description: Emails that received a spam complaint in the window.
           default: 0
         rejected:
           type: integer
           title: Rejected
+          description: Emails rejected by the provider before sending, in the window.
           default: 0
         opened:
           type: integer
           title: Opened
+          description:
+            Total open events in the window, including repeat opens by
+            the same recipient.
           default: 0
         clicked:
           type: integer
           title: Clicked
+          description:
+            Total click events in the window, including repeat clicks by
+            the same recipient.
           default: 0
         unique_opened:
           type: integer
           title: Unique Opened
+          description: Distinct emails opened at least once in the window.
           default: 0
         unique_clicked:
           type: integer
           title: Unique Clicked
+          description: Distinct emails clicked at least once in the window.
           default: 0
         bucket_start:
           type: string
           format: date-time
           title: Bucket Start
+          description: Start of this bucket, ISO 8601 timestamp.
       type: object
       required:
         - bucket_start
@@ -3292,46 +4953,61 @@ components:
         sent:
           type: integer
           title: Sent
+          description: Emails sent in the window.
           default: 0
         delivered:
           type: integer
           title: Delivered
+          description: Emails confirmed delivered in the window.
           default: 0
         delivery_delayed:
           type: integer
           title: Delivery Delayed
+          description: Emails with a delivery-delayed event in the window.
           default: 0
         bounced:
           type: integer
           title: Bounced
+          description: Emails bounced (soft or hard) in the window.
           default: 0
         bounced_hard:
           type: integer
           title: Bounced Hard
+          description: Emails hard-bounced in the window. Subset of bounced.
           default: 0
         complained:
           type: integer
           title: Complained
+          description: Emails that received a spam complaint in the window.
           default: 0
         rejected:
           type: integer
           title: Rejected
+          description: Emails rejected by the provider before sending, in the window.
           default: 0
         opened:
           type: integer
           title: Opened
+          description:
+            Total open events in the window, including repeat opens by
+            the same recipient.
           default: 0
         clicked:
           type: integer
           title: Clicked
+          description:
+            Total click events in the window, including repeat clicks by
+            the same recipient.
           default: 0
         unique_opened:
           type: integer
           title: Unique Opened
+          description: Distinct emails opened at least once in the window.
           default: 0
         unique_clicked:
           type: integer
           title: Unique Clicked
+          description: Distinct emails clicked at least once in the window.
           default: 0
       type: object
       title: EmailStatsCounts
@@ -3342,26 +5018,31 @@ components:
             - type: number
             - type: "null"
           title: Delivery
+          description: delivered / sent for the window. Null when sent == 0.
         bounce:
           anyOf:
             - type: number
             - type: "null"
           title: Bounce
+          description: bounced_hard / sent for the window. Null when sent == 0.
         complaint:
           anyOf:
             - type: number
             - type: "null"
           title: Complaint
+          description: complained / sent for the window. Null when sent == 0.
         open:
           anyOf:
             - type: number
             - type: "null"
           title: Open
+          description: unique_opened / sent for the window. Null when sent == 0.
         click:
           anyOf:
             - type: number
             - type: "null"
           title: Click
+          description: unique_clicked / sent for the window. Null when sent == 0.
       type: object
       title: EmailStatsRates
       description: All None when sent == 0 in the window.
@@ -3371,25 +5052,35 @@ components:
           type: string
           format: date-time
           title: From
+          description: Start of the queried window, ISO 8601 timestamp (inclusive).
         to:
           type: string
           format: date-time
           title: To
+          description: End of the queried window, ISO 8601 timestamp (exclusive).
         bucket:
           type: string
           enum:
             - hour
             - day
           title: Bucket
+          description: Time-bucket size used for the series.
         totals:
           $ref: "#/components/schemas/EmailStatsCounts"
+          description: Event counts summed across the whole window.
         rates:
           $ref: "#/components/schemas/EmailStatsRates"
+          description:
+            Derived rates (delivery, bounce, complaint, open, click) for
+            the whole window. Each individual rate is null when sent == 0.
         series:
           items:
             $ref: "#/components/schemas/EmailStatsBucket"
           type: array
           title: Series
+          description:
+            Per-bucket event counts across the window, in chronological
+            order.
       type: object
       required:
         - from
@@ -3405,42 +5096,57 @@ components:
           type: string
           format: uuid
           title: Id
+          description: Unique identifier for this email.
         organization_id:
           type: string
           format: uuid
           title: Organization Id
+          description: Organization that sent or received this email.
         conversation_id:
           anyOf:
             - type: string
               format: uuid
             - type: "null"
           title: Conversation Id
+          description:
+            Conversation thread this email is grouped into, if any. Null
+            when it was not linked to a conversation.
         email_domain_id:
           anyOf:
             - type: string
               format: uuid
             - type: "null"
           title: Email Domain Id
+          description:
+            The sending domain used, if from_address belongs to one of
+            the org's configured domains.
         direction:
           type: string
           enum:
             - outbound
             - inbound
           title: Direction
+          description: "'outbound' for emails Hail sent, 'inbound' for emails
+            received."
           default: outbound
         from_address:
           type: string
           title: From Address
+          description: Sender email address.
         from_name:
           anyOf:
             - type: string
             - type: "null"
           title: From Name
+          description:
+            "Display name used on the From: header, when the sender supplied
+            one. Always null on inbound rows."
         to_addresses:
           items:
             type: string
           type: array
           title: To Addresses
+          description: Recipient email addresses.
         cc_addresses:
           anyOf:
             - items:
@@ -3448,6 +5154,7 @@ components:
               type: array
             - type: "null"
           title: Cc Addresses
+          description: CC recipient email addresses, if any.
         bcc_addresses:
           anyOf:
             - items:
@@ -3455,14 +5162,17 @@ components:
               type: array
             - type: "null"
           title: Bcc Addresses
+          description: BCC recipient email addresses, if any.
         reply_to:
           anyOf:
             - type: string
             - type: "null"
           title: Reply To
+          description: Reply-To email address, if set.
         subject:
           type: string
           title: Subject
+          description: Email subject line.
         status:
           type: string
           enum:
@@ -3474,36 +5184,51 @@ components:
             - complained
             - received
           title: Status
+          description:
+            "Delivery status: 'queued', 'sent', 'delivered', 'failed',
+            'bounced', 'complained', or 'received' (inbound emails)."
         end_reason:
           anyOf:
             - type: string
             - type: "null"
           title: End Reason
+          description:
+            Reason delivery failed or bounced, if applicable. Null on success
+            or while pending.
         provider_message_id:
           anyOf:
             - type: string
             - type: "null"
           title: Provider Message Id
+          description: The email provider's identifier for this message, if assigned.
         requested_at:
           type: string
           format: date-time
           title: Requested At
+          description: When the send was requested, ISO 8601 timestamp.
         sent_at:
           anyOf:
             - type: string
               format: date-time
             - type: "null"
           title: Sent At
+          description:
+            When the message was handed to the provider, ISO 8601 timestamp.
+            Null until sent.
         failed_at:
           anyOf:
             - type: string
               format: date-time
             - type: "null"
           title: Failed At
+          description: When the send failed, ISO 8601 timestamp. Null unless it failed.
         metadata:
           additionalProperties: true
           type: object
           title: Metadata
+          description:
+            Free-form JSON object attached to the email, as sent on create.
+            Not interpreted by Hail.
       type: object
       required:
         - id
@@ -3534,6 +5259,7 @@ components:
           type: string
           format: uuid
           title: Id
+          description: Unique identifier for this event.
         source:
           type: string
           enum:
@@ -3541,35 +5267,45 @@ components:
             - email
             - sms
           title: Source
+          description: "Which channel this event belongs to: 'call', 'email',
+            or 'sms'."
         call_id:
           anyOf:
             - type: string
               format: uuid
             - type: "null"
           title: Call Id
+          description: The call this event belongs to. Set only when source='call'.
         email_id:
           anyOf:
             - type: string
               format: uuid
             - type: "null"
           title: Email Id
+          description: The email this event belongs to. Set only when source='email'.
         sms_id:
           anyOf:
             - type: string
               format: uuid
             - type: "null"
           title: Sms Id
+          description: The message this event belongs to. Set only when source='sms'.
         kind:
           type: string
           title: Kind
+          description:
+            Event kind within the source (e.g. 'queued', 'delivered', 'bounced').
+            Vocabulary differs per source.
         payload:
           additionalProperties: true
           type: object
           title: Payload
+          description: Event-kind-specific detail, as a free-form JSON object.
         occurred_at:
           type: string
           format: date-time
           title: Occurred At
+          description: When this event occurred, ISO 8601 timestamp.
       type: object
       required:
         - id
@@ -3586,11 +5322,15 @@ components:
             $ref: "#/components/schemas/EventResponse"
           type: array
           title: Items
+          description: Events in this page, oldest first.
         next_cursor:
           anyOf:
             - type: string
             - type: "null"
           title: Next Cursor
+          description:
+            Opaque cursor for the next page. Null when there are no more
+            results.
         call_status:
           anyOf:
             - type: string
@@ -3606,6 +5346,10 @@ components:
                 - canceled
             - type: "null"
           title: Call Status
+          description:
+            Current status of the call named by the id filter (e.g. id=call:<uuid>).
+            Null for org-wide tails and non-call filters, since there is no single
+            call to report a status for.
       type: object
       required:
         - items
@@ -3617,6 +5361,9 @@ components:
             $ref: "#/components/schemas/ValidationError"
           type: array
           title: Detail
+          description:
+            "List of validation errors: each entry gives the field location
+            (loc), the problem (msg), and the error type (type)."
       type: object
       title: HTTPValidationError
     LLMConfig:
@@ -3624,12 +5371,20 @@ components:
         base_url:
           type: string
           title: Base Url
+          description:
+            "Public HTTPS base URL of the BYO LLM endpoint the call runs\
+            \ on. Must resolve to a public address \u2014 private/internal hosts are\
+            \ rejected."
         api_key:
           type: string
           title: Api Key
+          description:
+            "API key sent to the BYO LLM endpoint. Write-only \u2014 never\
+            \ echoed back."
         model:
           type: string
           title: Model
+          description: Model name to request from the BYO LLM endpoint.
       additionalProperties: false
       type: object
       required:
@@ -3642,6 +5397,7 @@ components:
         phone_e164:
           type: string
           title: Phone E164
+          description: Phone number to save for the caller, E.164 format.
       additionalProperties: false
       type: object
       required:
@@ -3654,6 +5410,9 @@ components:
           maxLength: 2
           minLength: 2
           title: Country Code
+          description:
+            ISO alpha-2 country code to acquire a number in (e.g. 'US').
+            Case-insensitive.
         number_type:
           type: string
           enum:
@@ -3662,6 +5421,9 @@ components:
             - toll_free
             - national
           title: Number Type
+          description:
+            "Kind of number to acquire: 'local', 'mobile', 'toll_free',
+            or 'national'."
           default: local
       additionalProperties: false
       type: object
@@ -3675,11 +5437,15 @@ components:
             $ref: "#/components/schemas/PhoneNumberResponse"
           type: array
           title: Items
+          description: Numbers in this page.
         next_cursor:
           anyOf:
             - type: string
             - type: "null"
           title: Next Cursor
+          description:
+            Opaque cursor for the next page. Null when there are no more
+            results.
       type: object
       required:
         - items
@@ -3690,31 +5456,45 @@ components:
           type: string
           format: uuid
           title: Id
+          description: Unique identifier for this number.
         e164:
           type: string
           title: E164
+          description: The phone number, E.164 format.
         country_code:
           type: string
           title: Country Code
+          description: ISO alpha-2 country code this number belongs to.
         number_type:
           type: string
           title: Number Type
+          description: "Kind of number: 'local', 'mobile', 'toll_free', or 'national'."
         capabilities:
           items:
             type: string
           type: array
           title: Capabilities
+          description:
+            Channels this number supports, e.g. ['voice'], ['sms'], or
+            both.
         provisioning_state:
           type: string
           title: Provisioning State
+          description: "'pending', 'active', 'failed', or 'released'."
         is_dedicated:
           type: boolean
           title: Is Dedicated
+          description:
+            True if this number is owned by the organization. False for
+            shared-pool numbers.
         messaging_service_sid:
           anyOf:
             - type: string
             - type: "null"
           title: Messaging Service Sid
+          description:
+            Provider messaging-service identifier once SMS has been enabled
+            on this number. Null until then.
       type: object
       required:
         - id
@@ -3730,6 +5510,7 @@ components:
         provider:
           type: string
           title: Provider
+          description: Previously saved provider to make active for this layer.
       additionalProperties: false
       type: object
       required:
@@ -3745,29 +5526,42 @@ components:
             - tts
             - stt
           title: Layer
+          description: Voice-pipeline layer this config applies to.
         provider:
           type: string
           title: Provider
+          description: Provider name (e.g. 'openai', 'cartesia').
         key_last4:
           anyOf:
             - type: string
             - type: "null"
           title: Key Last4
+          description:
+            Last 4 characters of the saved API key, for display. Null if
+            no key is saved.
         key_set_at:
           anyOf:
             - type: string
             - type: "null"
           title: Key Set At
+          description:
+            When the API key was last set, ISO 8601 timestamp. Null if
+            no key is saved.
         params:
           additionalProperties: true
           type: object
           title: Params
+          description: Saved provider-specific config for this row.
         fallback_enabled:
           type: boolean
           title: Fallback Enabled
+          description:
+            Whether Hail's default provider is used as a fallback if this
+            one fails.
         is_active:
           type: boolean
           title: Is Active
+          description: True if this is the row currently used by calls on this layer.
       type: object
       required:
         - layer
@@ -3795,6 +5589,7 @@ components:
             $ref: "#/components/schemas/ProviderConfigEntry"
           type: array
           title: Providers
+          description: Every saved provider row for the organization, across all layers.
       type: object
       required:
         - providers
@@ -3804,20 +5599,33 @@ components:
         provider:
           type: string
           title: Provider
+          description:
+            Provider name to save/activate for this layer (e.g. 'openai',
+            'cartesia').
         api_key:
           anyOf:
             - type: string
             - type: "null"
           title: Api Key
+          description:
+            "API key for this provider. Omit to edit params without resending\
+            \ the key. Write-only \u2014 never echoed back."
         params:
           additionalProperties: true
           type: object
           title: Params
+          description:
+            Provider-specific config, validated against the layer's schema
+            (LLMParams/TTSParams/STTParams). Only the keys you send are changed; other
+            saved keys are kept.
         fallback_enabled:
           anyOf:
             - type: boolean
             - type: "null"
           title: Fallback Enabled
+          description:
+            Whether to fall back to Hail's default provider on failure.
+            Omit to leave unchanged; defaults to false on a new row.
       additionalProperties: false
       type: object
       required:
@@ -3843,15 +5651,18 @@ components:
             - type: string
             - type: "null"
           title: Api Key
+          description: Key to test instead of the stored one. Not persisted.
         provider:
           anyOf:
             - type: string
             - type: "null"
           title: Provider
+          description: "Provider to test. Omitted: the layer's currently active provider."
         params:
           additionalProperties: true
           type: object
           title: Params
+          description: Provider-specific config to test alongside the key.
       additionalProperties: false
       type: object
       title: ProviderValidateRequest
@@ -3865,11 +5676,16 @@ components:
         status:
           type: string
           title: Status
+          description: "Probe outcome: 'valid', 'invalid', or 'indeterminate'
+            (the provider could not be reached)."
         message:
           anyOf:
             - type: string
             - type: "null"
           title: Message
+          description:
+            Human-readable detail about the outcome. 'ok' on success, an
+            error description otherwise.
       type: object
       required:
         - status
@@ -3883,6 +5699,10 @@ components:
             - type: string
             - type: "null"
           title: Custom Sender Id
+          description:
+            Alphanumeric sender id (2-11 characters, letters/digits only)
+            to use on alphanumeric-eligible corridors instead of a phone number. Explicit
+            null clears it, reverting to the platform default.
       additionalProperties: false
       type: object
       title: SenderIdPatch
@@ -3893,9 +5713,15 @@ components:
             - type: string
             - type: "null"
           title: Custom Sender Id
+          description:
+            The organization's configured alphanumeric sender id. Null
+            if none is set.
         effective_default:
           type: string
           title: Effective Default
+          description:
+            The platform's alphanumeric sender id, used on eligible corridors
+            when custom_sender_id is null.
           default: HAIL
       type: object
       required:
@@ -3939,20 +5765,30 @@ components:
         to:
           type: string
           title: To
+          description: Recipient phone number, E.164 format (e.g. +14155551234).
         from:
           anyOf:
             - type: string
             - type: "null"
           title: From
+          description:
+            "Sender phone number, E.164 format. Must be a number owned
+            by the organization with the SMS capability. Omitted: an active org-owned
+            number is used if one exists, else a number is claimed from the shared
+            pool."
         body:
           type: string
           maxLength: 1600
           minLength: 1
           title: Body
+          description: Message text. Long bodies are split into multiple carrier segments.
         metadata:
           additionalProperties: true
           type: object
           title: Metadata
+          description:
+            Free-form JSON object attached to the message and echoed back
+            on reads. Not interpreted by Hail.
       additionalProperties: false
       type: object
       required:
@@ -3967,11 +5803,15 @@ components:
             $ref: "#/components/schemas/SmsResponse"
           type: array
           title: Items
+          description: Messages in this page, newest first.
         next_cursor:
           anyOf:
             - type: string
             - type: "null"
           title: Next Cursor
+          description:
+            Opaque cursor for the next page. Null when there are no more
+            results.
       type: object
       required:
         - items
@@ -3982,22 +5822,29 @@ components:
           type: string
           format: uuid
           title: Id
+          description: Unique identifier for this message.
         organization_id:
           type: string
           format: uuid
           title: Organization Id
+          description: Organization that sent or received this message.
         from_e164:
           type: string
           title: From E164
+          description: Sender phone number, E.164 format.
         to_e164:
           type: string
           title: To E164
+          description: Recipient phone number, E.164 format.
         direction:
           type: string
           enum:
             - outbound
             - inbound
           title: Direction
+          description:
+            "'outbound' for messages Hail sent, 'inbound' for messages
+            received."
         status:
           type: string
           enum:
@@ -4008,32 +5855,45 @@ components:
             - undelivered
             - received
           title: Status
+          description:
+            "Delivery status: 'queued', 'sent', 'delivered', 'failed',
+            'undelivered', or 'received' (inbound messages)."
         body:
           type: string
           title: Body
+          description: Message text.
         provider_message_sid:
           anyOf:
             - type: string
             - type: "null"
           title: Provider Message Sid
+          description: The carrier/provider's identifier for this message, if assigned.
         segment_count:
           type: integer
           title: Segment Count
+          description: Number of carrier SMS segments the body was split into.
         error_code:
           anyOf:
             - type: string
             - type: "null"
           title: Error Code
+          description:
+            Carrier error code if delivery failed. Null on success or while
+            pending.
         requested_at:
           type: string
           format: date-time
           title: Requested At
+          description: When the send was requested, ISO 8601 timestamp.
         sent_at:
           anyOf:
             - type: string
               format: date-time
             - type: "null"
           title: Sent At
+          description:
+            When the message was handed to the carrier, ISO 8601 timestamp.
+            Null until sent.
       type: object
       required:
         - id
@@ -4056,11 +5916,15 @@ components:
             $ref: "#/components/schemas/SuppressionResponse"
           type: array
           title: Items
+          description: Suppressed recipients in this page.
         next_cursor:
           anyOf:
             - type: string
             - type: "null"
           title: Next Cursor
+          description:
+            Opaque cursor for the next page. Null when there are no more
+            results.
       type: object
       required:
         - items
@@ -4071,22 +5935,34 @@ components:
           type: string
           format: uuid
           title: Id
+          description: Unique identifier for this suppression entry.
         recipient:
           type: string
           title: Recipient
+          description:
+            "The suppressed recipient \u2014 E.164 phone number for voice/sms,\
+            \ lowercased email address for email."
         channel:
           type: string
           title: Channel
+          description: "Channel this entry blocks sends on: 'voice', 'email',
+            'sms', or 'all' (every channel)."
         reason:
           type: string
           title: Reason
+          description:
+            Why the recipient was suppressed (e.g. an unsubscribe or a
+            bounce).
         source:
           type: string
           title: Source
+          description: "How this entry was created: 'unsubscribe_link', 'manual'
+            (an operator action), or 'bounce'."
         created_at:
           type: string
           format: date-time
           title: Created At
+          description: When this entry was created, ISO 8601 timestamp.
       type: object
       required:
         - id
@@ -4105,17 +5981,26 @@ components:
               - type: integer
           type: array
           title: Location
+          description:
+            Path to the invalid field within the request, as a list of
+            keys/indices (e.g. ['body', 'to']).
         msg:
           type: string
           title: Message
+          description: Human-readable description of the validation failure.
         type:
           type: string
           title: Error Type
+          description: Machine-readable error type code (e.g. 'missing', 'string_type').
         input:
           title: Input
+          description: The value that was actually provided and failed validation.
         ctx:
           type: object
           title: Context
+          description:
+            Additional machine-readable context for the error, when the
+            error type provides one.
       type: object
       required:
         - loc
@@ -4128,22 +6013,29 @@ components:
           type: string
           const: cartesia
           title: Tts
+          description: Text-to-speech provider. Currently only 'cartesia'.
           default: cartesia
         vad:
           type: string
           const: silero
           title: Vad
+          description: Voice-activity-detection engine. Currently only 'silero'.
           default: silero
         turn_detection:
           type: string
           const: livekit
           title: Turn Detection
+          description: Turn-detection engine. Currently only 'livekit'.
           default: livekit
         voice_id:
           anyOf:
             - type: string
             - type: "null"
           title: Voice Id
+          description:
+            "Per-call TTS voice override, applied to whichever TTS provider
+            serves the call. Omitted: the organization's or environment's default
+            voice."
         language:
           anyOf:
             - type: string
@@ -4204,11 +6096,15 @@ components:
             $ref: "#/components/schemas/WebhookDeliveryResponse"
           type: array
           title: Items
+          description: Delivery attempts in this page.
         next_cursor:
           anyOf:
             - type: string
             - type: "null"
           title: Next Cursor
+          description:
+            Opaque cursor for the next page. Null when there are no more
+            results.
       type: object
       required:
         - items
@@ -4219,28 +6115,39 @@ components:
           type: string
           format: uuid
           title: Id
+          description: Unique identifier for this delivery attempt.
         subscription_id:
           anyOf:
             - type: string
               format: uuid
             - type: "null"
           title: Subscription Id
+          description: Subscription this delivery belongs to.
         email_domain_id:
           anyOf:
             - type: string
               format: uuid
             - type: "null"
           title: Email Domain Id
+          description:
+            "Email domain the triggering event relates to, if any. Informational\
+            \ only (surfaced as the X-Hail-Email-Domain header) \u2014 not a routing\
+            \ target."
         event_type:
           type: string
           title: Event Type
+          description: The event type being delivered (e.g. 'call.completed').
         event_id:
           type: string
           format: uuid
           title: Event Id
+          description: Identifier of the underlying event that triggered this delivery.
         attempt:
           type: integer
           title: Attempt
+          description:
+            Number of delivery attempts made so far for this event, starting
+            at 0.
         status:
           type: string
           enum:
@@ -4249,30 +6156,43 @@ components:
             - failed
             - dead
           title: Status
+          description: "'pending' (queued/retrying), 'succeeded', 'failed' (will
+            retry), or 'dead' (retries exhausted)."
         response_status:
           anyOf:
             - type: integer
             - type: "null"
           title: Response Status
+          description:
+            HTTP status code returned by the target URL on the last attempt.
+            Null before any attempt.
         response_body:
           anyOf:
             - type: string
             - type: "null"
           title: Response Body
+          description:
+            Response body returned by the target URL on the last attempt,
+            if any. Null before any attempt.
         next_attempt_at:
           type: string
           format: date-time
           title: Next Attempt At
+          description: When the next delivery attempt is scheduled, ISO 8601 timestamp.
         succeeded_at:
           anyOf:
             - type: string
               format: date-time
             - type: "null"
           title: Succeeded At
+          description:
+            When this delivery succeeded, ISO 8601 timestamp. Null until
+            it does.
         created_at:
           type: string
           format: date-time
           title: Created At
+          description: When this delivery was queued, ISO 8601 timestamp.
       type: object
       required:
         - id
@@ -4291,6 +6211,7 @@ components:
           type: string
           minLength: 1
           title: Target Url
+          description: HTTPS URL Hail POSTs event payloads to.
         event_types:
           items:
             type: string
@@ -4316,6 +6237,9 @@ components:
           type: array
           minItems: 1
           title: Event Types
+          description:
+            Event types to subscribe to (e.g. 'call.completed', 'email.bounced').
+            At least one required.
       type: object
       required:
         - target_url
@@ -4328,11 +6252,15 @@ components:
             $ref: "#/components/schemas/WebhookSubscriptionResponse"
           type: array
           title: Items
+          description: Subscriptions in this page.
         next_cursor:
           anyOf:
             - type: string
             - type: "null"
           title: Next Cursor
+          description:
+            Opaque cursor for the next page. Null when there are no more
+            results.
       type: object
       required:
         - items
@@ -4344,6 +6272,7 @@ components:
             - type: string
             - type: "null"
           title: Target Url
+          description: New delivery URL. Omit to leave unchanged.
         event_types:
           anyOf:
             - items:
@@ -4370,6 +6299,7 @@ components:
               type: array
             - type: "null"
           title: Event Types
+          description: New set of subscribed event types. Omit to leave unchanged.
         status:
           anyOf:
             - type: string
@@ -4378,6 +6308,9 @@ components:
                 - disabled
             - type: "null"
           title: Status
+          description:
+            Set to 'disabled' to pause deliveries, or 'active' to resume.
+            Omit to leave unchanged.
       type: object
       title: WebhookSubscriptionPatch
     WebhookSubscriptionResponse:
@@ -4386,52 +6319,70 @@ components:
           type: string
           format: uuid
           title: Id
+          description: Unique identifier for this subscription.
         organization_id:
           type: string
           format: uuid
           title: Organization Id
+          description: Organization that owns this subscription.
         target_url:
           type: string
           title: Target Url
+          description: HTTPS URL event payloads are POSTed to.
         event_types:
           items:
             type: string
           type: array
           title: Event Types
+          description: Event types this subscription receives.
         status:
           type: string
           enum:
             - active
             - disabled
           title: Status
+          description: "'active' (delivering) or 'disabled' (paused)."
         consecutive_failures:
           type: integer
           title: Consecutive Failures
+          description:
+            Consecutive failed delivery attempts since the last success.
+            Resets to 0 on success.
         last_success_at:
           anyOf:
             - type: string
               format: date-time
             - type: "null"
           title: Last Success At
+          description:
+            When a delivery last succeeded, ISO 8601 timestamp. Null if
+            never.
         last_failure_at:
           anyOf:
             - type: string
               format: date-time
             - type: "null"
           title: Last Failure At
+          description: When a delivery last failed, ISO 8601 timestamp. Null if never.
         created_at:
           type: string
           format: date-time
           title: Created At
+          description: When this subscription was created, ISO 8601 timestamp.
         updated_at:
           type: string
           format: date-time
           title: Updated At
+          description: When this subscription was last modified, ISO 8601 timestamp.
         secret:
           anyOf:
             - type: string
             - type: "null"
           title: Secret
+          description:
+            Plaintext signing secret for verifying delivery payloads. Only
+            present in the create and rotate-secret responses; every later read returns
+            null.
       type: object
       required:
         - id
@@ -4458,26 +6409,34 @@ components:
             - jwt
             - shared
           title: Auth Kind
+          description:
+            "How the caller authenticated: 'apikey' (org API key), 'jwt'
+            (logged-in user session), or 'shared' (the shared HAIL_API_KEY, which
+            carries no human identity)."
         organization_id:
           type: string
           format: uuid
           title: Organization Id
+          description: Organization the caller belongs to.
         user_id:
           anyOf:
             - type: string
               format: uuid
             - type: "null"
           title: User Id
+          description: The authenticated user's id. Null for 'shared' callers.
         email:
           anyOf:
             - type: string
             - type: "null"
           title: Email
+          description: The authenticated user's email. Null for 'shared' callers.
         name:
           anyOf:
             - type: string
             - type: "null"
           title: Name
+          description: The authenticated user's display name. Null for 'shared' callers.
       type: object
       required:
         - auth_kind

--- a/uv.lock
+++ b/uv.lock
@@ -584,6 +584,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1048,6 +1060,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
+    { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -1077,6 +1090,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "ruff", marker = "extra == 'dev'" },
+    { name = "slowapi", specifier = ">=0.1.10" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
@@ -1595,6 +1609,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453, upload-time = "2026-04-09T16:06:05.229Z" },
     { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044, upload-time = "2026-04-09T16:06:06.398Z" },
     { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009, upload-time = "2026-04-09T16:06:07.995Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
 ]
 
 [[package]]
@@ -3465,6 +3493,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "slowapi"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/52/24527cf25a8b508926aff53350b0136561dfe86c7125f61526653666e1b2/slowapi-0.1.10.tar.gz", hash = "sha256:d320d5bc04d9f171a77fb16700faf3036d85b00f420f22924c8a225f95bd14f9", size = 13841, upload-time = "2026-06-13T11:59:31.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/8b/1d359f38706b4097d9a943bf8bd22599f537de4cbaff1e622d3e3936e164/slowapi-0.1.10-py3-none-any.whl", hash = "sha256:3acb61561dc9d687e3d3669362ff6a439de9ba44e2fed3a9c165da26b4b83e28", size = 14921, upload-time = "2026-06-13T11:59:30.485Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes gaps an "Is Agentic" AI-agent-readiness audit found in the Hail API and MCP server:

- **`/v1` URL versioning**: every customer-facing router is dual-mounted — `/v1/<resource>` is canonical and the only mount in the OpenAPI schema; the legacy unprefixed path still works but is excluded from the schema and carries `Deprecation: true` + a successor-version `Link` header. Documented in `docs/public/versioning.md`.
- **General rate limiting**: `RateLimit-Limit`/`RateLimit-Remaining`/`RateLimit-Reset` on every customer response, 429 + `Retry-After` when exceeded, documented in the OpenAPI spec (merged with the pre-existing per-org agent-abuse velocity cap's docs on 3 routes, not clobbered). Three public, self-credentialed routes (Twilio webhook receivers, the RFC 8058 unsubscribe endpoint) are exempt so they don't share a bucket with anonymous internet traffic.
- **OpenAPI operation + schema field descriptions**: every schema-visible operation and every transitively-referenced schema field (56 schemas) now has a real, accurate description.
- **MCP unauthenticated capability discovery**: `initialize` and `tools/list` now succeed without a bearer, so an agent can see what Hail offers before authenticating. Every other method still 401s. A 64 KiB cap bounds the pre-auth body peek; a per-IP rate cap bounds anonymous session creation.
- **Regenerated `openapi/openapi.yaml`** to reflect all of the above; CI's diff check passes.

## Process

Implemented via subagent-driven development: 6 tasks, each with its own TDD implementer, task-scoped review, and fix loop where needed; a final whole-branch review (opus) caught 2 Critical + 4 Important cross-cutting issues invisible to any single task's review (a shared-bucket rate-limit bug affecting Twilio webhooks/unsubscribe, unbounded anonymous MCP session creation, stale `Location` headers, deprecated-path references in spec prose and docs) — all fixed and re-reviewed clean.

Full plan and rationale: `docs/superpowers/plans/2026-08-22-agent-readiness-api-mcp.md`

## Deliberately out of scope (see plan/PR discussion for why)

- Dockerfile/uvicorn proxy-header trust config (needed for the rate limiter's IP fallback to see real client IPs) — infra/deploy change, not made blind in this PR.
- Migrating Hail's own first-party callers (MCP client, Python SDK, Twilio callback registration, unsubscribe link minting) to `/v1` — a live-production URL-minting change deserving its own rollout decision.
- `hail-website/lib/docs.ts` registration of the new versioning doc page — owned by a separate repo, needs a follow-up PR there.
- Go CLI codegen/release against the new spec — separate manual release step per repo docs.

## Test plan

- [x] `cd api && uv run pytest -q` — 543 passed
- [x] `cd core && uv run pytest -q` — 613 passed, 1 skipped
- [x] `cd mcp && uv run pytest -q` — 98 passed
- [x] `ruff check .` / `black --check .` clean on all 3 packages
- [x] `mypy` clean on all touched files
- [x] CI's OpenAPI diff check passes locally (53 operationIds, 0 duplicates)
- [x] `node docs-site/scripts/urls.mjs --check` passes