### PR TITLE
docs(docs-site): serve every doc and API reference page as markdown

### DIFF
--- a/docs-site/app/api/[[...slug]]/page.tsx
+++ b/docs-site/app/api/[[...slug]]/page.tsx
@@ -20,15 +20,22 @@ function ApiIndex() {
       <DocsBody>
         <h1>API Reference</h1>
         <p>
-          Hail exposes a REST API at <code>https://api.hail.so</code>. Every endpoint
-          below is generated from{" "}
-          <code>openapi/openapi.yaml</code>, the canonical contract that CI verifies
-          against the live service, so this reference never drifts from the code.
+          Hail exposes a REST API at <code>https://api.hail.so</code>. Every
+          endpoint below is generated from <code>openapi/openapi.yaml</code>,
+          the canonical contract that CI verifies against the live service, so
+          this reference never drifts from the code.
         </p>
         <p>
           Machine-readable spec:{" "}
           <a href="/docs/api/openapi.yaml">openapi.yaml</a> ·{" "}
           <a href="/docs/api/openapi.json">openapi.json</a>
+        </p>
+        <p>
+          Every page below (and every guide) is also available as plain markdown
+          — append <code>.md</code> to its URL, or fetch{" "}
+          <a href="/docs/llms.txt">llms.txt</a> (index) or{" "}
+          <a href="/docs/llms-full.txt">llms-full.txt</a> (everything,
+          concatenated).
         </p>
         <ul>
           {pages.map((page) => (
@@ -42,7 +49,9 @@ function ApiIndex() {
   );
 }
 
-export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
+export default async function Page(props: {
+  params: Promise<{ slug?: string[] }>;
+}) {
   const { slug } = await props.params;
   if (!slug || slug.length === 0) return <ApiIndex />;
 
@@ -60,7 +69,9 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
   return (
     <DocsPage toc={page.data.toc} full={page.data.full}>
       <DocsBody>
-        <MDX components={getMDXComponents({ OpenAPIPage: PreloadedOpenAPIPage })} />
+        <MDX
+          components={getMDXComponents({ OpenAPIPage: PreloadedOpenAPIPage })}
+        />
       </DocsBody>
     </DocsPage>
   );
@@ -75,7 +86,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const { slug } = await props.params;
   if (!slug || slug.length === 0) {
-    return { title: "API Reference", description: "REST API reference for Hail." };
+    return {
+      title: "API Reference",
+      description: "REST API reference for Hail.",
+    };
   }
   const page = apiSource.getPage(slug);
   if (!page) notFound();

--- a/docs-site/app/llms-full.txt/route.ts
+++ b/docs-site/app/llms-full.txt/route.ts
@@ -1,0 +1,16 @@
+import { getDocsLLMText } from "@/lib/get-llm-text";
+import { getOperationMarkdown } from "@/lib/openapi-markdown";
+import { apiSource, source } from "@/lib/source";
+
+export const revalidate = false;
+
+export async function GET() {
+  const guides = await Promise.all(source.getPages().map(getDocsLLMText));
+  const operations = (
+    await Promise.all(apiSource.getPages().map(getOperationMarkdown))
+  ).filter((text): text is string => text !== null);
+
+  return new Response([...guides, ...operations].join("\n\n---\n\n"), {
+    headers: { "content-type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/docs-site/app/llms.mdx/[[...slug]]/route.ts
+++ b/docs-site/app/llms.mdx/[[...slug]]/route.ts
@@ -1,0 +1,50 @@
+import { notFound } from "next/navigation";
+import { getDocsLLMText } from "@/lib/get-llm-text";
+import {
+  getOperationMarkdown,
+  renderApiIndexMarkdown,
+} from "@/lib/openapi-markdown";
+import { apiSource, source } from "@/lib/source";
+
+// Backs the `/:path*.md` rewrite in next.config.ts — every docs page and every
+// generated API-reference page is available as plain markdown by appending
+// `.md` to its URL. `revalidate: false` matches the rest of the docs-site:
+// content only changes on a new deploy.
+export const revalidate = false;
+
+const MARKDOWN_HEADERS = { "content-type": "text/markdown; charset=utf-8" };
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug?: string[] }> },
+) {
+  const { slug = [] } = await params;
+
+  if (slug[0] === "api") {
+    const apiSlug = slug.slice(1);
+    if (apiSlug.length === 0) {
+      return new Response(renderApiIndexMarkdown(apiSource.getPages()), {
+        headers: MARKDOWN_HEADERS,
+      });
+    }
+    const page = apiSource.getPage(apiSlug);
+    if (!page) notFound();
+    const markdown = await getOperationMarkdown(page);
+    if (!markdown) notFound();
+    return new Response(markdown, { headers: MARKDOWN_HEADERS });
+  }
+
+  const page = source.getPage(slug);
+  if (!page) notFound();
+  return new Response(await getDocsLLMText(page), {
+    headers: MARKDOWN_HEADERS,
+  });
+}
+
+export function generateStaticParams() {
+  const docsParams = source.generateParams();
+  const apiParams = apiSource
+    .generateParams()
+    .map(({ slug = [] }) => ({ slug: ["api", ...slug] }));
+  return [...docsParams, { slug: ["api"] }, ...apiParams];
+}

--- a/docs-site/app/llms.txt/route.ts
+++ b/docs-site/app/llms.txt/route.ts
@@ -29,7 +29,7 @@ export function GET() {
 
   const body = [
     "# Hail",
-    "Universal communication platform for AI agents — outbound calls, SMS, and email over one REST API, CLI, and MCP server.",
+    "Give your AI agent a voice, a real phone number, and an inbox — place AI phone calls with ElevenLabs voices, run an AI call center, send SMS and agent mail, all from one API, CLI, and MCP server.",
     "## Guides",
     guides.join("\n"),
     "## API reference",

--- a/docs-site/app/llms.txt/route.ts
+++ b/docs-site/app/llms.txt/route.ts
@@ -1,0 +1,43 @@
+import { apiSource, source } from "@/lib/source";
+
+// Absolute origin, matching the precedent in app/sitemap.ts: this file is
+// meant to be fetched and read outside the site (an agent's context window),
+// so its links need to resolve on their own, not just relative to a browser
+// tab. Self-hosted deployments don't need this file to point at themselves.
+const ORIGIN = "https://hail.so/docs";
+
+export const revalidate = false;
+
+export function GET() {
+  const guides = source
+    .getPages()
+    .slice()
+    .sort((a, b) => a.url.localeCompare(b.url))
+    .map((page) => {
+      const url = `${ORIGIN}${page.url === "/" ? "" : page.url}.md`;
+      const description = page.data.description
+        ? `: ${page.data.description}`
+        : "";
+      return `- [${page.data.title}](${url})${description}`;
+    });
+
+  const operations = apiSource
+    .getPages()
+    .slice()
+    .sort((a, b) => a.url.localeCompare(b.url))
+    .map((page) => `- [${page.data.title}](${ORIGIN}${page.url}.md)`);
+
+  const body = [
+    "# Hail",
+    "Universal communication platform for AI agents — outbound calls, SMS, and email over one REST API, CLI, and MCP server.",
+    "## Guides",
+    guides.join("\n"),
+    "## API reference",
+    `Full list: ${ORIGIN}/api.md`,
+    operations.join("\n"),
+  ].join("\n\n");
+
+  return new Response(`${body}\n`, {
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+}

--- a/docs-site/lib/get-llm-text.ts
+++ b/docs-site/lib/get-llm-text.ts
@@ -1,0 +1,23 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { source } from "@/lib/source";
+
+type DocsPage = NonNullable<ReturnType<typeof source.getPage>>;
+
+// fumadocs-mdx's own page.data.getText("raw") resolves the file through a
+// logical (URL-style) path joiner that treats a leading ".." as "nothing to
+// pop" instead of a real filesystem traversal — it 404s for a content dir
+// declared as "../docs/public" (source.config.ts), which is exactly ours:
+// docs/public/ lives one level above docs-site/. Read the file directly
+// instead, using `page.path` (content-dir-relative, e.g. "architecture.md"),
+// which isn't run through that joiner.
+const DOCS_PUBLIC_DIR = path.resolve(process.cwd(), "../docs/public");
+
+/**
+ * Every file in docs/public/ opens with its own `# H1` (see the comment in
+ * app/(docs)/[[...slug]]/page.tsx) and has no custom MDX components, so the
+ * raw file *is* the page's markdown — no re-rendering needed.
+ */
+export async function getDocsLLMText(page: DocsPage): Promise<string> {
+  return readFile(path.join(DOCS_PUBLIC_DIR, page.path), "utf-8");
+}

--- a/docs-site/lib/openapi-markdown.ts
+++ b/docs-site/lib/openapi-markdown.ts
@@ -1,0 +1,256 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { load as parseYaml } from "js-yaml";
+import type { apiSource } from "@/lib/source";
+
+type ApiPage = NonNullable<ReturnType<typeof apiSource.getPage>>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type JSONSchema = Record<string, any>;
+
+// The generated content/api/*.mdx files render via a client component that
+// reads its `operations` prop at runtime — there's no typed page-data API for
+// "which path+method is this page" outside that render path. The prop is a
+// literal JSON array fumadocs-openapi always emits in this exact shape (see
+// scripts/generate-openapi.mjs), so pull it back out of the raw file instead
+// of re-deriving it. `per: "operation"` in that script means every generated
+// page has exactly one entry.
+function extractOperationRef(
+  rawMdx: string,
+): { path: string; method: string } | null {
+  const match = rawMdx.match(/operations=\{(\[[^\]]*\])\}/);
+  if (!match) return null;
+  try {
+    return JSON.parse(match[1])[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+let cachedDoc: Promise<JSONSchema> | undefined;
+// Same file scripts/generate-openapi.mjs reads, with the same library — kept
+// independent of fumadocs-openapi's internal document cache so this doesn't
+// depend on how it keys/bundles schemas internally.
+function loadOpenApiDoc(): Promise<JSONSchema> {
+  cachedDoc ??= readFile(
+    path.join(process.cwd(), "../openapi/openapi.yaml"),
+    "utf8",
+  ).then((text) => parseYaml(text) as JSONSchema);
+  return cachedDoc;
+}
+
+interface FieldRow {
+  field: string;
+  type: string;
+  required: boolean;
+  description: string;
+}
+
+function resolveRef(doc: JSONSchema, ref: string): JSONSchema | undefined {
+  const parts = ref.replace(/^#\//, "").split("/");
+  let node: JSONSchema = doc;
+  for (const part of parts) node = node?.[part];
+  return node;
+}
+
+function resolveSchema(
+  doc: JSONSchema,
+  schema: JSONSchema | undefined,
+): JSONSchema | undefined {
+  if (!schema) return schema;
+  if (schema.$ref) return resolveSchema(doc, resolveRef(doc, schema.$ref));
+  return schema;
+}
+
+function typeLabel(doc: JSONSchema, schema: JSONSchema | undefined): string {
+  const resolved = resolveSchema(doc, schema);
+  if (!resolved) return "unknown";
+  if (resolved.anyOf) {
+    return resolved.anyOf.map((s: JSONSchema) => typeLabel(doc, s)).join(" | ");
+  }
+  if (resolved.enum) {
+    return resolved.enum.map((v: unknown) => JSON.stringify(v)).join(" | ");
+  }
+  if (resolved.type === "array") return `${typeLabel(doc, resolved.items)}[]`;
+  if (resolved.type === "object" || resolved.properties) return "object";
+  if (resolved.format) return `${resolved.type} (${resolved.format})`;
+  return resolved.type ?? "any";
+}
+
+function cell(value: string | undefined): string {
+  return (value ?? "").replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
+}
+
+// Flattens a schema's properties into a field table, expanding one level of
+// nested object/array-of-object properties (dotted paths) so a body like
+// EmailCreate reads as one table instead of a maze of $refs. `seen` guards
+// against a $ref cycle re-expanding itself forever.
+function collectFields(
+  doc: JSONSchema,
+  schema: JSONSchema | undefined,
+  prefix = "",
+  depth = 0,
+  seen: Set<string> = new Set(),
+): FieldRow[] {
+  const resolved = resolveSchema(doc, schema);
+  if (!resolved) return [];
+  if (resolved.anyOf) {
+    const objectBranch = resolved.anyOf.find(
+      (s: JSONSchema) => resolveSchema(doc, s)?.properties,
+    );
+    return objectBranch
+      ? collectFields(doc, objectBranch, prefix, depth, seen)
+      : [];
+  }
+
+  const properties: Record<string, JSONSchema> = resolved.properties ?? {};
+  const required: string[] = resolved.required ?? [];
+  const rows: FieldRow[] = [];
+
+  for (const [name, propSchema] of Object.entries(properties)) {
+    const resolvedProp = resolveSchema(doc, propSchema);
+    const fieldPath = prefix ? `${prefix}.${name}` : name;
+    rows.push({
+      field: fieldPath,
+      type: typeLabel(doc, propSchema),
+      required: required.includes(name),
+      description: resolvedProp?.description ?? propSchema.description ?? "",
+    });
+
+    if (depth >= 1 || !resolvedProp) continue;
+    if (propSchema.$ref) {
+      if (seen.has(propSchema.$ref)) continue;
+      seen.add(propSchema.$ref);
+    }
+    const nested =
+      (resolvedProp.properties && resolvedProp) ||
+      (resolvedProp.type === "array" &&
+        resolveSchema(doc, resolvedProp.items)?.properties &&
+        resolveSchema(doc, resolvedProp.items));
+    if (nested)
+      rows.push(...collectFields(doc, nested, fieldPath, depth + 1, seen));
+  }
+  return rows;
+}
+
+function fieldsTable(rows: FieldRow[]): string {
+  if (rows.length === 0) return "_None._";
+  const header =
+    "| Field | Type | Required | Description |\n| --- | --- | --- | --- |";
+  const body = rows
+    .map(
+      (r) =>
+        `| \`${r.field}\` | ${cell(r.type)} | ${r.required ? "yes" : "no"} | ${cell(r.description) || "—"} |`,
+    )
+    .join("\n");
+  return `${header}\n${body}`;
+}
+
+function parametersTable(
+  doc: JSONSchema,
+  parameters: JSONSchema[] | undefined,
+  location: "path" | "query" | "header",
+): string | null {
+  const filtered = (parameters ?? []).filter((p) => p.in === location);
+  if (filtered.length === 0) return null;
+  const header =
+    "| Name | Type | Required | Description |\n| --- | --- | --- | --- |";
+  const body = filtered
+    .map((p) => {
+      const description =
+        p.description ?? resolveSchema(doc, p.schema)?.description ?? "";
+      return `| \`${p.name}\` | ${cell(typeLabel(doc, p.schema))} | ${p.required ? "yes" : "no"} | ${cell(description) || "—"} |`;
+    })
+    .join("\n");
+  return `${header}\n${body}`;
+}
+
+const LOCATION_TITLE = {
+  path: "Path",
+  query: "Query",
+  header: "Header",
+} as const;
+
+function renderOperationMarkdown(
+  doc: JSONSchema,
+  path: string,
+  method: string,
+  operation: JSONSchema,
+  title: string,
+  description?: string,
+): string {
+  const sections: string[] = [
+    `# ${title}`,
+    `\`${method.toUpperCase()} ${path}\``,
+  ];
+
+  const opDescription = description ?? operation.description;
+  if (opDescription) sections.push(opDescription);
+
+  for (const location of ["path", "query", "header"] as const) {
+    const table = parametersTable(doc, operation.parameters, location);
+    if (table)
+      sections.push(`## ${LOCATION_TITLE[location]} parameters\n\n${table}`);
+  }
+
+  const bodySchema =
+    operation.requestBody?.content?.["application/json"]?.schema;
+  if (bodySchema) {
+    sections.push(
+      `## Request body\n\n${fieldsTable(collectFields(doc, bodySchema))}`,
+    );
+  }
+
+  const responses: Record<string, JSONSchema> = operation.responses ?? {};
+  const codes = Object.keys(responses);
+  if (codes.length) {
+    const responseSections = codes.map((code) => {
+      const response = responses[code];
+      const schema = response.content?.["application/json"]?.schema;
+      const parts = [`### ${code}`];
+      if (response.description) parts.push(response.description);
+      if (schema) parts.push(fieldsTable(collectFields(doc, schema)));
+      return parts.join("\n\n");
+    });
+    sections.push(`## Responses\n\n${responseSections.join("\n\n")}`);
+  }
+
+  return `${sections.join("\n\n")}\n`;
+}
+
+/**
+ * Renders one generated API-reference page's operation as plain markdown —
+ * summary, parameters, and request/response schema fields with the same
+ * descriptions the HTML page (`<OpenAPIPage />`) reads from openapi.yaml.
+ */
+export async function getOperationMarkdown(
+  page: ApiPage,
+): Promise<string | null> {
+  const raw = await page.data.getText("raw");
+  const op = extractOperationRef(raw);
+  if (!op) return null;
+  const doc = await loadOpenApiDoc();
+  const operation = doc.paths?.[op.path]?.[op.method];
+  if (!operation) return null;
+  return renderOperationMarkdown(
+    doc,
+    op.path,
+    op.method,
+    operation,
+    page.data.title,
+    page.data.description,
+  );
+}
+
+export function renderApiIndexMarkdown(pages: ApiPage[]): string {
+  const lines = [
+    "# API Reference",
+    "Hail exposes a REST API at `https://api.hail.so`.",
+    "Machine-readable spec: [openapi.yaml](/docs/api/openapi.yaml) · [openapi.json](/docs/api/openapi.json)",
+    "## Operations",
+    ...pages
+      .slice()
+      .sort((a, b) => a.data.title.localeCompare(b.data.title))
+      .map((page) => `- [${page.data.title}](/docs${page.url}.md)`),
+  ];
+  return `${lines.join("\n\n")}\n`;
+}

--- a/docs-site/next.config.ts
+++ b/docs-site/next.config.ts
@@ -9,6 +9,13 @@ const nextConfig: NextConfig = {
   // basePath keeps this app's /_next/* assets namespaced so they can't collide
   // with the apex app's, and makes the standalone deployment browsable too.
   basePath: "/docs",
+  async rewrites() {
+    // Every doc page and every generated API-reference page is available as
+    // plain markdown by appending `.md` — e.g. /docs/architecture.md,
+    // /docs/api/create_email_emails_post.md. Handled by app/llms.mdx/[[...slug]],
+    // which knows both sources; this just maps the friendly suffix onto it.
+    return [{ source: "/:path*.md", destination: "/llms.mdx/:path*" }];
+  },
   async redirects() {
     // Aug 2026 IA reorg: cloud docs moved to the top level, provisioning docs
     // under self-host/. Sources are basePath-relative (Next prefixes /docs).
@@ -17,10 +24,26 @@ const nextConfig: NextConfig = {
       { source: "/setup", destination: "/self-host", permanent: true },
       { source: "/setup/mcp", destination: "/mcp", permanent: true },
       { source: "/setup/webhooks", destination: "/webhooks", permanent: true },
-      { source: "/setup/twilio", destination: "/self-host/twilio", permanent: true },
-      { source: "/setup/livekit-cloud", destination: "/self-host/livekit-cloud", permanent: true },
-      { source: "/setup/aws-ses", destination: "/self-host/aws-ses", permanent: true },
-      { source: "/operations", destination: "/self-host/operations", permanent: true },
+      {
+        source: "/setup/twilio",
+        destination: "/self-host/twilio",
+        permanent: true,
+      },
+      {
+        source: "/setup/livekit-cloud",
+        destination: "/self-host/livekit-cloud",
+        permanent: true,
+      },
+      {
+        source: "/setup/aws-ses",
+        destination: "/self-host/aws-ses",
+        permanent: true,
+      },
+      {
+        source: "/operations",
+        destination: "/self-host/operations",
+        permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION
## Summary

- Every `docs/public/*` page and every generated OpenAPI reference page is available as plain markdown by appending `.md` to its URL (e.g. `/docs/api/create_email_v1_emails_post.md`).
- `/docs/llms.txt` — index of every guide and API operation, with absolute links.
- `/docs/llms-full.txt` — everything concatenated into one file.
- API reference markdown renders operation summary, parameters, and request/response schema fields straight from `openapi.yaml`, carrying the same field descriptions as the HTML page (now that #89 has landed, that includes the `from` field's actual resolution rule).
- `/docs/api` index page now links `llms.txt`/`llms-full.txt` and mentions the `.md` suffix.

This was planned and deferred in the original docs-site MVP plan (`docs/superpowers/plans/2026-05-05-docs-site-mvp.md`, "Agent surfaces: raw `.md` route handler, `llms.txt` + `llms-full.txt` generators") and never built.

Also fixes a real bug hit along the way: `fumadocs-mdx`'s `page.data.getText("raw")` 404s for any content dir declared with a leading `../` — exactly this repo's setup (`docs/public/` lives one level above `docs-site/`). Its path joiner treats `..` as "pop, or no-op if nothing to pop" instead of real filesystem traversal. Static docs markdown now reads the file directly instead of going through that call.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `prettier --check` clean on all touched files
- [x] `next build` — all 145 static pages generate, including 68 `/llms.mdx/*` routes
- [x] `next start` smoke test: `/docs/architecture.md`, `/docs/api/create_email_v1_emails_post.md`, `/docs/llms.txt`, `/docs/llms-full.txt` all 200; existing HTML pages (`/docs/architecture`, `/docs/api/...`, `/docs/api`) unaffected; unknown `.md` path 404s
- [x] Verified `from` field description renders correctly in the generated API markdown