### PR TITLE
docs: refresh tagline to new voice/phone-number/inbox positioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Notes for Claude (and other AI assistants) working in this repo.
 
 ## What Hail is
 
-A universal communication platform for AI agents. Outbound phone calls in v1; SMS, email, inbound to follow. Self-hostable via Docker Compose. Consumed via OpenAPI, CLI (`hail`), and an MCP server. AGPLv3.
+Give your AI agent a voice, a real phone number, and an inbox. Outbound phone calls in v1; SMS, email, inbound to follow. Self-hostable via Docker Compose. Consumed via OpenAPI, CLI (`hail`), and an MCP server. AGPLv3.
 
 ## Repo layout
 

--- a/api/hailhq/api/main.py
+++ b/api/hailhq/api/main.py
@@ -231,7 +231,7 @@ app = FastAPI(
     title="Hail",
     version="0.1.0",
     description=(
-        "Universal communication platform for AI agents.\n\n"
+        "Give your AI agent a voice, a real phone number, and an inbox.\n\n"
         "This file is the source of truth for the Go CLI. Regenerate it after\n"
         "changing API routes — see docs/public/contributing.md.\n"
     ),

--- a/cli/.goreleaser.yml
+++ b/cli/.goreleaser.yml
@@ -68,7 +68,7 @@ release:
   header: |
     ## hail CLI {{ .Tag }}
 
-    Universal communication platform for AI agents — `hail` CLI binaries.
+    Give your AI agent a voice, a real phone number, and an inbox — `hail` CLI binaries.
 
     Install via Homebrew:
 
@@ -83,7 +83,7 @@ brews:
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     homepage: https://hail.so
-    description: Universal communication platform for AI agents (CLI)
+    description: Give your AI agent a voice, a phone number, and an inbox (CLI)
     license: AGPL-3.0-or-later
     install: |
       bin.install "hail"

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -242,8 +242,8 @@ func NewRootCmd(stdout, stderr io.Writer, getenv func(string) string) *cobra.Com
 
 	root := &cobra.Command{
 		Use:   "hail",
-		Short: "hail — universal communication platform for AI agents",
-		Long: `hail — universal communication platform for AI agents.
+		Short: "hail — give your AI agent a voice, a phone number, and an inbox",
+		Long: `hail — give your AI agent a voice, a phone number, and an inbox.
 
 Works with Hail Cloud (the managed offering at https://hail.so) and self-hosted
 deployments. Cloud users authenticate via ` + "`hail login`" + `; self-hosters seed an
@@ -324,7 +324,7 @@ or pass --api-key.`,
 		}
 
 		out := cmd.OutOrStdout()
-		fmt.Fprintln(out, "hail — universal communication platform for AI agents.")
+		fmt.Fprintln(out, "hail — give your AI agent a voice, a phone number, and an inbox.")
 		fmt.Fprintln(out)
 		if apiKey == "" {
 			fmt.Fprintln(out, "Get started:")

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,4 +1,4 @@
-// Command hail is the universal communication platform CLI.
+// Command hail gives your AI agent a voice, a phone number, and an inbox.
 package main
 
 import "github.com/hail-hq/hail/cli/internal/cmd"

--- a/docs-site/lib/site-copy.ts
+++ b/docs-site/lib/site-copy.ts
@@ -1,7 +1,6 @@
 export const DOCS_SITE_COPY = {
   name: "hail.so / docs",
   title: "Hail docs",
-  description:
-    "Build agentic phone calls, SMS, and email with one MCP, API, and CLI.",
-  eyebrow: "phone + sms + email in one mcp, api & cli",
+  description: "Give your AI agent a voice, a real phone number, and an inbox.",
+  eyebrow: "voice, phone number & inbox for ai agents",
 } as const;

--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -1,6 +1,6 @@
 # Hail documentation
 
-Hail is a universal communication platform for AI agents — outbound phone calls, SMS, and email behind one MCP endpoint, one API key, one invoice. Most people use [Hail Cloud](https://hail.so); Hail's services are also self-hostable under AGPLv3, with LiveKit Cloud and channel providers remaining external.
+Hail gives your AI agent a voice, a real phone number, and an inbox — place AI phone calls with ElevenLabs voices, run an AI call center, send SMS and agent mail, all behind one MCP endpoint, one API key, one invoice. Most people use [Hail Cloud](https://hail.so); Hail's services are also self-hostable under AGPLv3, with LiveKit Cloud and channel providers remaining external.
 
 ## Using Hail Cloud
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,9 +2,9 @@ openapi: 3.1.0
 info:
   title: Hail
   description:
-    "Universal communication platform for AI agents.\n\nThis file is the\
-    \ source of truth for the Go CLI. Regenerate it after\nchanging API routes \u2014\
-    \ see docs/public/contributing.md.\n"
+    "Give your AI agent a voice, a real phone number, and an inbox.\n\n\
+    This file is the source of truth for the Go CLI. Regenerate it after\nchanging\
+    \ API routes \u2014 see docs/public/contributing.md.\n"
   version: 0.1.0
 servers:
   - url: https://api.hail.so

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,6 +1,6 @@
 # hail-sdk
 
-Python SDK for [Hail](https://hail.so) — universal communication platform for AI agents.
+Python SDK for [Hail](https://hail.so) — give your AI agent a voice, a real phone number, and an inbox.
 
 ## Install
 

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "hail-sdk"
 version = "0.15.0"
-description = "Python SDK for Hail — universal communication platform for AI agents."
+description = "Python SDK for Hail — give your AI agent a voice, a real phone number, and an inbox."
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Replaces the old "universal communication platform for AI agents" tagline with copy matching the new hail.so hero ("give your ai agent a voice, a real phone number, and an inbox" / "place ai phone calls with elevenlabs voices, run an ai call center, send sms and agent mail"), adapted to proper case for technical surfaces:

- `CLAUDE.md` — "What Hail is"
- CLI: `--help` short/long text, root-help banner, goreleaser release notes + Homebrew formula description, `main.go` doc comment
- SDK: `sdk/README.md`, `sdk/pyproject.toml` PyPI description
- API: `FastAPI(description=...)` in `api/hailhq/api/main.py`, regenerated `openapi/openapi.yaml` from the live app (`app.openapi()`) — CLI codegen re-run, no diff (description isn't embedded in generated client code)
- docs-site: `docs/public/README.md` opening paragraph, `docs-site/lib/site-copy.ts` meta description + eyebrow

Short tagline used where space is tight: **"Give your AI agent a voice, a real phone number, and an inbox."** Long form where there's room for the mechanism (README, OpenAPI, SDK): adds "place AI phone calls with ElevenLabs voices, run an AI call center, send SMS and agent mail, all from one API, CLI, and MCP server."

Not touched: `docs/submissions/*` (9 platform-tailored outreach drafts still using the old positioning, not yet submitted per the 2026-09-01 gate) and historical `docs/superpowers/plans/*` / `specs/*` — flagging as a separate follow-up rather than rewriting marketing drafts unasked.

## Test plan

- [x] `gofmt -l`, `go build ./...`, `go vet ./...` clean on touched CLI files
- [x] `ruff check` / `black --check` clean on `api/hailhq/api/main.py`
- [x] `prettier --check` clean on touched TS
- [x] Regenerated `openapi.yaml` diffs to only the description string (prettier-formatted)
- [x] `cli make codegen` re-run — no diff in `client.gen.go`
- [x] `grep -r "universal communication platform"` — zero hits outside historical plan/spec docs