### PR TITLE
docs: HTML open/click tracking note + release 0.22.0

### DIFF
--- a/cli/internal/client/client.gen.go
+++ b/cli/internal/client/client.gen.go
@@ -1278,10 +1278,10 @@ type EmailCreate struct {
 	// Bcc BCC recipient email addresses.
 	Bcc *[]string `json:"bcc,omitempty"`
 
-	// BodyHtml HTML body. Either body_text or body_html (or both) is required.
+	// BodyHtml HTML body. Either body_text or body_html (or both) is required. Prefer including body_html: open and click tracking only works for emails with an HTML body. Plain-text-only emails still get sent, delivered, and bounce events, but opens and clicks are never tracked.
 	BodyHtml *string `json:"body_html,omitempty"`
 
-	// BodyText Plain-text body. Either body_text or body_html (or both) is required.
+	// BodyText Plain-text body. Either body_text or body_html (or both) is required. A plain-text-only email cannot be tracked for opens or clicks; include body_html to get those events.
 	BodyText *string `json:"body_text,omitempty"`
 
 	// Cc CC recipient email addresses.
@@ -1480,7 +1480,7 @@ type EmailEventResponse struct {
 	// Id Unique identifier for this event.
 	Id openapi_types.UUID `json:"id"`
 
-	// Kind Event kind: 'sent', 'delivered', 'delivery_delayed', 'bounced', 'complained', 'rejected', 'opened', or 'clicked'.
+	// Kind Event kind: 'sent', 'delivered', 'delivery_delayed', 'bounced', 'complained', 'rejected', 'opened', or 'clicked'. 'opened' and 'clicked' only occur for emails sent with an HTML body; plain-text-only emails never produce them.
 	Kind EmailEventResponseKind `json:"kind"`
 
 	// OccurredAt When this event occurred, ISO 8601 timestamp.
@@ -1490,7 +1490,7 @@ type EmailEventResponse struct {
 	Payload map[string]interface{} `json:"payload"`
 }
 
-// EmailEventResponseKind Event kind: 'sent', 'delivered', 'delivery_delayed', 'bounced', 'complained', 'rejected', 'opened', or 'clicked'.
+// EmailEventResponseKind Event kind: 'sent', 'delivered', 'delivery_delayed', 'bounced', 'complained', 'rejected', 'opened', or 'clicked'. 'opened' and 'clicked' only occur for emails sent with an HTML body; plain-text-only emails never produce them.
 type EmailEventResponseKind string
 
 // EmailListResponse defines model for EmailListResponse.
@@ -1621,7 +1621,7 @@ type EmailStatsBucket struct {
 	// BucketStart Start of this bucket, ISO 8601 timestamp.
 	BucketStart time.Time `json:"bucket_start"`
 
-	// Clicked Total click events in the window, including repeat clicks by the same recipient.
+	// Clicked Total click events in the window, including repeat clicks by the same recipient. HTML emails only; plain-text-only emails are never tracked for clicks.
 	Clicked *int `json:"clicked,omitempty"`
 
 	// Complained Emails that received a spam complaint in the window.
@@ -1633,7 +1633,7 @@ type EmailStatsBucket struct {
 	// DeliveryDelayed Emails with a delivery-delayed event in the window.
 	DeliveryDelayed *int `json:"delivery_delayed,omitempty"`
 
-	// Opened Total open events in the window, including repeat opens by the same recipient.
+	// Opened Total open events in the window, including repeat opens by the same recipient. HTML emails only; plain-text-only emails are never tracked for opens.
 	Opened *int `json:"opened,omitempty"`
 
 	// Rejected Emails rejected by the provider before sending, in the window.
@@ -1642,10 +1642,10 @@ type EmailStatsBucket struct {
 	// Sent Emails sent in the window.
 	Sent *int `json:"sent,omitempty"`
 
-	// UniqueClicked Distinct emails clicked at least once in the window.
+	// UniqueClicked Distinct emails clicked at least once in the window (HTML emails only).
 	UniqueClicked *int `json:"unique_clicked,omitempty"`
 
-	// UniqueOpened Distinct emails opened at least once in the window.
+	// UniqueOpened Distinct emails opened at least once in the window (HTML emails only).
 	UniqueOpened *int `json:"unique_opened,omitempty"`
 }
 
@@ -1657,7 +1657,7 @@ type EmailStatsCounts struct {
 	// BouncedHard Emails hard-bounced in the window. Subset of bounced.
 	BouncedHard *int `json:"bounced_hard,omitempty"`
 
-	// Clicked Total click events in the window, including repeat clicks by the same recipient.
+	// Clicked Total click events in the window, including repeat clicks by the same recipient. HTML emails only; plain-text-only emails are never tracked for clicks.
 	Clicked *int `json:"clicked,omitempty"`
 
 	// Complained Emails that received a spam complaint in the window.
@@ -1669,7 +1669,7 @@ type EmailStatsCounts struct {
 	// DeliveryDelayed Emails with a delivery-delayed event in the window.
 	DeliveryDelayed *int `json:"delivery_delayed,omitempty"`
 
-	// Opened Total open events in the window, including repeat opens by the same recipient.
+	// Opened Total open events in the window, including repeat opens by the same recipient. HTML emails only; plain-text-only emails are never tracked for opens.
 	Opened *int `json:"opened,omitempty"`
 
 	// Rejected Emails rejected by the provider before sending, in the window.
@@ -1678,10 +1678,10 @@ type EmailStatsCounts struct {
 	// Sent Emails sent in the window.
 	Sent *int `json:"sent,omitempty"`
 
-	// UniqueClicked Distinct emails clicked at least once in the window.
+	// UniqueClicked Distinct emails clicked at least once in the window (HTML emails only).
 	UniqueClicked *int `json:"unique_clicked,omitempty"`
 
-	// UniqueOpened Distinct emails opened at least once in the window.
+	// UniqueOpened Distinct emails opened at least once in the window (HTML emails only).
 	UniqueOpened *int `json:"unique_opened,omitempty"`
 }
 
@@ -1690,7 +1690,7 @@ type EmailStatsRates struct {
 	// Bounce bounced_hard / sent for the window. Null when sent == 0.
 	Bounce *float32 `json:"bounce,omitempty"`
 
-	// Click unique_clicked / sent for the window. Null when sent == 0.
+	// Click unique_clicked / sent for the window. Null when sent == 0. Only HTML emails can be click-tracked, so plain-text sends lower this rate.
 	Click *float32 `json:"click,omitempty"`
 
 	// Complaint complained / sent for the window. Null when sent == 0.
@@ -1699,7 +1699,7 @@ type EmailStatsRates struct {
 	// Delivery delivered / sent for the window. Null when sent == 0.
 	Delivery *float32 `json:"delivery,omitempty"`
 
-	// Open unique_opened / sent for the window. Null when sent == 0.
+	// Open unique_opened / sent for the window. Null when sent == 0. Only HTML emails can be opened-tracked, so plain-text sends lower this rate.
 	Open *float32 `json:"open,omitempty"`
 }
 

--- a/cli/internal/cmd/email.go
+++ b/cli/internal/cmd/email.go
@@ -78,7 +78,10 @@ The recipient flag may be repeated, or comma-separated:
   --to alice@example.com --to bob@example.com
   --to alice@example.com,bob@example.com
 
-Either --body or --body-html (or both) must be supplied. --body-file
+Either --body or --body-html (or both) must be supplied. Prefer
+--body-html: open and click tracking only works for emails with an
+HTML body. A plain-text-only email still gets sent, delivered, and
+bounce events, but opens and clicks are never tracked. --body-file
 and --body-html-file read content from disk. --attach uploads a local
 file and attaches it (repeatable); --attach-id attaches a file already
 uploaded via ` + "`hail email attachment-upload`" + ` (repeatable).
@@ -106,7 +109,7 @@ Example (minimal):
 	cmd.Flags().StringVar(&f.replyTo, "reply-to", "", "Reply-To header")
 	cmd.Flags().StringVar(&f.subject, "subject", "", "Subject line")
 	cmd.Flags().StringVar(&f.body, "body", "", "Plain-text body — one of --body/--body-html required")
-	cmd.Flags().StringVar(&f.bodyHTML, "body-html", "", "HTML body — one of --body/--body-html required")
+	cmd.Flags().StringVar(&f.bodyHTML, "body-html", "", "HTML body — one of --body/--body-html required; needed for open/click tracking")
 	cmd.Flags().StringVar(&f.bodyFile, "body-file", "", "Read plain-text body from this file (use '-' for stdin); exclusive with --body")
 	cmd.Flags().StringVar(&f.bodyHTMLFile, "body-html-file", "", "Read HTML body from this file (use '-' for stdin); exclusive with --body-html")
 	cmd.Flags().StringVar(&f.idempotencyKey, "idempotency-key", "", "Defaults to a fresh UUID")

--- a/core/hailhq/core/schemas.py
+++ b/core/hailhq/core/schemas.py
@@ -1030,11 +1030,21 @@ class EmailCreate(ConsentAttestationMixin):
     )
     body_text: str | None = Field(
         default=None,
-        description="Plain-text body. Either body_text or body_html (or both) is required.",
+        description=(
+            "Plain-text body. Either body_text or body_html (or both) is "
+            "required. A plain-text-only email cannot be tracked for opens "
+            "or clicks; include body_html to get those events."
+        ),
     )
     body_html: str | None = Field(
         default=None,
-        description="HTML body. Either body_text or body_html (or both) is required.",
+        description=(
+            "HTML body. Either body_text or body_html (or both) is required. "
+            "Prefer including body_html: open and click tracking only works "
+            "for emails with an HTML body. Plain-text-only emails still get "
+            "sent, delivered, and bounce events, but opens and clicks are "
+            "never tracked."
+        ),
     )
     conversation_id: UUID | None = Field(
         default=None,
@@ -1136,7 +1146,9 @@ class EmailEventResponse(BaseModel):
     kind: EmailEventKind = Field(
         description=(
             "Event kind: 'sent', 'delivered', 'delivery_delayed', "
-            "'bounced', 'complained', 'rejected', 'opened', or 'clicked'."
+            "'bounced', 'complained', 'rejected', 'opened', or 'clicked'. "
+            "'opened' and 'clicked' only occur for emails sent with an HTML "
+            "body; plain-text-only emails never produce them."
         )
     )
     payload: dict[str, Any] = Field(
@@ -1180,17 +1192,31 @@ class EmailStatsCounts(BaseModel):
     )
     opened: int = Field(
         default=0,
-        description="Total open events in the window, including repeat opens by the same recipient.",
+        description=(
+            "Total open events in the window, including repeat opens by the "
+            "same recipient. HTML emails only; plain-text-only emails are "
+            "never tracked for opens."
+        ),
     )
     clicked: int = Field(
         default=0,
-        description="Total click events in the window, including repeat clicks by the same recipient.",
+        description=(
+            "Total click events in the window, including repeat clicks by "
+            "the same recipient. HTML emails only; plain-text-only emails "
+            "are never tracked for clicks."
+        ),
     )
     unique_opened: int = Field(
-        default=0, description="Distinct emails opened at least once in the window."
+        default=0,
+        description=(
+            "Distinct emails opened at least once in the window " "(HTML emails only)."
+        ),
     )
     unique_clicked: int = Field(
-        default=0, description="Distinct emails clicked at least once in the window."
+        default=0,
+        description=(
+            "Distinct emails clicked at least once in the window " "(HTML emails only)."
+        ),
     )
 
 
@@ -1217,11 +1243,19 @@ class EmailStatsRates(BaseModel):
     )
     open: float | None = Field(
         default=None,
-        description="unique_opened / sent for the window. Null when sent == 0.",
+        description=(
+            "unique_opened / sent for the window. Null when sent == 0. "
+            "Only HTML emails can be opened-tracked, so plain-text sends "
+            "lower this rate."
+        ),
     )  # unique_opened / sent
     click: float | None = Field(
         default=None,
-        description="unique_clicked / sent for the window. Null when sent == 0.",
+        description=(
+            "unique_clicked / sent for the window. Null when sent == 0. "
+            "Only HTML emails can be click-tracked, so plain-text sends "
+            "lower this rate."
+        ),
     )  # unique_clicked / sent
 
 

--- a/docs/public/webhooks.md
+++ b/docs/public/webhooks.md
@@ -86,7 +86,11 @@ The full set is the `WebhookEventType` enum in
 - **`email.bounced`** — the recipient mail server rejected the message (permanent or soft bounce).
 - **`email.complained`** — the recipient marked the message as spam.
 - **`email.opened`** — the recipient opened the message (image tracked, approximate).
-- **`email.clicked`** — the recipient clicked a tracked link.
+  Only fires for emails sent with an HTML body; plain-text-only emails are never
+  tracked for opens.
+- **`email.clicked`** — the recipient clicked a tracked link. Only fires for
+  emails sent with an HTML body; plain-text-only emails are never tracked for
+  clicks.
 - **`email.send_failed`** — an outbound email failed to send.
 - **`sms.received`** — an inbound SMS arrived, and Hail accepted it. Hail delivers
   it through the same signed, retried webhook worker as the email events
@@ -197,7 +201,7 @@ presigned S3 URL on access. `email.received.suppressed` carries a trimmed `data`
 }
 ```
 
-The `detail` field varies by event type. `bounced` and `complained` carry SES metadata. `delivered` and `delivery_delayed` carry SES status details. `opened` and `clicked` carry `ip_address` and `user_agent`; `clicked` adds `link` (the event time is the sibling `occurred_at` field). For `bounced`, the provider-neutral `hard` flag distinguishes hard bounces from soft bounces. Only hard bounces move the email to `status=bounced` and count toward `bounced_hard` in `GET /emails/stats`.
+The `detail` field varies by event type. `bounced` and `complained` carry SES metadata. `delivered` and `delivery_delayed` carry SES status details. `opened` and `clicked` carry `ip_address` and `user_agent`; `clicked` adds `link` (the event time is the sibling `occurred_at` field). Both only occur for emails sent with an HTML body: the tracking pixel and link rewriting live in the HTML part, so plain-text-only emails never produce them. For `bounced`, the provider-neutral `hard` flag distinguishes hard bounces from soft bounces. Only hard bounces move the email to `status=bounced` and count toward `bounced_hard` in `GET /emails/stats`.
 
 ## Retries
 

--- a/mcp/hailhq/mcp/tools.py
+++ b/mcp/hailhq/mcp/tools.py
@@ -676,7 +676,11 @@ def register_tools(
 
         ``to`` is a non-empty list of RFC-style email addresses. At
         least one of ``body_text`` / ``body_html`` is required (both
-        is fine — multipart-alternative). ``cc``, ``bcc``, and
+        is fine — multipart-alternative). Prefer including
+        ``body_html``: open and click tracking only works for emails
+        with an HTML body. A plain-text-only email still gets sent,
+        delivered, and bounce events, but opens and clicks are never
+        tracked. ``cc``, ``bcc``, and
         ``reply_to`` are optional and follow the usual mail
         conventions. Hail sets no ``reply_to`` of its own — to have
         replies reach the human running this session, call ``whoami``
@@ -1024,7 +1028,10 @@ def register_tools(
         Returns ``{"items": [...], "next_cursor": ...}`` where each item has
         ``kind`` (one of sent, delivered, delivery_delayed, bounced,
         complained, rejected, opened, clicked), ``payload``, and
-        ``occurred_at``. Pass ``cursor`` from a previous ``next_cursor`` to
+        ``occurred_at``. ``opened`` and ``clicked`` only occur for emails
+        sent with an HTML body. A plain-text-only email still gets sent,
+        delivered, and bounce events, but opens and clicks are never
+        tracked. Pass ``cursor`` from a previous ``next_cursor`` to
         page (``limit`` 1..1000, default 100). On failure returns
         ``{"error": "resource not found"}`` for an unknown id.
         """
@@ -1058,7 +1065,9 @@ def register_tools(
         "rates": {...}, "series": [...]}`` — ``totals``/each ``series``
         bucket carry counts (sent, delivered, bounced, opened, ...) and
         ``rates`` carries derived ratios (delivery, bounce, open, click),
-        each ``None`` when ``totals.sent`` is 0. On failure returns
+        each ``None`` when ``totals.sent`` is 0. Open and click numbers
+        only count HTML emails. Plain-text-only emails are never tracked
+        for opens or clicks, so they lower those rates. On failure returns
         ``{"error": "<message>"}`` instead.
         """
         try:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -4173,13 +4173,18 @@ components:
           title: Body Text
           description:
             Plain-text body. Either body_text or body_html (or both) is
-            required.
+            required. A plain-text-only email cannot be tracked for opens or clicks;
+            include body_html to get those events.
         body_html:
           anyOf:
             - type: string
             - type: "null"
           title: Body Html
-          description: HTML body. Either body_text or body_html (or both) is required.
+          description:
+            "HTML body. Either body_text or body_html (or both) is required.
+            Prefer including body_html: open and click tracking only works for emails
+            with an HTML body. Plain-text-only emails still get sent, delivered, and
+            bounce events, but opens and clicks are never tracked."
         conversation_id:
           anyOf:
             - type: string
@@ -4549,7 +4554,9 @@ components:
             - clicked
           title: Kind
           description: "Event kind: 'sent', 'delivered', 'delivery_delayed',
-            'bounced', 'complained', 'rejected', 'opened', or 'clicked'."
+            'bounced', 'complained', 'rejected', 'opened', or 'clicked'.
+            'opened' and 'clicked' only occur for emails sent with an HTML body;
+            plain-text-only emails never produce them."
         payload:
           additionalProperties: true
           type: object
@@ -4901,24 +4908,30 @@ components:
           title: Opened
           description:
             Total open events in the window, including repeat opens by
-            the same recipient.
+            the same recipient. HTML emails only; plain-text-only emails are never
+            tracked for opens.
           default: 0
         clicked:
           type: integer
           title: Clicked
           description:
             Total click events in the window, including repeat clicks by
-            the same recipient.
+            the same recipient. HTML emails only; plain-text-only emails are never
+            tracked for clicks.
           default: 0
         unique_opened:
           type: integer
           title: Unique Opened
-          description: Distinct emails opened at least once in the window.
+          description:
+            Distinct emails opened at least once in the window (HTML emails
+            only).
           default: 0
         unique_clicked:
           type: integer
           title: Unique Clicked
-          description: Distinct emails clicked at least once in the window.
+          description:
+            Distinct emails clicked at least once in the window (HTML emails
+            only).
           default: 0
         bucket_start:
           type: string
@@ -4971,24 +4984,30 @@ components:
           title: Opened
           description:
             Total open events in the window, including repeat opens by
-            the same recipient.
+            the same recipient. HTML emails only; plain-text-only emails are never
+            tracked for opens.
           default: 0
         clicked:
           type: integer
           title: Clicked
           description:
             Total click events in the window, including repeat clicks by
-            the same recipient.
+            the same recipient. HTML emails only; plain-text-only emails are never
+            tracked for clicks.
           default: 0
         unique_opened:
           type: integer
           title: Unique Opened
-          description: Distinct emails opened at least once in the window.
+          description:
+            Distinct emails opened at least once in the window (HTML emails
+            only).
           default: 0
         unique_clicked:
           type: integer
           title: Unique Clicked
-          description: Distinct emails clicked at least once in the window.
+          description:
+            Distinct emails clicked at least once in the window (HTML emails
+            only).
           default: 0
       type: object
       title: EmailStatsCounts
@@ -5017,13 +5036,18 @@ components:
             - type: number
             - type: "null"
           title: Open
-          description: unique_opened / sent for the window. Null when sent == 0.
+          description:
+            unique_opened / sent for the window. Null when sent == 0. Only
+            HTML emails can be opened-tracked, so plain-text sends lower this rate.
         click:
           anyOf:
             - type: number
             - type: "null"
           title: Click
-          description: unique_clicked / sent for the window. Null when sent == 0.
+          description:
+            unique_clicked / sent for the window. Null when sent == 0.
+            Only HTML emails can be click-tracked, so plain-text sends lower this
+            rate.
       type: object
       title: EmailStatsRates
       description: All None when sent == 0 in the window.

--- a/sdk/hail/client.py
+++ b/sdk/hail/client.py
@@ -312,7 +312,11 @@ class _EmailsResource:
         """Send an outbound email.
 
         At least one of ``body_text`` / ``body_html`` is required; the
-        server returns 422 if neither is supplied. ``recipient_consent``
+        server returns 422 if neither is supplied. Prefer including
+        ``body_html``: open and click tracking only works for emails
+        with an HTML body. A plain-text-only email still gets sent,
+        delivered, and bounce events, but opens and clicks are never
+        tracked. ``recipient_consent``
         is required — the server 422s without it. ``from_`` is optional
         while the org has one verified sender; with several the server
         422s and you must name one (read ``default_from`` from

--- a/sdk/hail/models.py
+++ b/sdk/hail/models.py
@@ -318,7 +318,10 @@ TERMINAL_EMAIL_STATUSES: frozenset[str] = frozenset(
 class EmailCreate(BaseModel):
     """Body shape for ``POST /emails``.
 
-    At least one of ``body_text`` / ``body_html`` is required. ``to`` is a
+    At least one of ``body_text`` / ``body_html`` is required. Prefer
+    including ``body_html``: open and click tracking only works for emails
+    with an HTML body; a plain-text-only email is never tracked for opens
+    or clicks. ``to`` is a
     non-empty list of recipient addresses. ``from_`` is optional while the
     org has one verified sender; with several the server 422s and the
     caller must name one (or none at all, which auto-mints a hail-mail


### PR DESCRIPTION
## Why

Debugging "opens/clicks never show up" turned out to be expected SES behavior: the tracking pixel and link rewriting live in the HTML part, so a plain-text-only email never produces `opened`/`clicked` events (it still gets `sent`/`delivered`/bounce events). Nothing said this anywhere, so it read as a broken pipeline. Second commit cuts release 0.22.0, which also picks up the unreleased PRs #84, #88, #89.

## What

**Commit 1 — say it on every surface that mentions opens or clicks:**

- **core schemas**: `body_text`/`body_html` field descriptions, event-kind description, stats counts and open/click rate descriptions
- **MCP**: `send_email`, `get_email_events`, `get_email_stats` docstrings
- **SDK**: `EmailCreate` model docstring + `emails.send` docstring
- **CLI**: `hail email send` long help + `--body-html` flag help
- **docs**: `docs/public/webhooks.md` event list + detail-field notes
- `openapi/openapi.yaml` regenerated (descriptions only, verified semantically); CLI client re-codegened via `make codegen`

**Commit 2 — `chore(release): 0.22.0`:**

- CHANGELOG 0.22.0 section: /v1 versioning, rate limiting, OpenAPI descriptions, MCP discovery (#89), voicebot single-turn disclosure (#88), `default_from` claim fix + deploy prune (#84), HTML tracking docs (this PR)
- SDK 0.15.0 → 0.15.1 (+ `uv lock`)
- After merge, tag the merge commit: `sdk-v0.15.1` + `cli-v0.21.0`

## Verification

- `go build ./... && go test ./...` in `cli/`: pass
- `core` schema tests + full `sdk` suite (110 tests): pass
- ruff + black on touched Python files: clean